### PR TITLE
docs: say Broadcast instead of pub/sub

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -178,7 +178,7 @@ chat.send({ type: 'ping' }) // sent immediately, no await needed
 
 ## new Broadcast()
 
-`new Broadcast({ key })` creates one member of a pub/sub group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to it.
+`new Broadcast({ key })` creates one member of a broadcast group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to it.
 
 ```ts
 // Chat.telefunc.ts

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -232,9 +232,9 @@ chat.subscribe((msg, info) => {
 chat.publish({ user: 'Alice', text: 'Hello!', })
 ```
 
-### Server-only pub/sub
+### Server-only broadcast
 
-Use the static methods for server-side-only pub/sub — no client, no lifecycle:
+Use the static methods to publish and subscribe purely on the server — no client, no lifecycle:
 
 ```ts
 import { Broadcast } from 'telefunc'
@@ -270,14 +270,14 @@ info.ts   // server timestamp (Unix epoch ms)
 
 `publish()` returns a `Promise` that resolves to `info` once the message is accepted. `subscribe()` receives `info` alongside each message — useful for ordering and gap detection.
 
-> In-memory pub/sub works out of the box for single-server deployments. For multi-server, set `config.broadcast.transport` — see [Multi-server](#multi-server). On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
+> In-memory broadcast works out of the box for single-server deployments. For multi-server, set `config.broadcast.transport` — see [Multi-server](#multi-server). On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
 
 
 ## Multi-server
 
-By default, pub/sub is in-memory — messages only reach subscribers on the same server. To broadcast across multiple servers, configure a transport on `config.broadcast.transport`.
+By default, `Broadcast` is in-memory — messages only reach subscribers on the same server. To broadcast across multiple servers, configure a transport on `config.broadcast.transport`.
 
-For Redis-backed multi-server routing and pub/sub fan-out, see <Link href="/integrations/redis" text={<code>@telefunc/redis</code>} />.
+For Redis-backed multi-server routing and broadcast fan-out, see <Link href="/integrations/redis" text={<code>@telefunc/redis</code>} />.
 
 ### Custom transport
 
@@ -294,7 +294,7 @@ type BroadcastTransport = {
 
 `send` / `sendBinary` must return the assigned `{ seq, ts }` so subscribers across nodes see a single global order per key. `listen` / `listenBinary` return an unsubscribe function and are called at most once per key.
 
-> On Cloudflare Workers, Telefunc handles distributed pub/sub automatically via Durable Objects — no transport needed. See <Link href="/cloudflare" />.
+> On Cloudflare Workers, Telefunc handles distributed broadcast automatically via Durable Objects — no transport needed. See <Link href="/cloudflare" />.
 
 
 ## Lifecycle
@@ -374,4 +374,4 @@ config.channel = {
 - <Link href="/file-upload" /> — file uploads with progress
 - <Link href="/file-download" /> — streaming file downloads
 - <Link href="/transport" /> — transport configuration
-- <Link href="/cloudflare" /> — Cloudflare Workers with distributed pub/sub
+- <Link href="/cloudflare" /> — Cloudflare Workers with distributed broadcast

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -47,7 +47,7 @@ export default {
 > Why these bindings:
 >
 > - **Durable Object**: channels are stateful. Each WebSocket connection and its in-memory channel state live on a Durable Object.
-> - **KV**: stores session tokens (so each browser reaches the same Durable Object across requests) and pub/sub presence (which Durable Objects have active subscribers for a key).
+> - **KV**: stores session tokens (so each browser reaches the same Durable Object across requests) and broadcast presence (which Durable Objects have active subscribers for a key).
 >
 > Both bindings are always required: `tf.serve()` routes every Telefunc request through the Durable Object, plain telefunction calls included, and checks the session token in KV on each request. If your app doesn't use `Channel` or `Broadcast`, you can skip both bindings and use `serve()` instead of `telefunc/cloudflare`, see <Link text="Low-level API" href="/server#low-level-api" />.
 >
@@ -68,11 +68,11 @@ const tf = telefunc({
 
 ## Architecture
 
-Telefunc uses [Durable Objects](https://developers.cloudflare.com/durable-objects/) for channel state and pub/sub. Channel state is in-memory JavaScript (closures, callbacks, local variables), so it must live on the same Durable Object as the WebSocket connection.
+Telefunc uses [Durable Objects](https://developers.cloudflare.com/durable-objects/) for channel state and broadcast fan-out. Channel state is in-memory JavaScript (closures, callbacks, local variables), so it must live on the same Durable Object as the WebSocket connection.
 
 [KV](https://developers.cloudflare.com/kv/) stores two things:
 - **Session tokens** — pins a browser to the same Durable Object across requests.
-- **Pub/sub presence** — tracks which Durable Objects have active subscribers for each key.
+- **Broadcast presence** — tracks which Durable Objects have active subscribers for each key.
 
 ### Regions
 
@@ -119,9 +119,9 @@ const tf = telefunc({
 Only specified regions get Durable Objects. Requests from unspecified regions fall back to `locationFallback`.
 
 
-## Distributed pub/sub
+## Distributed broadcast
 
-Pub/sub (<Link href="/channel#new-broadcast" />) broadcasts across all regions automatically.
+`Broadcast` (<Link href="/channel#new-broadcast" />) fans out across all regions automatically.
 
 ### How it works
 
@@ -165,7 +165,7 @@ A KV record is created on subscribe and deleted on unsubscribe. If a Durable Obj
 | Acknowledgements | `send(data, { ack: true })` resolves when the other side processes the message. |
 | Loss | If the disconnect exceeds `config.channel.reconnectTimeout`, the channel closes with `ChannelNetworkError`. |
 
-### Pub/sub messages (`publish` / `subscribe`)
+### Broadcast messages (`publish` / `subscribe`)
 
 | Guarantee | Details |
 |---|---|
@@ -173,7 +173,7 @@ A KV record is created on subscribe and deleted on unsubscribe. If a Durable Obj
 | Delivery | `publish()` resolves after all Durable Objects with subscribers have received the message. Client delivery happens over the channel wire. |
 | Presence lag | Up to 90 seconds. A new subscriber may miss a publish until its KV record is written (typically a few milliseconds). |
 
-> Once a pub/sub message reaches a Durable Object, it has the same buffering and replay guarantees as regular channel messages.
+> Once a broadcast message reaches a Durable Object, it has the same buffering and replay guarantees as regular channel messages.
 
 
 ## Configuration
@@ -213,5 +213,5 @@ config.channel = {
 ## See also
 
 - <Link href="/server" /> — serve API for all runtimes
-- <Link href="/channel" /> — channel and pub/sub API
+- <Link href="/channel" /> — `Channel` and `Broadcast` API
 - <Link href="/real-time" /> — real-time patterns

--- a/docs/pages/integrations/tanstack-query/+Page.mdx
+++ b/docs/pages/integrations/tanstack-query/+Page.mdx
@@ -104,14 +104,14 @@ Prefix matching — invalidating `['global:documents']` hits `['global:documents
 **Global keys:**
 1. `QueryClient` sends each global query's `queryKey` alongside the telefunc call.
 2. The telefunction executes (including auth). Only after it succeeds, the server subscribes to invalidation events for that key.
-3. Mutations work the same way — the telefunction runs first, then global keys from `meta.invalidates` are published through <Link text="pub/sub" href="/channel#new-broadcast" />.
+3. Mutations work the same way — the telefunction runs first, then global keys from `meta.invalidates` are published through <Link text={<code>Broadcast</code>} href="/channel#new-broadcast" />.
 4. Every connected client with a matching subscription calls `invalidateQueries()`.
 
-Works across multiple servers via the <Link text="pub/sub adapter" href="/channel#multi-server" />.
+Works across multiple servers via a <Link text="broadcast transport" href="/channel#multi-server" />.
 
 
 ## See also
 
-- <Link href="/channel" /> — channels and pub/sub
+- <Link href="/channel" /> — `Channel` and `Broadcast`
 - <Link href="/real-time" /> — real-time patterns
 - <Link href="/cloudflare" /> — Cloudflare Workers

--- a/docs/pages/multiple-nodes/+Page.mdx
+++ b/docs/pages/multiple-nodes/+Page.mdx
@@ -21,7 +21,7 @@ Without sticky sessions a reconnect that lands on a different instance sees no m
 
 ## Broadcast across instances
 
-A `Broadcast` is different. It's a pub/sub primitive keyed by a string, so subscribers and publishers are intentionally decoupled. Each instance keeps its own subscriber list locally, and the broadcast transport is what makes a publish on instance A reach a subscriber on instance B.
+A `Broadcast` is different: publishers and subscribers are intentionally decoupled — they only share a string key. Each instance keeps its own subscriber list locally, and the broadcast transport is what makes a publish on instance A reach a subscriber on instance B.
 
 In a single-instance setup the default in-memory transport is enough. In a multi-instance setup, configure a transport that fans out across the cluster:
 
@@ -34,7 +34,7 @@ const redis = new IORedis(process.env.REDIS_URL)
 installRedis(redis)
 ```
 
-See <Link href="/integrations/redis" /> for details. Redis is the only adapter shipped today, but the `BroadcastTransport` interface is small — about four methods — so a custom transport on top of NATS, Kafka, RabbitMQ, or anything else with pub/sub is straightforward.
+See <Link href="/integrations/redis" /> for details. Redis is the only adapter shipped today, but the `BroadcastTransport` interface is small — about four methods — so a custom transport on top of NATS, Kafka, RabbitMQ, or any other message broker is straightforward.
 
 
 ## Load balancer setup

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -80,7 +80,7 @@ See <Link href="/channel" /> for the full API.
 > Channel messages are **shield-validated at runtime** from your TypeScript types — every client→server message passed to `listen()` is checked against the declared client-to-server type before reaching server code, and every ack response from the client is checked against the declared server-to-client type. See <Link href="/shield#channels" text="Shield — Channels" />.
 
 
-## Pub/sub
+## Broadcast
 
 Use <Link text={<code>new Broadcast()</code>} href="/channel#new-broadcast" /> for broadcast messaging — all instances sharing a key form a broadcast group.
 
@@ -119,7 +119,7 @@ chat.subscribe((msg) => console.log(msg))
 chat.publish({ user: 'Alice', text: 'Hello!' })
 ```
 
-See <Link href="/channel#new-broadcast" /> for the full pub/sub API.
+See <Link href="/channel#new-broadcast" /> for the full `Broadcast` API.
 
 > Client-published messages are **shield-validated at runtime** from your TypeScript types — when the client calls `publish()` on a `Broadcast<T>` returned from a telefunction, the value is checked against `T` on the server before fanning out to subscribers. A failing shield rejects the client's `publish()` promise with `ShieldValidationError`. See <Link href="/shield" />.
 

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -156,7 +156,7 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 }
 ```
 
-> See <Link text="Cloudflare Workers" href="/cloudflare" /> for scaling, distributed pub/sub, delivery guarantees, and Durable Object configuration.
+> See <Link text="Cloudflare Workers" href="/cloudflare" /> for scaling, distributed broadcast, delivery guarantees, and Durable Object configuration.
 
 
 ## Return value

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -210,7 +210,7 @@ await events.send({ tick: 1 }, { ack: true })
 
 ### Broadcast
 
-[`new Broadcast<T>({ key })`](/channel#new-broadcast) declares the message type `T` flowing through a keyed pub/sub topic. Telefunc generates a `data` sub-shield that fires on the server when a client calls `publish()` on a `Broadcast` returned from a telefunction:
+[`new Broadcast<T>({ key })`](/channel#new-broadcast) declares the message type `T` flowing through a keyed broadcast topic. Telefunc generates a `data` sub-shield that fires on the server when a client calls `publish()` on a `Broadcast` returned from a telefunction:
 
 ```ts
 // Chat.telefunc.ts

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telefunc/redis",
   "version": "0.1.0",
