### PR TITLE
Restructure Channel and Broadcast documentation with comparison table

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -231,7 +231,7 @@ const headings = [
   },
   {
     level: 2,
-    title: '`Channel` / `Broadcast`',
+    title: '`Channel`',
     url: '/channel',
   },
   {

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -6,8 +6,7 @@ Telefunc provides two primitives for real-time communication:
 
 | | `new Channel()` | `new Broadcast()` |
 |---|---|---|
-| What is it | Direct messages between one server and one client | Broadcast to many subscribers |
-| Use cases | AI chat, live dashboards, order tracking | Chat rooms, live scores, notifications |
+| Purpose | Direct messages between *one* server and *one* client | Broadcast to *all* subscribers |
 
 Both are returned from a telefunction — they serialize into client-side objects automatically.
 
@@ -297,31 +296,15 @@ These are the two natural shapes of communication.
 
 You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods tap directly.
 
-### Use cases
-
-Use `Channel` when the server talks with one client:
-
-- An AI chat: the response streams in, the user can interrupt or send a follow-up
-- A live dashboard: the server pushes fresh metrics to the user viewing it
-- Order tracking: "preparing", "out for delivery", pushed to the customer who ordered
-
-Use `Broadcast` when a message concerns everyone following a topic:
-
-- A chat room: every member sees every message
-- A live auction or sports score: every viewer sees each bid or goal
-- Notifications: publish once to `notifications:${userId}`, and every open tab of that user receives it
-
-The two compose: a card game can use a `Broadcast` for the table that everyone sees, and a `Channel` for each player's hand.
-
 ### Comparison
 
 | | `new Channel()` | `new Broadcast()` |
 |---|---|---|
-| Topology | One server ↔ one client | All members sharing a `key` (server or client) |
-| Methods | `send()` / `listen()` | `publish()` / `subscribe()`, also as statics for [server-only use](#server-only-broadcast) |
-| Delivery | The other end | Every subscriber of the key, including the publisher |
-| Message type | Asymmetric:<ul><li>Two directions: `Channel<ClientToServer, ServerToClient>`</li><li>The server keeps the channel and returns `chat.client`, the same API with directions flipped</li></ul> | Symmetric:<ul><li>One type for every member: `Broadcast<T>`</li><li>The telefunction returns the instance itself</li></ul> |
-| Message return | The other end's reply (with `{ ack: true }`) | A receipt: `key`, `seq`, `timestamp` |
+| Topology | One server ↔ one client | All members sharing a `key` (server and client) |
+| Methods | `send()` / `listen()` | `publish()` / `subscribe()` |
+| Delivery | The other end | Every subscriber of the `key`, including the publisher |
+| Message type | Asymmetric:<ul><li>Two different types: `Channel<ClientMessageType, ServerMessageType>`</li><li>The server uses the `channel = new Channel()` instance and returns `channel.client` for the client (asymmetric)</li></ul> | Symmetric:<ul><li>Same type for every member: `Broadcast<MessageType>`</li><li>The server uses and returns the same instance `Broadcast` (symmetric)</li></ul> |
+| Message return | The other end's reply (if `{ ack: true }`) | A receipt: `{ key, seq, timestamp }` |
 | `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
 | Multi-server | [Sticky sessions](/multiple-nodes) | [Broadcast transport](#multi-server) |
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -7,7 +7,7 @@ Telefunc provides two primitives for real-time communication:
 | | `new Channel()` | `new Broadcast()` |
 |---|---|---|
 | What is it | Direct messages between one server and one client | Broadcast to many subscribers |
-| Use cases | Commands, request-response, per-client pushes | Chat rooms, live feeds, notifications |
+| Use cases | AI chat, live dashboards, order tracking | Chat rooms, live scores, notifications |
 
 Both are returned from a telefunction — they serialize into client-side objects automatically.
 
@@ -297,27 +297,27 @@ You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast
 
 Use `Channel` when the server talks with one client:
 
-- Commands and acknowledgements
-- Request-response beyond a single telefunction call
-- Per-client pushes, like a live dashboard
+- An AI chat: the response streams in, the user can interrupt or send a follow-up
+- A live dashboard: the server pushes fresh metrics to the user viewing it
+- Order tracking: "preparing", "out for delivery", pushed to the customer who ordered
 
-Use `Broadcast` when a message concerns everyone interested in a topic:
+Use `Broadcast` when a message concerns everyone following a topic:
 
-- Chat rooms
-- Live feeds and notifications
-- Collaborative editing and multiplayer state
+- A chat room: every member sees every message
+- A live auction or sports score: every viewer sees each bid or goal
+- Notifications: publish once to `notifications:${userId}`, and every open tab of that user receives it
 
-The two compose: a chat app can use a `Broadcast` for the room and a `Channel` per user for direct messages and delivery receipts.
+The two compose: a card game can use a `Broadcast` for the table that everyone sees, and a `Channel` for each player's hand.
 
 ### Comparison
 
 | | `new Channel()` | `new Broadcast()` |
 |---|---|---|
-| Topology | One server ↔ one client | All instances sharing a string `key`, server or client |
+| Topology | One server ↔ one client | All members sharing a `key` (server or client) |
 | Methods | `send()` / `listen()` | `publish()` / `subscribe()`, also as statics for [server-only use](#server-only-broadcast) |
 | Delivery | The other end | Every subscriber of the key, including the publisher |
-| TypeScript & replies | Two function signatures, `Channel<ClientToServer, ServerToClient>`; their return types declare the acks | Single message type, `Broadcast<T>`; `publish()` resolves to a receipt (`key`, `seq`, `timestamp`) |
-| Return from telefunction | `chat.client` (message directions flip) | The instance itself (no flip) |
+| Message type | Asymmetric:<ul><li>Two directions: `Channel<ClientToServer, ServerToClient>`</li><li>The server keeps the channel and returns `chat.client`, the same API with directions flipped</li></ul> | Symmetric:<ul><li>One type for every member: `Broadcast<T>`</li><li>The telefunction returns the instance itself</li></ul> |
+| Message return | The other end's reply (with `{ ack: true }`) | A receipt: `key`, `seq`, `timestamp` |
 | `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
 | Multi-server | [Sticky sessions](/multiple-nodes) | [Broadcast transport](#multi-server) |
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -6,12 +6,12 @@ Telefunc provides two primitives for real-time communication:
 
 | | `new Channel()` | `new Broadcast()` |
 |---|---|---|
-| What is it | A private line between one server and one client | A message group: everyone with the same `key` receives every publish |
+| What is it | Direct messages between one server and one client | Broadcast to many subscribers |
 | Use cases | Commands, request-response, per-client pushes | Chat rooms, live feeds, notifications |
 
-Return either from a telefunction — they serialize into client-side objects automatically.
+Both are returned from a telefunction — they serialize into client-side objects automatically.
 
-By default, channels and broadcast use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background. See <Link href="/transport" />.
+> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background, see <Link href="/transport" />.
 
 > For short-lived callbacks (e.g. progress updates), <Link href="/real-time">function passing</Link> is usually simpler.
 
@@ -279,15 +279,19 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 ### Fundamentally
 
-Fundamentally, the difference is what a message is addressed to: a `Channel` message is addressed to *someone*, a `Broadcast` message is addressed to *something*.
+Fundamentally, the difference is what a message is addressed to: a `Channel` message is addressed to *someone*, a `Broadcast` message is addressed to *a topic* (the `key`).
 
-A `Channel` is a conversation, like a phone call: two fixed ends (the server and the one client that received it), private to them, over when either side hangs up.
+A `Channel` is a conversation, like a phone call: two fixed ends (the server and the one client that received the channel), private to them, finishes when either side hangs up.
 
-A `Broadcast` is an announcement, like a radio frequency: whoever tunes in to the `key` receives everything published to it (the publisher included), members come and go, and the key belongs to no one.
+A `Broadcast` is an announcement, like a radio frequency: whoever tunes in to the `key` receives everything published to it (the publisher included), members come and go, and the `key` belongs to no one.
 
-These are the two natural shapes of communication, and the rest follows from the addressing: only the two ends of a channel can use it, while anything that knows a key can join its group; a channel ends when either side closes it, while a group outlives any single member.
+Only the two ends of a channel can use it, while anything that knows a `key` can join its broadcast. A channel ends when either side closes it, while a broadcast outlives any single member.
 
-You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the instance holds a private channel to the one client that received it, and bridges that client into the keyed publish/subscribe group that the static methods tap directly.
+These are the two natural shapes of communication.
+
+### Technically
+
+You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods tap directly.
 
 ### Use cases
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -2,18 +2,32 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Telefunc provides two primitives for real-time communication:
-
-| Primitive | Methods | Use case |
-|---|---|---|
-| **`new Channel()`** | `send()` / `listen()` | Direct messages between one server and one client — commands, acks, request-response over a persistent connection. |
-| **`new Broadcast()`** | `publish()` / `subscribe()` | Broadcast to all subscribers sharing a key — chat rooms, live feeds, collaborative editing. |
+Telefunc provides two primitives for real-time communication: `Channel` and `Broadcast`.
 
 Return either from a telefunction — they serialize into client-side objects automatically.
 
 By default, channels and broadcast use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background. See <Link href="/transport" />.
 
 > For short-lived callbacks (e.g. progress updates), <Link href="/real-time">function passing</Link> is usually simpler.
+
+
+## `Channel` vs `Broadcast`
+
+Both share the same transport, reconnection, lifecycle, binary support, and shield validation. The difference is topology: a `Channel` connects two fixed ends, a `Broadcast` connects everyone sharing a key.
+
+| | `new Channel()` | `new Broadcast()` |
+|---|---|---|
+| Topology | One server ↔ one client | All instances sharing a string `key`, server or client |
+| Methods | `send()` / `listen()` | `publish()` / `subscribe()`, also as statics for [server-only use](#server-only-broadcast) |
+| Delivery | The other end | Every subscriber of the key, including the publisher |
+| TypeScript & replies | Two function signatures, `Channel<ClientToServer, ServerToClient>`; their return types declare the acks | Single message type, `Broadcast<T>`; `publish()` resolves to a receipt (`key`, `seq`, `timestamp`) |
+| Return from telefunction | `chat.client` (message directions flip) | The instance itself (no flip) |
+| `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
+| Multi-server | [Sticky sessions](/multiple-nodes) | [Broadcast transport](#multi-server) |
+
+`new Broadcast()` is essentially `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the instance holds a private channel to the one client that received it, and bridges that client into the keyed publish/subscribe group that the static methods tap directly.
+
+Use `Channel` for request-response and per-client pushes: commands, acks, live dashboards. Use `Broadcast` for fan-out to a group: chat rooms, live feeds, notifications.
 
 
 ## new Channel()
@@ -225,12 +239,12 @@ import { onJoinChat } from './Chat.telefunc'
 
 const chat = await onJoinChat('Alice')
 
-// Receive messages published by other instances with the same key
+// Receive messages published to the key, including this instance's own publishes
 chat.subscribe((msg, info) => {
   console.log(`#${info.seq} ${msg.user}: ${msg.text}`)
 })
 
-// Publish to all other instances with the same key
+// Publish to every subscriber of the key
 chat.publish({ user: 'Alice', text: 'Hello!', })
 ```
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -2,32 +2,18 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Telefunc provides two primitives for real-time communication: `Channel` and `Broadcast`.
+Telefunc provides two primitives for real-time communication:
+
+| | `new Channel()` | `new Broadcast()` |
+|---|---|---|
+| What is it | A private line between one server and one client | A message group: everyone with the same `key` receives every publish |
+| Use cases | Commands, request-response, per-client pushes | Chat rooms, live feeds, notifications |
 
 Return either from a telefunction — they serialize into client-side objects automatically.
 
 By default, channels and broadcast use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background. See <Link href="/transport" />.
 
 > For short-lived callbacks (e.g. progress updates), <Link href="/real-time">function passing</Link> is usually simpler.
-
-
-## `Channel` vs `Broadcast`
-
-Both share the same transport, reconnection, lifecycle, binary support, and shield validation. The difference is topology: a `Channel` connects two fixed ends, a `Broadcast` connects everyone sharing a key.
-
-| | `new Channel()` | `new Broadcast()` |
-|---|---|---|
-| Topology | One server ↔ one client | All instances sharing a string `key`, server or client |
-| Methods | `send()` / `listen()` | `publish()` / `subscribe()`, also as statics for [server-only use](#server-only-broadcast) |
-| Delivery | The other end | Every subscriber of the key, including the publisher |
-| TypeScript & replies | Two function signatures, `Channel<ClientToServer, ServerToClient>`; their return types declare the acks | Single message type, `Broadcast<T>`; `publish()` resolves to a receipt (`key`, `seq`, `timestamp`) |
-| Return from telefunction | `chat.client` (message directions flip) | The instance itself (no flip) |
-| `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
-| Multi-server | [Sticky sessions](/multiple-nodes) | [Broadcast transport](#multi-server) |
-
-`new Broadcast()` is essentially `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the instance holds a private channel to the one client that received it, and bridges that client into the keyed publish/subscribe group that the static methods tap directly.
-
-Use `Channel` for request-response and per-client pushes: commands, acks, live dashboards. Use `Broadcast` for fan-out to a group: chat rooms, live feeds, notifications.
 
 
 ## new Channel()
@@ -287,6 +273,49 @@ info.timestamp  // server timestamp (Unix epoch ms)
 `publish()` returns a `Promise` that resolves to `info` once the message is accepted. `subscribe()` receives `info` alongside each message — useful for ordering and gap detection.
 
 > In-memory broadcast works out of the box for single-server deployments. For multi-server, set `config.broadcast.transport` — see [Multi-server](#multi-server). On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
+
+
+## `Channel` vs `Broadcast`
+
+### Fundamentally
+
+Fundamentally, the difference is what a message is addressed to: a `Channel` message is addressed to *someone*, a `Broadcast` message is addressed to *something*.
+
+A `Channel` is a conversation, like a phone call: two fixed ends (the server and the one client that received it), private to them, over when either side hangs up.
+
+A `Broadcast` is an announcement, like a radio frequency: whoever tunes in to the `key` receives everything published to it (the publisher included), members come and go, and the key belongs to no one.
+
+These are the two natural shapes of communication, and the rest follows from the addressing: only the two ends of a channel can use it, while anything that knows a key can join its group; a channel ends when either side closes it, while a group outlives any single member.
+
+You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the instance holds a private channel to the one client that received it, and bridges that client into the keyed publish/subscribe group that the static methods tap directly.
+
+### Use cases
+
+Use `Channel` when the server talks with one client:
+
+- Commands and acknowledgements
+- Request-response beyond a single telefunction call
+- Per-client pushes, like a live dashboard
+
+Use `Broadcast` when a message concerns everyone interested in a topic:
+
+- Chat rooms
+- Live feeds and notifications
+- Collaborative editing and multiplayer state
+
+The two compose: a chat app can use a `Broadcast` for the room and a `Channel` per user for direct messages and delivery receipts.
+
+### Comparison
+
+| | `new Channel()` | `new Broadcast()` |
+|---|---|---|
+| Topology | One server ↔ one client | All instances sharing a string `key`, server or client |
+| Methods | `send()` / `listen()` | `publish()` / `subscribe()`, also as statics for [server-only use](#server-only-broadcast) |
+| Delivery | The other end | Every subscriber of the key, including the publisher |
+| TypeScript & replies | Two function signatures, `Channel<ClientToServer, ServerToClient>`; their return types declare the acks | Single message type, `Broadcast<T>`; `publish()` resolves to a receipt (`key`, `seq`, `timestamp`) |
+| Return from telefunction | `chat.client` (message directions flip) | The instance itself (no flip) |
+| `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
+| Multi-server | [Sticky sessions](/multiple-nodes) | [Broadcast transport](#multi-server) |
 
 
 ## Multi-server

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -12,7 +12,7 @@ Telefunc handles real-time flows — chat, upload progress, live updates — usi
 | **[RxJS](https://rxjs.dev/) `Observable` / `Subject`** | Reactive streams with full operator support — pass rxjs primitives transparently | <Link href="/integrations/rxjs" text={<code>@telefunc/rxjs</code>} /> |
 | **`config.stream.transport = 'channel'`** | <Link href="/stream">Streamed values</Link> over the same reconnecting transport as channels | Same as channels |
 
-For the differences between the two channel primitives, see [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast).
+> See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)
 
 
 ## Function passing

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -12,6 +12,8 @@ Telefunc handles real-time flows — chat, upload progress, live updates — usi
 | **[RxJS](https://rxjs.dev/) `Observable` / `Subject`** | Reactive streams with full operator support — pass rxjs primitives transparently | <Link href="/integrations/rxjs" text={<code>@telefunc/rxjs</code>} /> |
 | **`config.stream.transport = 'channel'`** | <Link href="/stream">Streamed values</Link> over the same reconnecting transport as channels | Same as channels |
 
+For the differences between the two channel primitives, see [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast).
+
 
 ## Function passing
 


### PR DESCRIPTION
## Summary
Reorganized the Channel and Broadcast documentation to improve clarity and help users understand when to use each primitive. The changes include a new dedicated comparison section and refined explanations throughout.

## Key Changes
- **Replaced introductory table** with a concise summary sentence, moving detailed comparison to a new dedicated section
- **Added new "Channel vs Broadcast" section** with a comprehensive comparison table covering:
  - Topology differences (one-to-one vs pub/sub)
  - Method signatures and return types
  - Delivery semantics
  - TypeScript patterns
  - Lifecycle behavior (`close()`)
  - Multi-server considerations
- **Added explanatory text** clarifying that `Broadcast` is essentially `Channel` plus static publish/subscribe methods
- **Added usage guidance** recommending `Channel` for request-response and per-client pushes, and `Broadcast` for fan-out scenarios
- **Updated code comments** in examples to be more accurate:
  - Changed "other instances" to "every subscriber of the key" to clarify that publishers receive their own messages
  - Clarified that subscriptions include the instance's own publishes
- **Added cross-reference link** in the real-time overview page pointing to the new comparison section

## Notable Details
The restructuring maintains all existing technical content while improving discoverability and decision-making for users choosing between the two primitives. The new comparison table uses consistent formatting and covers both basic and advanced considerations like TypeScript patterns and multi-server deployments.

https://claude.ai/code/session_01HX2FQctBMEkvPXfbMpkBo9