### PR TITLE
Adding export default to transformerTelefuncFile.ts

### DIFF
--- a/telefunc/node/transformer/transformTelefuncFile.ts
+++ b/telefunc/node/transformer/transformTelefuncFile.ts
@@ -44,6 +44,8 @@ function getCode(exportNames: readonly string[], telefuncFilePath: string) {
     }
   })
 
+  lines.push(`export default { ${exportNames.join(', ')} };`);
+  
   const code = lines.join('\n')
   return code
 }


### PR DESCRIPTION
Trying `examples/vite` I noticed I could not do in the `index.html` e.g. `import api from 'hello.telefunc.js'`, only `import {hello} ...`. 

I tried adding an `export default` in `hello.telefunc.js`, but was receiving `Error: [telefunc@0.1.16][Wrong Usage] The telefunction 'default()' (/api.telefunc.js) is not a function.`

Finally I realized an easy solution could be the one on this PR, adding an `export default` in the generated client file, but I am new to the project so I don't know if this can have unintended side effects, just sending this for you to consider.

I think this feature is useful as being able to do an import default allows to have the autocomplete of available apis in the client.

Congrats on this interesting project. Regards!