-  "description": "Redis pub/sub adapter for Telefunc — scale channels and pub/sub across multiple server instances.",
+  "description": "Redis broadcast transport for Telefunc — fan out Broadcast messages across multiple server instances.",
   "homepage": "https://github.com/brillout/telefunc/tree/main/packages/redis#readme",
   "repository": {
     "type": "git",

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -6,7 +6,7 @@ import { config, type BroadcastTransport } from 'telefunc'
 import { assert } from './assert.js'
 import { callDefinedCommand } from './callDefinedCommand.js'
 
-/** Wires Redis-backed broadcast pub/sub fan-out into the telefunc broadcast adapter so
+/** Wires Redis-backed fan-out into the telefunc broadcast transport so
  *  `Broadcast.publish()`/`subscribe()` cross instances. Pair with sticky-session routing
  *  at the load balancer so each client's channel traffic stays on one instance. */
 function installRedis(redis: Redis | Cluster, options: InstallRedisOptions = {}): void {

--- a/packages/telefunc/node/server/serverConfig.ts
+++ b/packages/telefunc/node/server/serverConfig.ts
@@ -62,7 +62,7 @@ type StreamConfigUser = {
 }
 
 type BroadcastConfigUser = {
-  /** Transport for cross-node pub/sub delivery. */
+  /** Transport for cross-node `Broadcast` delivery. */
   transport?: BroadcastTransport
 }
 
@@ -200,7 +200,7 @@ type ConfigUser = {
   stream: StreamConfigUser
   /** Enabled transports and runtime settings for Telefunc channels. */
   channel: ChannelConfigUser
-  /** Pub/sub configuration. */
+  /** `Broadcast` configuration. */
   broadcast: BroadcastConfigUser
   /** Registered server extensions. Use `config.extensions.push(ext)` to add. */
   extensions: TelefuncServerExtension[]

--- a/packages/telefunc/wire-protocol/channel.ts
+++ b/packages/telefunc/wire-protocol/channel.ts
@@ -23,7 +23,7 @@ import type { TELEFUNC_SHIELDS } from '../node/shared/transformer/generateShield
 type ChannelData<T> = [T] extends [never] ? never : T extends (data: infer D) => any ? D : T
 type ChannelAck<T> = [T] extends [never] ? never : T extends (data: any) => infer R ? Awaited<R> : unknown
 type ChannelPublishMeta = Record<string, unknown>
-/** Metadata delivered to pub/sub subscribers alongside each message. */
+/** Metadata delivered to broadcast subscribers alongside each message. */
 type ChannelPublishInfo = {
   key: string
   /** Strict per-key counter (1, 2, 3…). Resets if the authority restarts. Use for gap detection. */

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.ts
@@ -240,7 +240,7 @@ class CloudflareBroadcastAuthorityState {
 }
 
 // ---------------------------------------------------------------------------
-// CloudflareBroadcastTransport — per-isolate pub/sub transport.
+// CloudflareBroadcastTransport — per-isolate broadcast transport.
 //
 // A single CloudflareBroadcastTransport instance exists per worker isolate.
 // Multiple Durable Object instances in the same isolate share this transport.
@@ -291,7 +291,7 @@ class CloudflareBroadcastTransport implements BroadcastAdapter {
   // --- KV presence ---
 
   private requireKV(): KVNamespace {
-    assert(this.kv, 'Cloudflare KV binding is not attached. Keyed pub/sub requires a KV namespace.')
+    assert(this.kv, 'Cloudflare KV binding is not attached. Broadcast requires a KV namespace.')
     return this.kv
   }
 

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/routing.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/routing.ts
@@ -18,7 +18,7 @@ import { TELEFUNC_SESSION_HEADER } from '../../../constants.js'
 import { assert } from '../../../../utils/assert.js'
 
 /**
- * Cloudflare routing primitives for Telefunc's session and pub/sub Durable Objects.
+ * Cloudflare routing primitives for Telefunc's session and broadcast Durable Objects.
  *
  * Routing now always resolves to one of Telefunc's canonical Cloudflare location hints.
  * If Cloudflare doesn't provide a precise mapping, Telefunc uses `locationFallback`.

--- a/packages/telefunc/wire-protocol/server/broadcast.spec.ts
+++ b/packages/telefunc/wire-protocol/server/broadcast.spec.ts
@@ -449,7 +449,7 @@ describe('DefaultBroadcastAdapter — multi-node transport', () => {
 })
 
 // ───────────────────────────────────────────────────────────────────────────
-// Static methods — server-only fire-and-forget pub/sub. Bypasses the
+// Static methods — server-only fire-and-forget broadcast. Bypasses the
 // instance-lifecycle (no register, no peer) and goes straight to the adapter.
 // Bug class: regression where statics start touching instance state.
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/telefunc/wire-protocol/server/broadcast.ts
+++ b/packages/telefunc/wire-protocol/server/broadcast.ts
@@ -15,7 +15,7 @@ import type { WirePublishInfo } from '../shared-ws.js'
 /** Transport-level publish result. */
 type BroadcastPublishResult = WirePublishInfo & { meta?: Record<string, unknown> }
 
-/** Callback for delivering a pub/sub message to a subscriber. */
+/** Callback for delivering a broadcast message to a subscriber. */
 type BroadcastOnMessage = (serialized: string, info: WirePublishInfo) => void
 
 type BroadcastBinaryOnMessage = (data: Uint8Array, info: WirePublishInfo) => void
@@ -30,7 +30,7 @@ type BroadcastAdapter = {
 }
 
 /**
- * Minimal interface for a pub/sub transport backend.
+ * Minimal interface for a broadcast transport backend.
  *
  * Implement these 4 methods to get a full BroadcastAdapter via `new DefaultBroadcastAdapter(transport)`.
  * Subscriber multiplexing and lifecycle are handled for you.


### PR DESCRIPTION
Renames the term "pub/sub" to "Broadcast" across the docs, matching the API name. The docs already use "broadcast transport", "broadcast group", and `config.broadcast.transport`, so "pub/sub" was a second name for the same feature.

Changes:
- Docs pages: `real-time`, `channel`, `cloudflare`, `server`, `shield`, `multiple-nodes`, and the TanStack Query integration page. Headings renamed: "Pub/sub" to "Broadcast", "Distributed pub/sub" to "Distributed broadcast", "Server-only pub/sub" to "Server-only broadcast". No existing links point at the old heading anchors.
- JSDoc on `config.broadcast`, `BroadcastTransport`, and the publish info type.
- The `@telefunc/redis` npm description and one runtime error message.

Kept as-is:
- "Redis Pub/Sub" on the Redis pages, since that's the name of the Redis feature.
- The generated `worker-configuration.d.ts` references to Cloudflare Pub/Sub.

The branch also contains a merge of `main` (two pnpm config commits), needed to fast-forward the branch from its original tip.

https://claude.ai/code/session_01B4HFHj3ZdYaKGGi1dU1zJc