### PR TITLE
Rename extension hook onTransformResult to onTelefunctionResult

### DIFF
--- a/packages/tanstack-query/src/server.ts
+++ b/packages/tanstack-query/src/server.ts
@@ -21,7 +21,7 @@ function topLevelKey(queryKey: readonly unknown[]): string {
 const extension = {
   name: EXTENSION_NAME,
   hooks: {
-    onTransformResult(ctx) {
+    onTelefunctionResult(ctx) {
       const data = ctx.data as TanstackQueryExtensionData
 
       if ('invalidates' in data) {

--- a/packages/telefunc/node/server/extensions.ts
+++ b/packages/telefunc/node/server/extensions.ts
@@ -11,7 +11,8 @@ import type {
 type TelefuncServerExtension = {
   name: string
   hooks?: {
-    onTransformResult?: (ctx: { result: unknown; data: Record<string, unknown> }) => unknown | Promise<unknown>
+    /** Called after the telefunction returns (before serialization), only when the request carries this extension's data. The return value replaces the result. */
+    onTelefunctionResult?: (ctx: { result: unknown; data: Record<string, unknown> }) => unknown | Promise<unknown>
   }
   /** Custom replacer types for server→client serialization (appended after built-in types). */
   responseTypes?: ReplacerType<TypeContract, ServerReplacerContext>[]

--- a/packages/telefunc/node/server/runTelefunc/executeTelefunction.ts
+++ b/packages/telefunc/node/server/runTelefunc/executeTelefunction.ts
@@ -69,10 +69,10 @@ async function executeTelefunction(runContext: {
 
   if (!telefunctionHasErrored && !telefunctionAborted) {
     for (const ext of extensions) {
-      if (ext.hooks?.onTransformResult && requestExtensions[ext.name]) {
+      if (ext.hooks?.onTelefunctionResult && requestExtensions[ext.name]) {
         const data = requestExtensions[ext.name]!
         telefunctionReturn = await withContext(() =>
-          ext.hooks!.onTransformResult!({ result: telefunctionReturn, data }),
+          ext.hooks!.onTelefunctionResult!({ result: telefunctionReturn, data }),
         )
       }
     }


### PR DESCRIPTION
Renames the server extension hook `onTransformResult` to `onTelefunctionResult`.

The `on` prefix names the moment a hook runs at. "Transform result" described the handler's job, and no such event exists on its own; the hook is the transformation. "Telefunction result" names the actual lifecycle moment: the telefunction produced its result. The qualifier also pins which result is meant, since `responseTypes` reshapes the result again at the serialization layer.

Also adds a JSDoc line on the hook stating its contract: it runs after the telefunction returns, before serialization, only when the request carries the extension's data, and its return value replaces the result.

Verified with `tsc --build` on `packages/telefunc` and `packages/tanstack-query` (exit 0) and `pnpm run test:units` (136 tests passed).

https://claude.ai/code/session_017455QC7JLStJYoNuEDPTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_017455QC7JLStJYoNuEDPTCj)_