### PR TITLE
fix: detect referenced tsconfig paths when locating function tsconfig files

### DIFF
--- a/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.spec.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.spec.ts
@@ -1,4 +1,4 @@
-import { findTsConfig } from './generateShield.js'
+import { findTsConfig } from './findTsConfig.js'
 import { describe, it, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'

--- a/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.spec.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.spec.ts
@@ -1,0 +1,203 @@
+import { findTsConfig } from './generateShield.js'
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'telefunc-test-'))
+}
+
+function toPosix(p: string) {
+  return p.split(path.sep).join('/')
+}
+
+function writeJson(filePath: string, content: object) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2))
+}
+
+function writeFile(filePath: string, content: string = '') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+const tempDirs: string[] = []
+
+function setup() {
+  const dir = createTempDir()
+  tempDirs.push(dir)
+  return toPosix(fs.realpathSync(dir))
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs.length = 0
+})
+
+describe('findTsConfig', () => {
+  it('finds nearest tsconfig.json by walking up', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, { compilerOptions: { strict: true } })
+    writeFile(`${root}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/src/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/tsconfig.json`)
+  })
+
+  it('returns null when no tsconfig exists', () => {
+    const root = setup()
+    writeFile(`${root}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/src/hello.telefunc.ts`, `${root}`)
+    expect(result).toBeNull()
+  })
+
+  it('finds tsconfig in a nested package directory', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, { compilerOptions: { strict: true } })
+    writeJson(`${root}/packages/app/tsconfig.json`, { compilerOptions: { strict: true } })
+    writeFile(`${root}/packages/app/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/packages/app/src/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/packages/app/tsconfig.json`)
+  })
+
+  it('resolves via project references to find owning child tsconfig', () => {
+    const root = setup()
+    // Root tsconfig with references
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      files: [],
+      references: [{ path: './tsconfig.lib.json' }, { path: './tsconfig.app.json' }],
+    })
+    // tsconfig.lib.json includes src/lib/**
+    writeJson(`${root}/tsconfig.lib.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/lib/**/*.ts'],
+    })
+    // tsconfig.app.json includes src/app/**
+    writeJson(`${root}/tsconfig.app.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/app/**/*.ts'],
+    })
+    writeFile(`${root}/src/app/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/src/app/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/tsconfig.app.json`)
+  })
+
+  it('falls back to nearest tsconfig when no reference claims the file', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      references: [{ path: './tsconfig.lib.json' }],
+    })
+    writeJson(`${root}/tsconfig.lib.json`, {
+      compilerOptions: { strict: true },
+      include: ['lib/**/*.ts'],
+    })
+    // File is NOT under lib/, so tsconfig.lib.json doesn't claim it
+    writeFile(`${root}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/src/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/tsconfig.json`)
+  })
+
+  it('handles references pointing to directories', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      files: [],
+      references: [{ path: './packages/core' }],
+    })
+    writeJson(`${root}/packages/core/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/**/*.ts'],
+    })
+    writeFile(`${root}/packages/core/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/packages/core/src/hello.telefunc.ts`, `${root}`)
+    // Tier A finds packages/core/tsconfig.json directly (nearest), so it should return that
+    // Tier B would also find it via references, but Tier A's nearest is already correct
+    expect(toPosix(result!)).toBe(`${root}/packages/core/tsconfig.json`)
+  })
+
+  it('handles nested project references (depth-first)', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      files: [],
+      references: [{ path: './packages/core' }],
+    })
+    writeJson(`${root}/packages/core/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      files: [],
+      references: [{ path: './tsconfig.lib.json' }],
+    })
+    writeJson(`${root}/packages/core/tsconfig.lib.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/**/*.ts'],
+    })
+    writeFile(`${root}/packages/core/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/packages/core/src/hello.telefunc.ts`, `${root}`)
+    // Tier A finds packages/core/tsconfig.json, Tier B follows its reference to tsconfig.lib.json
+    expect(toPosix(result!)).toBe(`${root}/packages/core/tsconfig.lib.json`)
+  })
+
+  it('survives circular references without infinite loop', () => {
+    const root = setup()
+    // Two tsconfigs that reference each other — neither claims the file
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      include: ['nope/**/*.ts'],
+      references: [{ path: './tsconfig.other.json' }],
+    })
+    writeJson(`${root}/tsconfig.other.json`, {
+      compilerOptions: { strict: true },
+      include: ['also-nope/**/*.ts'],
+      references: [{ path: './tsconfig.json' }],
+    })
+    writeFile(`${root}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    // Should not hang — no reference claims the file, falls back to nearest tsconfig
+    const result = findTsConfig(`${root}/src/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/tsconfig.json`)
+  })
+
+  it('does not search above appRootDir boundary', () => {
+    const root = setup()
+    // tsconfig only exists above the appRootDir
+    writeJson(`${root}/tsconfig.json`, { compilerOptions: { strict: true } })
+    const subDir = `${root}/sub`
+    writeFile(`${subDir}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${subDir}/src/hello.telefunc.ts`, subDir)
+    expect(result).toBeNull()
+  })
+
+  it('first matching reference wins in depth-first order', () => {
+    const root = setup()
+    writeJson(`${root}/tsconfig.json`, {
+      compilerOptions: { strict: true },
+      files: [],
+      references: [{ path: './tsconfig.first.json' }, { path: './tsconfig.second.json' }],
+    })
+    // Both claim the same file
+    writeJson(`${root}/tsconfig.first.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/**/*.ts'],
+    })
+    writeJson(`${root}/tsconfig.second.json`, {
+      compilerOptions: { strict: true },
+      include: ['src/**/*.ts'],
+    })
+    writeFile(`${root}/src/hello.telefunc.ts`, 'export function onHello() {}')
+
+    const result = findTsConfig(`${root}/src/hello.telefunc.ts`, `${root}`)
+    expect(toPosix(result!)).toBe(`${root}/tsconfig.first.json`)
+  })
+})

--- a/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.ts
@@ -6,6 +6,8 @@ import { assertPosixPath } from '../../../../utils/path.js'
 import fs from 'node:fs'
 import path from 'node:path'
 
+const cache: Record<string, string | null> = {}
+
 // Matches the TypeScript language server algorithm: walk up to find the nearest tsconfig,
 // then check project references to find a more specific tsconfig that claims the file.
 function findTsConfig(telefuncFilePath: string, appRootDir: string): string | null {
@@ -14,12 +16,20 @@ function findTsConfig(telefuncFilePath: string, appRootDir: string): string | nu
   assertPosixPath(appRootDir)
   assert(telefuncFilePath.startsWith(appRootDir))
 
-  const nearestTsConfig = findNearestTsConfig(telefuncFilePath, appRootDir)
-  if (!nearestTsConfig) return null
+  const dir = path.dirname(telefuncFilePath)
+  if (dir in cache) return cache[dir]!
 
-  const realFilePath = cachedRealpathSync(telefuncFilePath)
+  const nearestTsConfig = findNearestTsConfig(telefuncFilePath, appRootDir)
+  if (!nearestTsConfig) {
+    cache[dir] = null
+    return null
+  }
+
+  const realFilePath = realpathSync(telefuncFilePath)
   const referencedTsConfig = findOwningReference(nearestTsConfig, realFilePath)
-  return referencedTsConfig ?? nearestTsConfig
+  const result = referencedTsConfig ?? nearestTsConfig
+  cache[dir] = result
+  return result
 }
 
 function findNearestTsConfig(filePath: string, appRootDir: string): string | null {
@@ -39,7 +49,7 @@ function findOwningReference(
   realFilePath: string,
   visited: Set<string> = new Set(),
 ): string | null {
-  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  const realTsConfigPath = realpathSync(tsConfigPath)
   if (visited.has(realTsConfigPath)) return null
   visited.add(realTsConfigPath)
 
@@ -50,6 +60,7 @@ function findOwningReference(
 
   for (const ref of references) {
     const refTsConfigPath = resolveReferencePath(tsConfigPath, ref.path)
+    if (!refTsConfigPath) continue
 
     if (tsConfigIncludesFile(refTsConfigPath, realFilePath)) {
       return refTsConfigPath
@@ -62,49 +73,35 @@ function findOwningReference(
   return null
 }
 
-const realpathCache: Record<string, string> = {}
-
-function cachedRealpathSync(filePath: string): string {
-  realpathCache[filePath] ??= fs.realpathSync(filePath)
-  return realpathCache[filePath]!
+function realpathSync(filePath: string): string {
+  return fs.realpathSync(filePath)
 }
-
-const tsConfigReadCache: Record<string, { config: any } | null> = {}
 
 function readTsConfig(realTsConfigPath: string): any | null {
-  if (!(realTsConfigPath in tsConfigReadCache)) {
-    const configFile = ts.readConfigFile(realTsConfigPath, ts.sys.readFile)
-    tsConfigReadCache[realTsConfigPath] = configFile.error ? null : { config: configFile.config }
-  }
-  return tsConfigReadCache[realTsConfigPath]?.config ?? null
+  const configFile = ts.readConfigFile(realTsConfigPath, ts.sys.readFile)
+  return configFile.error ? null : configFile.config
 }
 
-function resolveReferencePath(fromTsConfig: string, refPath: string): string {
+function resolveReferencePath(fromTsConfig: string, refPath: string): string | null {
   const resolved = path.resolve(path.dirname(fromTsConfig), refPath)
   try {
     if (fs.statSync(resolved).isDirectory()) {
       return path.join(resolved, 'tsconfig.json')
     }
+    return resolved
   } catch (err: any) {
-    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') return null
+    throw err
   }
-  return resolved
 }
 
-const parsedTsConfigFileCache: Record<string, Set<string>> = {}
-
 function tsConfigIncludesFile(tsConfigPath: string, realFilePath: string): boolean {
-  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  const realTsConfigPath = realpathSync(tsConfigPath)
   const config = readTsConfig(realTsConfigPath)
   if (!config) return false
 
-  if (!parsedTsConfigFileCache[realTsConfigPath]) {
-    const configDir = path.dirname(realTsConfigPath)
-    const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir)
-    parsedTsConfigFileCache[realTsConfigPath] = new Set(
-      parsed.fileNames.map((f) => cachedRealpathSync(path.resolve(f))),
-    )
-  }
-
-  return parsedTsConfigFileCache[realTsConfigPath]!.has(realFilePath)
+  const configDir = path.dirname(realTsConfigPath)
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir)
+  const fileNames = new Set(parsed.fileNames.map((f) => realpathSync(path.resolve(f))))
+  return fileNames.has(realFilePath)
 }

--- a/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/findTsConfig.ts
@@ -1,0 +1,110 @@
+export { findTsConfig }
+
+import { ts } from 'ts-morph'
+import { assert } from '../../../../utils/assert.js'
+import { assertPosixPath } from '../../../../utils/path.js'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Matches the TypeScript language server algorithm: walk up to find the nearest tsconfig,
+// then check project references to find a more specific tsconfig that claims the file.
+function findTsConfig(telefuncFilePath: string, appRootDir: string): string | null {
+  assert(fs.existsSync(telefuncFilePath))
+  assertPosixPath(telefuncFilePath)
+  assertPosixPath(appRootDir)
+  assert(telefuncFilePath.startsWith(appRootDir))
+
+  const nearestTsConfig = findNearestTsConfig(telefuncFilePath, appRootDir)
+  if (!nearestTsConfig) return null
+
+  const realFilePath = cachedRealpathSync(telefuncFilePath)
+  const referencedTsConfig = findOwningReference(nearestTsConfig, realFilePath)
+  return referencedTsConfig ?? nearestTsConfig
+}
+
+function findNearestTsConfig(filePath: string, appRootDir: string): string | null {
+  let curr = filePath
+  do {
+    const dir = path.dirname(curr)
+    if (dir === curr) return null
+    if (!dir.startsWith(appRootDir)) return null
+    const tsConfigFilePath = path.join(dir, 'tsconfig.json')
+    if (fs.existsSync(tsConfigFilePath)) return tsConfigFilePath
+    curr = dir
+  } while (true)
+}
+
+function findOwningReference(
+  tsConfigPath: string,
+  realFilePath: string,
+  visited: Set<string> = new Set(),
+): string | null {
+  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  if (visited.has(realTsConfigPath)) return null
+  visited.add(realTsConfigPath)
+
+  const config = readTsConfig(realTsConfigPath)
+  if (!config) return null
+  const references = config.references
+  if (!Array.isArray(references) || references.length === 0) return null
+
+  for (const ref of references) {
+    const refTsConfigPath = resolveReferencePath(tsConfigPath, ref.path)
+
+    if (tsConfigIncludesFile(refTsConfigPath, realFilePath)) {
+      return refTsConfigPath
+    }
+
+    const nested = findOwningReference(refTsConfigPath, realFilePath, visited)
+    if (nested) return nested
+  }
+
+  return null
+}
+
+const realpathCache: Record<string, string> = {}
+
+function cachedRealpathSync(filePath: string): string {
+  realpathCache[filePath] ??= fs.realpathSync(filePath)
+  return realpathCache[filePath]!
+}
+
+const tsConfigReadCache: Record<string, { config: any } | null> = {}
+
+function readTsConfig(realTsConfigPath: string): any | null {
+  if (!(realTsConfigPath in tsConfigReadCache)) {
+    const configFile = ts.readConfigFile(realTsConfigPath, ts.sys.readFile)
+    tsConfigReadCache[realTsConfigPath] = configFile.error ? null : { config: configFile.config }
+  }
+  return tsConfigReadCache[realTsConfigPath]?.config ?? null
+}
+
+function resolveReferencePath(fromTsConfig: string, refPath: string): string {
+  const resolved = path.resolve(path.dirname(fromTsConfig), refPath)
+  try {
+    if (fs.statSync(resolved).isDirectory()) {
+      return path.join(resolved, 'tsconfig.json')
+    }
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+  }
+  return resolved
+}
+
+const parsedTsConfigFileCache: Record<string, Set<string>> = {}
+
+function tsConfigIncludesFile(tsConfigPath: string, realFilePath: string): boolean {
+  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  const config = readTsConfig(realTsConfigPath)
+  if (!config) return false
+
+  if (!parsedTsConfigFileCache[realTsConfigPath]) {
+    const configDir = path.dirname(realTsConfigPath)
+    const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir)
+    parsedTsConfigFileCache[realTsConfigPath] = new Set(
+      parsed.fileNames.map((f) => cachedRealpathSync(path.resolve(f))),
+    )
+  }
+
+  return parsedTsConfigFileCache[realTsConfigPath]!.has(realFilePath)
+}

--- a/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
@@ -1,10 +1,11 @@
 export { generateShield }
 export { logResult }
 
-// For ./generateShield.spec.ts
+// For ./generateShield.spec.ts and ./findTsConfig.spec.ts
 export { testGenerateShield }
+export { findTsConfig }
 
-import { Project, SourceFile, getCompilerOptionsFromTsConfig } from 'ts-morph'
+import { Project, SourceFile, getCompilerOptionsFromTsConfig, ts } from 'ts-morph'
 import { assert, assertUsage, assertWarning } from '../../../../utils/assert.js'
 import { assertModuleScope } from '../../../../utils/assertModuleScope.js'
 import { getRandomId } from '../../../../utils/getRandomId.js'
@@ -323,26 +324,101 @@ function getTypeToShieldSrc() {
   return typeToShieldFileSrc
 }
 
+// Matches the TypeScript language server algorithm: walk up to find the nearest tsconfig,
+// then check project references to find a more specific tsconfig that claims the file.
 function findTsConfig(telefuncFilePath: string, appRootDir: string): string | null {
   assert(fs.existsSync(telefuncFilePath))
   assertPosixPath(telefuncFilePath)
   assertPosixPath(appRootDir)
   assert(telefuncFilePath.startsWith(appRootDir))
-  let curr = telefuncFilePath
+
+  const nearestTsConfig = findNearestTsConfig(telefuncFilePath, appRootDir)
+  if (!nearestTsConfig) return null
+
+  const realFilePath = cachedRealpathSync(telefuncFilePath)
+  const referencedTsConfig = findOwningReference(nearestTsConfig, realFilePath)
+  return referencedTsConfig ?? nearestTsConfig
+}
+
+function findNearestTsConfig(filePath: string, appRootDir: string): string | null {
+  let curr = filePath
   do {
     const dir = path.dirname(curr)
-    if (dir === curr) {
-      return null
-    }
-    if (!dir.startsWith(appRootDir)) {
-      return null
-    }
+    if (dir === curr) return null
+    if (!dir.startsWith(appRootDir)) return null
     const tsConfigFilePath = path.join(dir, 'tsconfig.json')
-    if (fs.existsSync(tsConfigFilePath)) {
-      return tsConfigFilePath
-    }
+    if (fs.existsSync(tsConfigFilePath)) return tsConfigFilePath
     curr = dir
   } while (true)
+}
+
+function findOwningReference(tsConfigPath: string, realFilePath: string, visited: Set<string> = new Set()): string | null {
+  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  if (visited.has(realTsConfigPath)) return null
+  visited.add(realTsConfigPath)
+
+  const config = readTsConfig(realTsConfigPath)
+  if (!config) return null
+  const references = config.references
+  if (!Array.isArray(references) || references.length === 0) return null
+
+  for (const ref of references) {
+    const refTsConfigPath = resolveReferencePath(tsConfigPath, ref.path)
+
+    if (tsConfigIncludesFile(refTsConfigPath, realFilePath)) {
+      return refTsConfigPath
+    }
+
+    const nested = findOwningReference(refTsConfigPath, realFilePath, visited)
+    if (nested) return nested
+  }
+
+  return null
+}
+
+const realpathCache: Record<string, string> = {}
+
+function cachedRealpathSync(filePath: string): string {
+  realpathCache[filePath] ??= fs.realpathSync(filePath)
+  return realpathCache[filePath]!
+}
+
+const tsConfigReadCache: Record<string, { config: any } | null> = {}
+
+function readTsConfig(realTsConfigPath: string): any | null {
+  if (!(realTsConfigPath in tsConfigReadCache)) {
+    const configFile = ts.readConfigFile(realTsConfigPath, ts.sys.readFile)
+    tsConfigReadCache[realTsConfigPath] = configFile.error ? null : { config: configFile.config }
+  }
+  return tsConfigReadCache[realTsConfigPath]?.config ?? null
+}
+
+function resolveReferencePath(fromTsConfig: string, refPath: string): string {
+  const resolved = path.resolve(path.dirname(fromTsConfig), refPath)
+  try {
+    if (fs.statSync(resolved).isDirectory()) {
+      return path.join(resolved, 'tsconfig.json')
+    }
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+  }
+  return resolved
+}
+
+const parsedTsConfigFileCache: Record<string, Set<string>> = {}
+
+function tsConfigIncludesFile(tsConfigPath: string, realFilePath: string): boolean {
+  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
+  const config = readTsConfig(realTsConfigPath)
+  if (!config) return false
+
+  if (!parsedTsConfigFileCache[realTsConfigPath]) {
+    const configDir = path.dirname(realTsConfigPath)
+    const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir)
+    parsedTsConfigFileCache[realTsConfigPath] = new Set(parsed.fileNames.map((f) => cachedRealpathSync(path.resolve(f))))
+  }
+
+  return parsedTsConfigFileCache[realTsConfigPath]!.has(realFilePath)
 }
 
 function getFilesystemRoot(): string {

--- a/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
@@ -1,18 +1,17 @@
 export { generateShield }
 export { logResult }
 
-// For ./generateShield.spec.ts and ./findTsConfig.spec.ts
+// For ./generateShield.spec.ts
 export { testGenerateShield }
-export { findTsConfig }
 
-import { Project, SourceFile, getCompilerOptionsFromTsConfig, ts } from 'ts-morph'
+import { Project, SourceFile, getCompilerOptionsFromTsConfig } from 'ts-morph'
 import { assert, assertUsage, assertWarning } from '../../../../utils/assert.js'
 import { assertModuleScope } from '../../../../utils/assertModuleScope.js'
 import { getRandomId } from '../../../../utils/getRandomId.js'
 import { objectAssign } from '../../../../utils/objectAssign.js'
-import { assertPosixPath } from '../../../../utils/path.js'
 import { unique } from '../../../../utils/unique.js'
 import { type ExportList, getExportList } from '../getExportList.js'
+import { findTsConfig } from './findTsConfig.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import pc from '@brillout/picocolors'
@@ -322,103 +321,6 @@ function getTypeToShieldSrc() {
   assert(typeToShieldFileSrc)
   assert(typeToShieldFileSrc.includes('SimpleType'))
   return typeToShieldFileSrc
-}
-
-// Matches the TypeScript language server algorithm: walk up to find the nearest tsconfig,
-// then check project references to find a more specific tsconfig that claims the file.
-function findTsConfig(telefuncFilePath: string, appRootDir: string): string | null {
-  assert(fs.existsSync(telefuncFilePath))
-  assertPosixPath(telefuncFilePath)
-  assertPosixPath(appRootDir)
-  assert(telefuncFilePath.startsWith(appRootDir))
-
-  const nearestTsConfig = findNearestTsConfig(telefuncFilePath, appRootDir)
-  if (!nearestTsConfig) return null
-
-  const realFilePath = cachedRealpathSync(telefuncFilePath)
-  const referencedTsConfig = findOwningReference(nearestTsConfig, realFilePath)
-  return referencedTsConfig ?? nearestTsConfig
-}
-
-function findNearestTsConfig(filePath: string, appRootDir: string): string | null {
-  let curr = filePath
-  do {
-    const dir = path.dirname(curr)
-    if (dir === curr) return null
-    if (!dir.startsWith(appRootDir)) return null
-    const tsConfigFilePath = path.join(dir, 'tsconfig.json')
-    if (fs.existsSync(tsConfigFilePath)) return tsConfigFilePath
-    curr = dir
-  } while (true)
-}
-
-function findOwningReference(tsConfigPath: string, realFilePath: string, visited: Set<string> = new Set()): string | null {
-  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
-  if (visited.has(realTsConfigPath)) return null
-  visited.add(realTsConfigPath)
-
-  const config = readTsConfig(realTsConfigPath)
-  if (!config) return null
-  const references = config.references
-  if (!Array.isArray(references) || references.length === 0) return null
-
-  for (const ref of references) {
-    const refTsConfigPath = resolveReferencePath(tsConfigPath, ref.path)
-
-    if (tsConfigIncludesFile(refTsConfigPath, realFilePath)) {
-      return refTsConfigPath
-    }
-
-    const nested = findOwningReference(refTsConfigPath, realFilePath, visited)
-    if (nested) return nested
-  }
-
-  return null
-}
-
-const realpathCache: Record<string, string> = {}
-
-function cachedRealpathSync(filePath: string): string {
-  realpathCache[filePath] ??= fs.realpathSync(filePath)
-  return realpathCache[filePath]!
-}
-
-const tsConfigReadCache: Record<string, { config: any } | null> = {}
-
-function readTsConfig(realTsConfigPath: string): any | null {
-  if (!(realTsConfigPath in tsConfigReadCache)) {
-    const configFile = ts.readConfigFile(realTsConfigPath, ts.sys.readFile)
-    tsConfigReadCache[realTsConfigPath] = configFile.error ? null : { config: configFile.config }
-  }
-  return tsConfigReadCache[realTsConfigPath]?.config ?? null
-}
-
-function resolveReferencePath(fromTsConfig: string, refPath: string): string {
-  const resolved = path.resolve(path.dirname(fromTsConfig), refPath)
-  try {
-    if (fs.statSync(resolved).isDirectory()) {
-      return path.join(resolved, 'tsconfig.json')
-    }
-  } catch (err: any) {
-    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
-  }
-  return resolved
-}
-
-const parsedTsConfigFileCache: Record<string, Set<string>> = {}
-
-function tsConfigIncludesFile(tsConfigPath: string, realFilePath: string): boolean {
-  const realTsConfigPath = cachedRealpathSync(tsConfigPath)
-  const config = readTsConfig(realTsConfigPath)
-  if (!config) return false
-
-  if (!parsedTsConfigFileCache[realTsConfigPath]) {
-    const configDir = path.dirname(realTsConfigPath)
-    const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir)
-    parsedTsConfigFileCache[realTsConfigPath] = new Set(parsed.fileNames.map((f) => cachedRealpathSync(path.resolve(f))))
-  }
-
-  return parsedTsConfigFileCache[realTsConfigPath]!.has(realFilePath)
 }
 
 function getFilesystemRoot(): string {


### PR DESCRIPTION
Updates tsconfig auto-detect to scan references when the first found tsconfig doesnt have the source file included. This is useful when using solution style tsconfigs like `nx` recommends and scaffolds like below: 

> apps/[app]/tsconfig.json
```json
{
  "files": [],
  "include": [],
  "references": [
    {
      "path": "./tsconfig.app.json"
    },
    {
      "path": "./tsconfig.spec.json"
    },
    {
      "path": "./tsconfig.functions.json"
    }
  ]
}
```

> apps/[app]/tsconfig.app.json
```json
{
  "extends": "../../tsconfig.base.json",
  "compilerOptions": {
    "declaration": true,
    "outDir": "../../dist/out-tsc",
    "types": ["node", "vite/client"],
    "composite": true
  },
  "files": [
    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
    "../../node_modules/@nx/react/typings/image.d.ts"
  ],
  "exclude": [
    "src/**/*.spec.ts",
    "src/**/*.test.ts",
    "src/**/*.spec.tsx",
    "src/**/*.test.tsx",
    "src/**/*.spec.js",
    "src/**/*.test.js",
    "src/**/*.spec.jsx",
    "src/**/*.test.jsx"
  ],
  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
  "references": [
    {
      "path": "../../libs/npm-data-access"
    }
  ]
}

```