### PR TITLE
Refactor telefunc factory function to Telefunc class

### DIFF
--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -11,9 +11,9 @@ Cloudflare-specific setup for <Link href="/channel">`Channel` and `Broadcast`</L
 // worker.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/cloudflare'
+import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 export const TelefuncDurableObject = tf.TelefuncDurableObject
 
@@ -58,7 +58,7 @@ export default {
 Pass per-request data to telefunctions via <Link text={<code>getContext()</code>} href="/getContext" />:
 
 ```ts
-const tf = telefunc({
+const tf = new Telefunc({
   context: async (request, env: Env) => ({
     user: await getUserFromCookie(request, env),
   }),
@@ -103,7 +103,7 @@ On the first request, Telefunc picks a Durable Object in the nearest region, sto
 By default, Telefunc creates one Durable Object per region. Increase capacity with `scale`:
 
 ```ts
-const tf = telefunc({ scale: 4 })
+const tf = new Telefunc({ scale: 4 })
 ```
 
 This creates 4 Durable Objects per region. Sessions are distributed across them.
@@ -111,7 +111,7 @@ This creates 4 Durable Objects per region. Sessions are distributed across them.
 ### Per-region scale
 
 ```ts
-const tf = telefunc({
+const tf = new Telefunc({
   scale: { weur: 5, enam: 3, apac: 2 },
 })
 ```
@@ -179,7 +179,7 @@ A KV record is created on subscribe and deleted on unsubscribe. If a Durable Obj
 ## Configuration
 
 ```ts
-const tf = telefunc({
+const tf = new Telefunc({
   bindingName: 'TelefuncDurableObject',  // DO binding name (default)
   kvBindingName: 'TelefuncKV',           // KV binding name (default)
   instanceName: 'telefunc',              // Base name for DO instances (default)

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -122,9 +122,9 @@ Deno.serve({ port: 3000 }, async (request, info) => {
 // worker.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/cloudflare'
+import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 export const TelefuncDurableObject = tf.TelefuncDurableObject
 

--- a/packages/telefunc/serve/cloudflare.ts
+++ b/packages/telefunc/serve/cloudflare.ts
@@ -1,6 +1,6 @@
 /// <reference types="@cloudflare/workers-types" />
 
-export { telefunc }
+export { Telefunc }
 export type { CloudflareWebSocketOptions }
 
 import { DurableObject } from 'cloudflare:workers'
@@ -24,7 +24,7 @@ import {
   resolveSessionRoutingTarget,
 } from '../wire-protocol/server/adapter/cloudflare/routing.js'
 import { assertUsage } from '../utils/assert.js'
-import type { Telefunc } from '../node/server/context/getContext.js'
+import type { Telefunc as TelefuncNamespace } from '../node/server/context/getContext.js'
 import type { CloudflareScale, LocationBucket } from '../wire-protocol/server/adapter/cloudflare/routing.js'
 import { CHANNEL_TRANSPORT } from '../wire-protocol/constants.js'
 
@@ -34,7 +34,7 @@ type CloudflareWebSocketOptions = {
   bindingName?: string
   kvBindingName?: string
   instanceName?: string
-  context?: (request: Request, env: Cloudflare.Env) => Telefunc.Context | Promise<Telefunc.Context>
+  context?: (request: Request, env: Cloudflare.Env) => TelefuncNamespace.Context | Promise<TelefuncNamespace.Context>
   scale?: CloudflareScale
   locationFallback?: DurableObjectLocationHint
   jurisdiction?: DurableObjectJurisdiction
@@ -51,90 +51,95 @@ type ServeInput = {
   ctx: ExecutionContext
 }
 
-interface TelefuncServe {
-  serve(input: ServeInput): Promise<Response | undefined>
-  TelefuncDurableObject: new (ctx: DurableObjectState, env: Cloudflare.Env) => DurableObject
-}
+class Telefunc {
+  readonly serve: (input: ServeInput) => Promise<Response | undefined>
+  readonly TelefuncDurableObject: new (
+    ctx: DurableObjectState,
+    env: Cloudflare.Env,
+  ) => DurableObject
 
-function telefunc(options?: CloudflareWebSocketOptions): TelefuncServe {
-  enableChannelTransports([CHANNEL_TRANSPORT.WS])
-  const bindingName = options?.bindingName ?? 'TelefuncDurableObject'
-  const kvBindingName = options?.kvBindingName ?? 'TelefuncKV'
-  const baseInstanceName = options?.instanceName ?? 'telefunc'
-  const scale = options?.scale
-  const locationFallback = options?.locationFallback ?? 'weur'
-  const jurisdiction = options?.jurisdiction
+  constructor(options?: CloudflareWebSocketOptions) {
+    enableChannelTransports([CHANNEL_TRANSPORT.WS])
+    const bindingName = options?.bindingName ?? 'TelefuncDurableObject'
+    const kvBindingName = options?.kvBindingName ?? 'TelefuncKV'
+    const baseInstanceName = options?.instanceName ?? 'telefunc'
+    const scale = options?.scale
+    const locationFallback = options?.locationFallback ?? 'weur'
+    const jurisdiction = options?.jurisdiction
 
-  const crosswsAdapter = crossws({
-    bindingName,
-    instanceName: baseInstanceName,
-    hooks: getTelefuncChannelHooks(),
-  })
-  // Factory runs only on first install. Bundler quirks can evaluate the user's entry twice in the same isolate;
-  // we want every evaluation to share one transport instance.
-  const broadcast = installBroadcastAdapter(() => new CloudflareBroadcastTransport({ baseInstanceName, scale }))
+    const crosswsAdapter = crossws({
+      bindingName,
+      instanceName: baseInstanceName,
+      hooks: getTelefuncChannelHooks(),
+    })
+    // Factory runs only on first install. Bundler quirks can evaluate the user's entry twice in the same isolate;
+    // we want every evaluation to share one transport instance.
+    const broadcast = installBroadcastAdapter(() => new CloudflareBroadcastTransport({ baseInstanceName, scale }))
 
-  function getBinding(env: Cloudflare.Env): DurableObjectNamespace | undefined {
-    const baseBinding = (env as Record<string, DurableObjectNamespace | undefined>)[bindingName]
-    return baseBinding && jurisdiction ? baseBinding.jurisdiction(jurisdiction) : baseBinding
-  }
-
-  function getKVBinding(env: Cloudflare.Env): KVNamespace | undefined {
-    return (env as Record<string, KVNamespace | undefined>)[kvBindingName]
-  }
-
-  const getContext = options?.context
-
-  const TelefuncDurableObject = class extends DurableObject {
-    private readonly authorityState: CloudflareBroadcastAuthorityState
-
-    constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
-      super(ctx, env)
-      const binding = getBinding(env)
-      assertUsage(binding, `Missing Cloudflare Durable Object binding "${bindingName}" in Durable Object constructor.`)
-      broadcast.attachBinding(binding, bindingName)
-      const kv = getKVBinding(env)
-      if (kv) broadcast.attachKV(kv)
-      this.authorityState = new CloudflareBroadcastAuthorityState(ctx)
-      crosswsAdapter.handleDurableInit(this, ctx, env)
+    function getBinding(env: Cloudflare.Env): DurableObjectNamespace | undefined {
+      const baseBinding = (env as Record<string, DurableObjectNamespace | undefined>)[bindingName]
+      return baseBinding && jurisdiction ? baseBinding.jurisdiction(jurisdiction) : baseBinding
     }
 
-    async fetch(request: Request) {
-      const shard = request.headers.get(TELEFUNC_SHARD_HEADER)
-      const bucket = request.headers.get(TELEFUNC_BROADCAST_BUCKET_HEADER) as LocationBucket | null
-      if (shard && bucket) {
-        broadcast.attachIsolateInfo(shard, bucket)
+    function getKVBinding(env: Cloudflare.Env): KVNamespace | undefined {
+      return (env as Record<string, KVNamespace | undefined>)[kvBindingName]
+    }
+
+    const getContext = options?.context
+
+    const TelefuncDurableObject = class extends DurableObject {
+      private readonly authorityState: CloudflareBroadcastAuthorityState
+
+      constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
+        super(ctx, env)
+        const binding = getBinding(env)
+        assertUsage(
+          binding,
+          `Missing Cloudflare Durable Object binding "${bindingName}" in Durable Object constructor.`,
+        )
+        broadcast.attachBinding(binding, bindingName)
+        const kv = getKVBinding(env)
+        if (kv) broadcast.attachKV(kv)
+        this.authorityState = new CloudflareBroadcastAuthorityState(ctx)
+        crosswsAdapter.handleDurableInit(this, ctx, env)
       }
-      if (request.headers.get('upgrade') === 'websocket') {
-        return crosswsAdapter.handleDurableUpgrade(this, request)
+
+      async fetch(request: Request) {
+        const shard = request.headers.get(TELEFUNC_SHARD_HEADER)
+        const bucket = request.headers.get(TELEFUNC_BROADCAST_BUCKET_HEADER) as LocationBucket | null
+        if (shard && bucket) {
+          broadcast.attachIsolateInfo(shard, bucket)
+        }
+        if (request.headers.get('upgrade') === 'websocket') {
+          return crosswsAdapter.handleDurableUpgrade(this, request)
+        }
+        const context = getContext ? await getContext(request, this.env as Cloudflare.Env) : undefined
+        const httpResponse = await serveTelefunc(context ? { request, context } : { request })
+        return new Response(httpResponse.getReadableWebStream(), {
+          status: httpResponse.statusCode,
+          headers: httpResponse.headers,
+        })
       }
-      const context = getContext ? await getContext(request, this.env as Cloudflare.Env) : undefined
-      const httpResponse = await serveTelefunc(context ? { request, context } : { request })
-      return new Response(httpResponse.getReadableWebStream(), {
-        status: httpResponse.statusCode,
-        headers: httpResponse.headers,
-      })
-    }
 
-    webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
-      return crosswsAdapter.handleDurableMessage(this, ws, message)
-    }
+      webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+        return crosswsAdapter.handleDurableMessage(this, ws, message)
+      }
 
-    webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
-      return crosswsAdapter.handleDurableClose(this, ws, code, reason, wasClean)
-    }
+      webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
+        return crosswsAdapter.handleDurableClose(this, ws, code, reason, wasClean)
+      }
 
-    telefuncBroadcastPublish(request: BroadcastPublishRequest) {
-      return broadcast.publishToSubscribers(this.authorityState, request)
-    }
+      telefuncBroadcastPublish(request: BroadcastPublishRequest) {
+        return broadcast.publishToSubscribers(this.authorityState, request)
+      }
 
-    telefuncBroadcastDeliver(request: BroadcastDeliverRequest) {
-      broadcast.deliverToLocal(request)
+      telefuncBroadcastDeliver(request: BroadcastDeliverRequest) {
+        broadcast.deliverToLocal(request)
+      }
     }
-  }
+    this.TelefuncDurableObject = TelefuncDurableObject
 
-  return {
-    async serve({ request, env, ctx }: ServeInput): Promise<Response | undefined> {
+    this.serve = async ({ request, env, ctx }: ServeInput): Promise<Response | undefined> => {
       const config = getServerConfig()
       if (!new URL(request.url).pathname.startsWith(config.telefuncUrl)) return undefined
 
@@ -188,7 +193,6 @@ function telefunc(options?: CloudflareWebSocketOptions): TelefuncServe {
       }
 
       return doResponse
-    },
-    TelefuncDurableObject,
+    }
   }
 }

--- a/packages/telefunc/wire-protocol/server/adapter/cloudflare/index.spec.ts
+++ b/packages/telefunc/wire-protocol/server/adapter/cloudflare/index.spec.ts
@@ -107,7 +107,7 @@ vi.mock('./routing.js', () => ({
   ),
 }))
 
-import { telefunc } from '../../../../serve/cloudflare.js'
+import { Telefunc } from '../../../../serve/cloudflare.js'
 
 function createMockKV(): KVNamespace {
   const store = new Map<string, { value: string; expirationTtl?: number }>()
@@ -169,7 +169,7 @@ beforeEach(() => {
 describe('cloudflare adapter entrypoint', () => {
   it('resolves shard from KV token and forwards routing headers', async () => {
     const { binding, get, fetch } = createBinding()
-    const tf = telefunc()
+    const tf = new Telefunc()
     const kv = createMockKV()
     await kv.put('session:my-token', JSON.stringify({ s: 'telefunc-shard-weur-1', b: 'weur' }))
     const request = new Request('https://telefunc.test/_telefunc?session=my-token')
@@ -197,7 +197,7 @@ describe('cloudflare adapter entrypoint', () => {
 
   it('derives a new shard and stores a KV token when no token is provided', async () => {
     const { binding, get, fetch } = createBinding()
-    const tf = telefunc()
+    const tf = new Telefunc()
     const kv = createMockKV()
     const waitUntilFns: Array<Promise<unknown>> = []
     const request = new Request('https://telefunc.test/_telefunc')
@@ -223,7 +223,7 @@ describe('cloudflare adapter entrypoint', () => {
   })
 
   it('returns undefined for non-telefunc traffic', async () => {
-    const tf = telefunc()
+    const tf = new Telefunc()
 
     await expect(
       tf.serve({
@@ -235,7 +235,7 @@ describe('cloudflare adapter entrypoint', () => {
   })
 
   it('asserts when binding is missing for telefunc traffic', async () => {
-    const tf = telefunc()
+    const tf = new Telefunc()
 
     await expect(
       tf.serve({
@@ -249,7 +249,7 @@ describe('cloudflare adapter entrypoint', () => {
   it('returns 400 for websocket upgrades when websocket transport is disabled', async () => {
     const { binding } = createBinding()
     mocks.getServerConfig.mockReturnValue({ telefuncUrl: '/_telefunc', channel: { transports: [] } })
-    const tf = telefunc()
+    const tf = new Telefunc()
     const request = new Request('https://telefunc.test/_telefunc', { headers: { upgrade: 'websocket' } })
 
     const response = await tf.serve({
@@ -264,7 +264,7 @@ describe('cloudflare adapter entrypoint', () => {
   it('applies jurisdiction wrapping before binding lookups', async () => {
     const { binding, jurisdiction } = createBinding()
     const kv = createMockKV()
-    const tf = telefunc({ jurisdiction: 'eu' as DurableObjectJurisdiction })
+    const tf = new Telefunc({ jurisdiction: 'eu' as DurableObjectJurisdiction })
 
     await tf.serve({
       request: new Request('https://telefunc.test/_telefunc'),
@@ -276,7 +276,7 @@ describe('cloudflare adapter entrypoint', () => {
   })
 
   it('passes base transport options to the broadcast transport', () => {
-    telefunc()
+    new Telefunc()
 
     expect(mocks.transportInstances[0]?.options).toEqual(
       expect.objectContaining({ baseInstanceName: 'telefunc', scale: undefined }),
@@ -285,7 +285,7 @@ describe('cloudflare adapter entrypoint', () => {
 
   it('wires the durable object runtime and delegates fetch, websocket, and broadcast methods', async () => {
     const { binding } = createBinding()
-    const tf = telefunc({ context: vi.fn(async () => ({ userId: 'user-1' })) })
+    const tf = new Telefunc({ context: vi.fn(async () => ({ userId: 'user-1' })) })
     const DurableClass = tf.TelefuncDurableObject
     const ctx = { id: { name: 'telefunc-shard-weur-1' } } as DurableObjectState
     const instance = new DurableClass(ctx, {

--- a/test/@cloudflare_vite-plugin/+server.ts
+++ b/test/@cloudflare_vite-plugin/+server.ts
@@ -1,7 +1,7 @@
 import vike from 'vike/fetch'
-import { telefunc } from 'telefunc/cloudflare'
+import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = telefunc({ scale: 5 })
+const tf = new Telefunc({ scale: 5 })
 
 // Cloudflare requires Durable Object classes to be named exports of the worker entry.
 // `wrangler.jsonc`'s `main: "vike:server-entry"` re-exports everything from this file,


### PR DESCRIPTION
## Summary
Refactored the `telefunc` factory function into a `Telefunc` class to provide a more idiomatic API for Cloudflare Workers integration. This change improves code organization and makes the instantiation pattern more explicit.

## Key Changes
- Converted the `telefunc()` factory function to a `Telefunc` class with a constructor
- Changed instantiation from `telefunc()` to `new Telefunc()` throughout the codebase
- Updated the export from `export { telefunc }` to `export { Telefunc }`
- Moved all factory function logic into the class constructor
- Converted `serve` and `TelefuncDurableObject` from returned object properties to class properties
- Renamed the imported `Telefunc` type to `TelefuncNamespace` to avoid naming conflicts with the new class
- Updated all test files and documentation to use the new class-based API

## Implementation Details
- The class constructor accepts the same `CloudflareWebSocketOptions` parameter as the previous factory function
- The `serve` method and `TelefuncDurableObject` property are now instance members initialized in the constructor
- All internal state and closures are preserved through the constructor scope
- The `TelefuncDurableObject` inner class remains unchanged in functionality, only its scope moved into the constructor

https://claude.ai/code/session_01Y7dvcj2H3yC28M7SwSrowT