### PR TITLE
Rename `ts` to `timestamp` in broadcast publish info

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -263,9 +263,9 @@ const unsub = Broadcast.subscribe('room:lobby', (msg, info) => {
 Both `publish` and `subscribe` share the same `info` object:
 
 ```ts
-info.key  // 'chat:lobby' — the broadcast key
-info.seq  // monotonic sequence number for this key
-info.ts   // server timestamp (Unix epoch ms)
+info.key        // 'chat:lobby' — the broadcast key
+info.seq        // monotonic sequence number for this key
+info.timestamp  // server timestamp (Unix epoch ms)
 ```
 
 `publish()` returns a `Promise` that resolves to `info` once the message is accepted. `subscribe()` receives `info` alongside each message — useful for ordering and gap detection.
@@ -285,14 +285,14 @@ For other backends (NATS, Kafka, …), implement `BroadcastTransport` and assign
 
 ```ts
 type BroadcastTransport = {
-  send(key: string, payload: string): { seq: number; ts: number } | Promise<{ seq: number; ts: number }>
-  listen(key: string, onMessage: (payload: string, info: { seq: number; ts: number }) => void): () => void
-  sendBinary(key: string, payload: Uint8Array): { seq: number; ts: number } | Promise<{ seq: number; ts: number }>
-  listenBinary(key: string, onMessage: (payload: Uint8Array, info: { seq: number; ts: number }) => void): () => void
+  send(key: string, payload: string): { seq: number; timestamp: number } | Promise<{ seq: number; timestamp: number }>
+  listen(key: string, onMessage: (payload: string, info: { seq: number; timestamp: number }) => void): () => void
+  sendBinary(key: string, payload: Uint8Array): { seq: number; timestamp: number } | Promise<{ seq: number; timestamp: number }>
+  listenBinary(key: string, onMessage: (payload: Uint8Array, info: { seq: number; timestamp: number }) => void): () => void
 }
 ```
 
-`send` / `sendBinary` must return the assigned `{ seq, ts }` so subscribers across nodes see a single global order per key. `listen` / `listenBinary` return an unsubscribe function and are called at most once per key.
+`send` / `sendBinary` must return the assigned `{ seq, timestamp }` so subscribers across nodes see a single global order per key. `listen` / `listenBinary` return an unsubscribe function and are called at most once per key.
 
 > On Cloudflare Workers, Telefunc handles distributed pub/sub automatically via Durable Objects — no transport needed. See <Link href="/cloudflare" />.
 

--- a/packages/redis/src/index.spec.ts
+++ b/packages/redis/src/index.spec.ts
@@ -83,15 +83,15 @@ function newAdapter() {
 }
 
 describe('Redis adapter — atomic publish via Lua', () => {
-  it('returns the monotonic per-key seq and Redis-clock ts assigned by the script', async () => {
+  it('returns the monotonic per-key seq and Redis-clock timestamp assigned by the script', async () => {
     const { fake, adapter } = newAdapter()
     fake.setClock(1_700_000_001_000)
 
     const first = await adapter.publish('room:a', 'hello')
     const second = await adapter.publish('room:a', 'world')
 
-    expect(first).toMatchObject({ seq: 1, ts: 1_700_000_001_000 })
-    expect(second).toMatchObject({ seq: 2, ts: 1_700_000_001_000 })
+    expect(first).toMatchObject({ seq: 1, timestamp: 1_700_000_001_000 })
+    expect(second).toMatchObject({ seq: 2, timestamp: 1_700_000_001_000 })
   })
 
   it('keeps separate seq counters per key', async () => {
@@ -108,19 +108,19 @@ describe('Redis adapter — atomic publish via Lua', () => {
 })
 
 describe('Redis adapter — live delivery', () => {
-  it('decodes the binary header and UTF-8 payload for text subscribers with the same seq/ts the publisher saw', async () => {
+  it('decodes the binary header and UTF-8 payload for text subscribers with the same seq/timestamp the publisher saw', async () => {
     const { fake, adapter } = newAdapter()
     fake.setClock(1_700_000_002_000)
 
-    const received: Array<{ payload: string; seq: number; ts: number }> = []
+    const received: Array<{ payload: string; seq: number; timestamp: number }> = []
     adapter.subscribe('room:live', (payload, info) => received.push({ payload, ...info }))
 
     await adapter.publish('room:live', 'msg-1')
     await adapter.publish('room:live', 'msg-2')
 
     expect(received).toEqual([
-      { payload: 'msg-1', seq: 1, ts: 1_700_000_002_000 },
-      { payload: 'msg-2', seq: 2, ts: 1_700_000_002_000 },
+      { payload: 'msg-1', seq: 1, timestamp: 1_700_000_002_000 },
+      { payload: 'msg-2', seq: 2, timestamp: 1_700_000_002_000 },
     ])
   })
 
@@ -128,7 +128,7 @@ describe('Redis adapter — live delivery', () => {
     const { fake, adapter } = newAdapter()
     fake.setClock(1_700_000_003_000)
 
-    const received: Array<{ payload: Uint8Array; seq: number; ts: number }> = []
+    const received: Array<{ payload: Uint8Array; seq: number; timestamp: number }> = []
     adapter.subscribeBinary('room:bin', (payload, info) => received.push({ payload, ...info }))
 
     await adapter.publishBinary('room:bin', new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
@@ -136,6 +136,6 @@ describe('Redis adapter — live delivery', () => {
     expect(received).toHaveLength(1)
     expect(Array.from(received[0]!.payload)).toEqual([0xde, 0xad, 0xbe, 0xef])
     expect(received[0]!.seq).toBe(1)
-    expect(received[0]!.ts).toBe(1_700_000_003_000)
+    expect(received[0]!.timestamp).toBe(1_700_000_003_000)
   })
 })

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -62,11 +62,11 @@ class RedisTransport implements BroadcastTransport {
     this.subscriber.on('messageBuffer', this._onMessage)
   }
 
-  async send(key: string, payload: string): Promise<{ seq: number; ts: number }> {
+  async send(key: string, payload: string): Promise<{ seq: number; timestamp: number }> {
     return this._publish(this.channelKey(key, 't'), this.seqKey(key), textEncoder.encode(payload))
   }
 
-  async sendBinary(key: string, payload: Uint8Array): Promise<{ seq: number; ts: number }> {
+  async sendBinary(key: string, payload: Uint8Array): Promise<{ seq: number; timestamp: number }> {
     return this._publish(this.channelKey(key, 'b'), this.seqKey(key), payload)
   }
 
@@ -96,16 +96,16 @@ class RedisTransport implements BroadcastTransport {
     assert(frame.byteLength >= HEADER_BYTES, 'Malformed publish frame: header too short')
     const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
     const seq = view.getUint32(0, false)
-    const ts = view.getUint32(4, false) * U32_RANGE + view.getUint32(8, false)
+    const timestamp = view.getUint32(4, false) * U32_RANGE + view.getUint32(8, false)
     const payload = frame.subarray(HEADER_BYTES)
     const channel = utf8.decode(channelBytes)
     const text = this.textCallbacks.get(channel)
     if (text) {
-      text(utf8.decode(payload), { seq, ts })
+      text(utf8.decode(payload), { seq, timestamp })
       return
     }
     const binary = this.binaryCallbacks.get(channel)
-    if (binary) binary(payload, { seq, ts })
+    if (binary) binary(payload, { seq, timestamp })
   }
 
   // ── Publish (private) ─────────────────────────────────────────────────
@@ -114,7 +114,7 @@ class RedisTransport implements BroadcastTransport {
     channelKey: string,
     seqKey: string,
     payload: Uint8Array,
-  ): Promise<{ seq: number; ts: number }> {
+  ): Promise<{ seq: number; timestamp: number }> {
     // ioredis 5.x checks `arg instanceof Buffer` to pick its binary path; a raw
     // `Uint8Array` falls into `String(arg)` and gets serialised as a comma-joined
     // string of byte values, corrupting the bytes. `Buffer.from(buf, off, len)`
@@ -122,9 +122,9 @@ class RedisTransport implements BroadcastTransport {
     const buf = Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength)
     const reply = await callDefinedCommand(this.publisher, PUBLISH_CMD, [seqKey, channelKey, buf])
     assert(Array.isArray(reply) && reply.length === 2, 'Publish script returned an unexpected shape')
-    const [seq, ts] = reply
-    assert(typeof seq === 'number' && typeof ts === 'number', 'Publish script returned non-numeric seq/ts')
-    return { seq, ts }
+    const [seq, timestamp] = reply
+    assert(typeof seq === 'number' && typeof timestamp === 'number', 'Publish script returned non-numeric seq/ts')
+    return { seq, timestamp }
   }
 
   // ── Key naming (private) ──────────────────────────────────────────────
@@ -141,8 +141,8 @@ class RedisTransport implements BroadcastTransport {
   }
 }
 
-type TextOnMessage = (payload: string, info: { seq: number; ts: number }) => void
-type BinaryOnMessage = (payload: Uint8Array, info: { seq: number; ts: number }) => void
+type TextOnMessage = (payload: string, info: { seq: number; timestamp: number }) => void
+type BinaryOnMessage = (payload: Uint8Array, info: { seq: number; timestamp: number }) => void
 
 /** Module-level codec — allocating one per call would burn measurable CPU on hot paths. */
 const utf8 = new TextDecoder('utf-8')

--- a/packages/telefunc/wire-protocol/channel.ts
+++ b/packages/telefunc/wire-protocol/channel.ts
@@ -29,12 +29,12 @@ type ChannelPublishInfo = {
   /** Strict per-key counter (1, 2, 3…). Resets if the authority restarts. Use for gap detection. */
   seq: number
   /** Server timestamp, Unix epoch milliseconds. */
-  ts: number
+  timestamp: number
 }
 type ChannelPublishAck = ChannelPublishInfo & { meta?: ChannelPublishMeta }
 
-function makePublishInfo(key: string, seq: number, ts: number): ChannelPublishInfo {
-  return { key, seq, ts }
+function makePublishInfo(key: string, seq: number, timestamp: number): ChannelPublishInfo {
+  return { key, seq, timestamp }
 }
 type ChannelListenReturn<T> = [T] extends [never]
   ? void

--- a/packages/telefunc/wire-protocol/client/channel.ts
+++ b/packages/telefunc/wire-protocol/client/channel.ts
@@ -682,7 +682,7 @@ class ClientBroadcast<T = unknown> extends ClientChannel {
 
   _onTransportPublish(data: string, wireInfo: WirePublishInfo): void {
     const parsed = parse(data) as ChannelData<T>
-    const info = makePublishInfo(this.key!, wireInfo.seq, wireInfo.ts)
+    const info = makePublishInfo(this.key!, wireInfo.seq, wireInfo.timestamp)
     for (const cb of this._broadcastListeners) {
       try {
         cb(parsed, info)
@@ -693,7 +693,7 @@ class ClientBroadcast<T = unknown> extends ClientChannel {
   }
 
   _onTransportPublishBinary(data: Uint8Array, wireInfo: WirePublishInfo): void {
-    const info = makePublishInfo(this.key!, wireInfo.seq, wireInfo.ts)
+    const info = makePublishInfo(this.key!, wireInfo.seq, wireInfo.timestamp)
     for (const cb of this._broadcastBinaryListeners) {
       try {
         cb(data, info)

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.spec.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.spec.ts
@@ -100,7 +100,7 @@ function createBasicBinding(
     get(id: { name: string }) {
       return {
         telefuncBroadcastPublish(request: any) {
-          return overrides?.onPublish?.(id, request) ?? Promise.resolve({ seq: 1, ts: Date.now() })
+          return overrides?.onPublish?.(id, request) ?? Promise.resolve({ seq: 1, timestamp: Date.now() })
         },
         telefuncBroadcastDeliver(request: any) {
           return overrides?.onDeliver?.(id, request) ?? Promise.resolve()
@@ -288,7 +288,7 @@ describe('cloudflare broadcast routing', () => {
         fanoutBuckets: ['weur', 'apac'],
       },
     })
-    expect(receipt.ts).toEqual(expect.any(Number))
+    expect(receipt.timestamp).toEqual(expect.any(Number))
   })
 
   it('waits for KV presence setup before authority publish fanout', async () => {
@@ -312,7 +312,7 @@ describe('cloudflare broadcast routing', () => {
       createBasicBinding({
         onPublish(id, request) {
           publishTargets.push(id.name)
-          return Promise.resolve({ seq: 1, ts: Date.now() })
+          return Promise.resolve({ seq: 1, timestamp: Date.now() })
         },
       }),
       'TelefuncDurableObject',
@@ -450,7 +450,7 @@ describe('cloudflare broadcast routing', () => {
         fanoutBuckets: ['weur'],
       },
     })
-    expect(receipt.ts).toEqual(expect.any(Number))
+    expect(receipt.timestamp).toEqual(expect.any(Number))
 
     _resetBroadcastAdapterForTesting(previousTransport)
   })
@@ -514,7 +514,7 @@ describe('cloudflare broadcast routing', () => {
       serialized: '{"text":"hello"}',
       forwarded: true,
       doNames: ['telefunc-shard-weur-0', 'telefunc-shard-weur-1'],
-      info: { seq: 1, ts: Date.now() },
+      info: { seq: 1, timestamp: Date.now() },
     })
 
     expect(deliveredTo.sort()).toEqual(['telefunc-shard-weur-0', 'telefunc-shard-weur-1'])
@@ -530,7 +530,7 @@ describe('cloudflare broadcast routing', () => {
       createBasicBinding({
         onPublish(id, { key, locationBucket, serialized }) {
           coordinatorPublishes.push({ name: id.name, key, locationBucket, serialized })
-          return Promise.resolve({ seq: 1, ts: Date.now() })
+          return Promise.resolve({ seq: 1, timestamp: Date.now() })
         },
       }),
       'TelefuncDurableObject',

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/broadcast.ts
@@ -23,8 +23,8 @@ const PRESENCE_REFRESH_INTERVAL_MS = 30_000
  *  RPC properties are lazy stubs that must be awaited to resolve their values. */
 async function unwrapRpcResult(rpc: Promise<BroadcastPublishResult>): Promise<BroadcastPublishResult> {
   const r = await rpc
-  const [seq, ts, meta] = await Promise.all([r.seq, r.ts, r.meta])
-  return { seq, ts, ...(meta ? { meta } : undefined) }
+  const [seq, timestamp, meta] = await Promise.all([r.seq, r.timestamp, r.meta])
+  return { seq, timestamp, ...(meta ? { meta } : undefined) }
 }
 
 type BroadcastPublishRequest = {
@@ -474,7 +474,7 @@ class CloudflareBroadcastTransport implements BroadcastAdapter {
           this.getBoundStub(doName).telefuncBroadcastDeliver({ key, serialized, binaryData, info }),
         ),
       )
-      return { seq: info.seq, ts: info.ts }
+      return { seq: info.seq, timestamp: info.timestamp }
     }
 
     const { authorityBucket, seq, presenceByBucket } = await authorityState.runInAuthorityChain(async () => ({
@@ -483,8 +483,8 @@ class CloudflareBroadcastTransport implements BroadcastAdapter {
       presenceByBucket: await this.listPresenceByBucket(key),
     }))
 
-    const ts = Date.now()
-    const info = { seq, ts }
+    const timestamp = Date.now()
+    const info = { seq, timestamp }
     const activeBuckets = Array.from(presenceByBucket.keys())
     await Promise.all(
       activeBuckets.map((activeBucket) =>
@@ -499,7 +499,7 @@ class CloudflareBroadcastTransport implements BroadcastAdapter {
         }),
       ),
     )
-    return { seq, ts, meta: { authorityBucket, fanoutBuckets: activeBuckets } }
+    return { seq, timestamp, meta: { authorityBucket, fanoutBuckets: activeBuckets } }
   }
 
   /**

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/index.spec.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/index.spec.ts
@@ -346,7 +346,7 @@ describe('cloudflare adapter entrypoint', () => {
     instance.telefuncBroadcastDeliver({
       key: 'room:test',
       serialized: '{"text":"hello"}',
-      info: { seq: 1, ts: Date.now() },
+      info: { seq: 1, timestamp: Date.now() },
     })
     expect(mocks.transportInstances[0]?.deliverToLocal).toHaveBeenCalledWith({
       key: 'room:test',

--- a/packages/telefunc/wire-protocol/server/broadcast.spec.ts
+++ b/packages/telefunc/wire-protocol/server/broadcast.spec.ts
@@ -203,7 +203,7 @@ describe('keyed in-process broadcast', () => {
     expect(b1.key).toBe(k2)
     expect(a2.seq).toBe(a1.seq + 1)
     expect(b1.seq).toBe(a1.seq) // separate key → seq counter is independent
-    expect(typeof a1.ts).toBe('number')
+    expect(typeof a1.timestamp).toBe('number')
   })
 })
 
@@ -330,7 +330,7 @@ describe('Broadcast shield validation', () => {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('DefaultBroadcastAdapter — multi-node transport', () => {
-  type TextListener = (payload: string, info: { seq: number; ts: number }) => void
+  type TextListener = (payload: string, info: { seq: number; timestamp: number }) => void
 
   /** Synchronous-delivery bus for fast, deterministic tests. */
   function createMockTransport(): BroadcastTransport & { _listeners: Map<string, Set<TextListener>> } {
@@ -341,10 +341,10 @@ describe('DefaultBroadcastAdapter — multi-node transport', () => {
       send(key, payload) {
         const seq = (seqs.get(key) ?? 0) + 1
         seqs.set(key, seq)
-        const ts = Date.now()
+        const timestamp = Date.now()
         const set = listeners.get(key)
-        if (set) for (const cb of set) cb(payload, { seq, ts })
-        return { seq, ts }
+        if (set) for (const cb of set) cb(payload, { seq, timestamp })
+        return { seq, timestamp }
       },
       listen(key, onMessage) {
         let set = listeners.get(key)
@@ -356,7 +356,7 @@ describe('DefaultBroadcastAdapter — multi-node transport', () => {
         return () => listeners.delete(key)
       },
       sendBinary(_key, _payload) {
-        return { seq: 0, ts: Date.now() }
+        return { seq: 0, timestamp: Date.now() }
       },
       listenBinary() {
         return () => {}
@@ -379,7 +379,7 @@ describe('DefaultBroadcastAdapter — multi-node transport', () => {
 
     expect(received).toEqual([{ text: 'hello' }])
     expect(receipt.seq).toBe(1)
-    expect(typeof receipt.ts).toBe('number')
+    expect(typeof receipt.timestamp).toBe('number')
   })
 
   // The classic distributed-bus footgun: the transport delivers to all subscribers

--- a/packages/telefunc/wire-protocol/server/broadcast.ts
+++ b/packages/telefunc/wire-protocol/server/broadcast.ts
@@ -36,14 +36,20 @@ type BroadcastAdapter = {
  * Subscriber multiplexing and lifecycle are handled for you.
  */
 type BroadcastTransport = {
-  /** Send a text message. Must return the assigned seq and ts. */
-  send(key: string, payload: string): { seq: number; ts: number } | Promise<{ seq: number; ts: number }>
+  /** Send a text message. Must return the assigned seq and timestamp. */
+  send(key: string, payload: string): { seq: number; timestamp: number } | Promise<{ seq: number; timestamp: number }>
   /** Listen for text messages on a key. Called at most once per key. Return an unsubscribe function. */
-  listen(key: string, onMessage: (payload: string, info: { seq: number; ts: number }) => void): () => void
-  /** Send a binary message. Must return the assigned seq and ts. */
-  sendBinary(key: string, payload: Uint8Array): { seq: number; ts: number } | Promise<{ seq: number; ts: number }>
+  listen(key: string, onMessage: (payload: string, info: { seq: number; timestamp: number }) => void): () => void
+  /** Send a binary message. Must return the assigned seq and timestamp. */
+  sendBinary(
+    key: string,
+    payload: Uint8Array,
+  ): { seq: number; timestamp: number } | Promise<{ seq: number; timestamp: number }>
   /** Listen for binary messages on a key. Called at most once per key. Return an unsubscribe function. */
-  listenBinary(key: string, onMessage: (payload: Uint8Array, info: { seq: number; ts: number }) => void): () => void
+  listenBinary(
+    key: string,
+    onMessage: (payload: Uint8Array, info: { seq: number; timestamp: number }) => void,
+  ): () => void
 }
 
 // ---------------------------------------------------------------------------
@@ -146,8 +152,8 @@ class DefaultBroadcastAdapter implements BroadcastAdapter {
   ): BroadcastPublishResult {
     const seq = (this.keySeqs.get(key) ?? 0) + 1
     this.keySeqs.set(key, seq)
-    const ts = Date.now()
-    const info = { seq, ts }
+    const timestamp = Date.now()
+    const info = { seq, timestamp }
     let delivered = 0
     const set = subs.get(key)
     if (set) {
@@ -156,7 +162,7 @@ class DefaultBroadcastAdapter implements BroadcastAdapter {
         onMessage(data, info)
       }
     }
-    return { seq, ts, meta: { delivered, transport: 'in-memory' } }
+    return { seq, timestamp, meta: { delivered, transport: 'in-memory' } }
   }
 
   // ── Shared ──

--- a/packages/telefunc/wire-protocol/server/server-broadcast.ts
+++ b/packages/telefunc/wire-protocol/server/server-broadcast.ts
@@ -68,7 +68,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
     const adapter = getBroadcastAdapter()
     return adapter.subscribe(key, (serialized, info) => {
       const data = parse(serialized) as ChannelData<U>
-      callback(data, { key, seq: info.seq, ts: info.ts })
+      callback(data, { key, seq: info.seq, timestamp: info.timestamp })
     })
   }
 
@@ -80,7 +80,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
   static subscribeBinary(key: string, callback: BroadcastBinaryListener): BroadcastUnsubscribe {
     const adapter = getBroadcastAdapter()
     return adapter.subscribeBinary(key, (data, info) => {
-      callback(data, { key, seq: info.seq, ts: info.ts })
+      callback(data, { key, seq: info.seq, timestamp: info.timestamp })
     })
   }
 
@@ -170,7 +170,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
   }
 
   _deliverBroadcastMessage(serialized: string, rawInfo: WirePublishInfo): void {
-    const info = makePublishInfo(this.key, rawInfo.seq, rawInfo.ts)
+    const info = makePublishInfo(this.key, rawInfo.seq, rawInfo.timestamp)
     const data = parse(serialized) as ChannelData<T>
     for (const cb of this._broadcastListeners) {
       try {
@@ -189,7 +189,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
   }
 
   _deliverBroadcastBinaryMessage(data: Uint8Array, rawInfo: WirePublishInfo): void {
-    const info = makePublishInfo(this.key, rawInfo.seq, rawInfo.ts)
+    const info = makePublishInfo(this.key, rawInfo.seq, rawInfo.timestamp)
     for (const cb of this._broadcastBinaryListeners) {
       try {
         cb(data, info)
@@ -263,7 +263,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
   private _publishBroadcast(serialized: string): ChannelPublishAck | Promise<ChannelPublishAck> {
     assert(this._adapter)
     const toAck = (r: BroadcastPublishResult): ChannelPublishAck =>
-      Object.assign(makePublishInfo(this.key, r.seq, r.ts), { meta: r.meta })
+      Object.assign(makePublishInfo(this.key, r.seq, r.timestamp), { meta: r.meta })
     const result = this._adapter.publish(this.key, serialized)
     if (isPromise(result)) return result.then(toAck)
     return toAck(result)
@@ -272,7 +272,7 @@ class ServerBroadcast<T = unknown> extends ServerChannel {
   private _publishBinaryBroadcast(data: Uint8Array): ChannelPublishAck | Promise<ChannelPublishAck> {
     assert(this._adapter)
     const toAck = (r: BroadcastPublishResult): ChannelPublishAck =>
-      Object.assign(makePublishInfo(this.key, r.seq, r.ts), { meta: r.meta })
+      Object.assign(makePublishInfo(this.key, r.seq, r.timestamp), { meta: r.meta })
     const result = this._adapter.publishBinary(this.key, data)
     if (isPromise(result)) return result.then(toAck)
     return toAck(result)

--- a/packages/telefunc/wire-protocol/shared-ws.ts
+++ b/packages/telefunc/wire-protocol/shared-ws.ts
@@ -167,7 +167,7 @@ const ACK_STATUS = {
 type AckResultStatus = (typeof ACK_STATUS)[keyof typeof ACK_STATUS]
 
 /** Ordering metadata embedded in PUBLISH frames on the wire. */
-type WirePublishInfo = { seq: number; ts: number }
+type WirePublishInfo = { seq: number; timestamp: number }
 
 // ===== Decoded frame =====
 
@@ -449,11 +449,11 @@ function decode(frame: Uint8Array): DecodedFrame {
 }
 
 // ===== Publish info helpers =====
-// Format: seq,ts\n{serialized text}
+// Format: seq,timestamp\n{serialized text}
 // JSON.stringify never produces bare \n, so the first \n reliably splits info from payload.
 
 function encodePublishText(text: string, info: WirePublishInfo): string {
-  return info.seq + ',' + info.ts + '\n' + text
+  return info.seq + ',' + info.timestamp + '\n' + text
 }
 
 function decodePublishText(wire: string): { text: string; info: WirePublishInfo } {
@@ -462,13 +462,13 @@ function decodePublishText(wire: string): { text: string; info: WirePublishInfo 
   const comma = wire.indexOf(',')
   assert(comma !== -1 && comma < nl, 'PUBLISH frame malformed info prefix')
   const seq = Number(wire.slice(0, comma))
-  const ts = Number(wire.slice(comma + 1, nl))
-  assert(Number.isFinite(seq) && Number.isFinite(ts), 'PUBLISH frame info must be finite numbers')
-  return { text: wire.slice(nl + 1), info: { seq, ts } }
+  const timestamp = Number(wire.slice(comma + 1, nl))
+  assert(Number.isFinite(seq) && Number.isFinite(timestamp), 'PUBLISH frame info must be finite numbers')
+  return { text: wire.slice(nl + 1), info: { seq, timestamp } }
 }
 
 // ===== Binary publish info helpers =====
-// Format: [4 bytes: seq as u32 LE][8 bytes: ts as f64 LE][binary data]
+// Format: [4 bytes: seq as u32 LE][8 bytes: timestamp as f64 LE][binary data]
 
 const PUBLISH_BINARY_HEADER = 12
 
@@ -476,7 +476,7 @@ function encodePublishBinary(data: Uint8Array, info: WirePublishInfo): Uint8Arra
   const result = new Uint8Array(PUBLISH_BINARY_HEADER + data.byteLength)
   const view = new DataView(result.buffer)
   view.setUint32(0, info.seq, true)
-  view.setFloat64(4, info.ts, true)
+  view.setFloat64(4, info.timestamp, true)
   result.set(data, PUBLISH_BINARY_HEADER)
   return result
 }
@@ -485,7 +485,7 @@ function decodePublishBinary(wire: Uint8Array): { data: Uint8Array; info: WirePu
   assert(wire.byteLength >= PUBLISH_BINARY_HEADER, 'PUBLISH_BINARY frame too short for info header')
   const view = new DataView(wire.buffer, wire.byteOffset, wire.byteLength)
   const seq = view.getUint32(0, true)
-  const ts = view.getFloat64(4, true)
-  assert(Number.isFinite(seq) && Number.isFinite(ts), 'PUBLISH_BINARY frame info must be finite numbers')
-  return { data: wire.subarray(PUBLISH_BINARY_HEADER), info: { seq, ts } }
+  const timestamp = view.getFloat64(4, true)
+  assert(Number.isFinite(seq) && Number.isFinite(timestamp), 'PUBLISH_BINARY frame info must be finite numbers')
+  return { data: wire.subarray(PUBLISH_BINARY_HEADER), info: { seq, timestamp } }
 }


### PR DESCRIPTION
This PR renames the `ts` field to `timestamp` throughout the broadcast system for improved clarity and consistency.

## Summary
Standardizes the naming convention across all broadcast-related types and implementations by replacing the abbreviated `ts` field with the more explicit `timestamp` field. This change improves code readability without altering any functionality.

## Key Changes
- **Type definitions**: Updated `BroadcastTransport`, `WirePublishInfo`, and `ChannelPublishInfo` types to use `timestamp` instead of `ts`
- **Redis transport**: Updated `RedisTransport` implementation and type signatures to use `timestamp`
- **Wire protocol**: Updated encoding/decoding functions in `shared-ws.ts` to use `timestamp` in serialization format and comments
- **Server broadcast**: Updated `ServerBroadcast` class to use `timestamp` when delivering messages and publishing
- **Client broadcast**: Updated `ClientBroadcast` to use `timestamp` when processing transport messages
- **Cloudflare adapter**: Updated broadcast routing and RPC result unwrapping to use `timestamp`
- **Default adapter**: Updated `DefaultBroadcastAdapter` implementation to use `timestamp`
- **Tests and documentation**: Updated all test assertions, mock implementations, and documentation to reflect the new field name

## Implementation Details
- The change is purely a rename with no behavioral modifications
- All internal variable names were updated for consistency (e.g., `ts` → `timestamp`)
- Comments and documentation strings were updated to reference `timestamp` instead of `ts`
- The wire protocol format comments were updated to reflect the new naming

https://claude.ai/code/session_01DVgXGjTfpPnWYf88AaYJ8i