### PR TITLE
Refactor QueryClient to withTelefunc() wrapper function

### DIFF
--- a/docs/pages/integrations/tanstack-query/+Page.mdx
+++ b/docs/pages/integrations/tanstack-query/+Page.mdx
@@ -4,13 +4,13 @@ Invalidate [TanStack Query](https://tanstack.com/query) queries after mutations 
 
 ## Setup
 
-Use `QueryClient` from `@telefunc/tanstack-query` instead of `@tanstack/react-query`:
+Wrap your `QueryClient` with `withTelefunc()`:
 
 ```tsx
-import { QueryClient } from '@telefunc/tanstack-query'
-import { QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { withTelefunc } from '@telefunc/tanstack-query'
 
-const queryClient = new QueryClient()
+const queryClient = withTelefunc(new QueryClient())
 
 function App() {
   return (
@@ -21,7 +21,7 @@ function App() {
 }
 ```
 
-It's a drop-in replacement — same options, same API.
+`withTelefunc()` returns the same `QueryClient` instance. All options and APIs keep working as-is.
 
 
 
@@ -99,10 +99,10 @@ Prefix matching — invalidating `['global:documents']` hits `['global:documents
 
 **Local keys:**
 1. Mutation succeeds.
-2. `QueryClient` calls `invalidateQueries()` on the current client for matching local keys.
+2. `withTelefunc()` calls `invalidateQueries()` on the current client for matching local keys.
 
 **Global keys:**
-1. `QueryClient` sends each global query's `queryKey` alongside the telefunc call.
+1. `withTelefunc()` sends each global query's `queryKey` alongside the telefunc call.
 2. The telefunction executes (including auth). Only after it succeeds, the server subscribes to invalidation events for that key.
 3. Mutations work the same way — the telefunction runs first, then global keys from `meta.invalidates` are published through <Link text={<code>Broadcast</code>} href="/channel#new-broadcast" />.
 4. Every connected client with a matching subscription calls `invalidateQueries()`.

--- a/packages/tanstack-query/src/client.ts
+++ b/packages/tanstack-query/src/client.ts
@@ -1,12 +1,6 @@
-export { QueryClient }
+export { withTelefunc }
 
-import {
-  QueryClient as BaseQueryClient,
-  hashKey,
-  type MutationOptions,
-  type QueryClientConfig,
-  type QueryPersister,
-} from '@tanstack/query-core'
+import { hashKey, type MutationOptions, type QueryClient, type QueryPersister } from '@tanstack/query-core'
 import { withContext } from 'telefunc/client'
 import {
   EXTENSION_NAME,
@@ -27,85 +21,86 @@ function isPromise(val: unknown): val is Promise<unknown> {
   return typeof val === 'object' && val !== null && 'then' in val && typeof val.then === 'function'
 }
 
-class QueryClient extends BaseQueryClient {
-  #subs = new Map<string, { close: () => Promise<unknown> }>()
-  #unsubCache: (() => void) | null = null
+/** Wire Telefunc invalidation into an existing `QueryClient`.
+ *
+ *  ```ts
+ *  import { QueryClient } from '@tanstack/react-query'
+ *  import { withTelefunc } from '@telefunc/tanstack-query'
+ *  const queryClient = withTelefunc(new QueryClient())
+ *  ```
+ */
+function withTelefunc<T extends QueryClient>(queryClient: T): T {
+  const isServer = typeof window === 'undefined'
+  if (isServer) return queryClient
 
-  constructor(config?: QueryClientConfig) {
-    const isServer = typeof window === 'undefined'
+  const subs = new Map<string, { close: () => Promise<unknown> }>()
 
-    const userPersister = config?.defaultOptions?.queries?.persister
-    const persister: QueryPersister = (queryFn, context, query) => {
-      const queryKey = context.queryKey
-      const wrappedQueryFn = isGlobalKey(queryKey)
-        ? withContext(() => queryFn(context), {
-            extensions: { [EXTENSION_NAME]: { queryKey } satisfies TanstackQueryExtensionData },
-          })
-        : () => queryFn(context)
-      const execute = userPersister ? () => userPersister(wrappedQueryFn, context, query) : wrappedQueryFn
-      const result = execute()
-      if (isPromise(result)) {
-        return result.then((resolved) => this.#handleResult(queryKey, resolved))
-      }
-      return this.#handleResult(queryKey, result)
-    }
-
-    super(isServer ? (config ?? {}) : assignDeep(config ?? {}, { defaultOptions: { queries: { persister } } }))
-    if (isServer) return
-
-    this.#unsubCache = this.getQueryCache().subscribe((event) => {
-      if (event.type === 'removed') this.#teardown(event.query)
-    })
-  }
-
-  #handleResult(queryKey: readonly unknown[], result: unknown): unknown {
+  function handleResult(queryKey: readonly unknown[], result: unknown): unknown {
     if (!isTanstackQueryResult(result)) return result
 
     const { [__TQ__DATA_KEY]: data, [__TQ__CHANNEL_KEY]: channel } = result
     const hashed = hashKey(queryKey)
 
-    const prev = this.#subs.get(hashed)
+    const prev = subs.get(hashed)
     if (prev) prev.close()
 
     channel.listen(() => {
-      this.invalidateQueries({ queryKey })
+      queryClient.invalidateQueries({ queryKey })
     })
-    this.#subs.set(hashed, { close: () => channel.close() })
+    subs.set(hashed, { close: () => channel.close() })
 
     return data
   }
 
-  #teardown(query: { queryKey: readonly unknown[] }) {
+  function teardown(query: { queryKey: readonly unknown[] }) {
     const hashed = hashKey(query.queryKey)
-    const sub = this.#subs.get(hashed)
+    const sub = subs.get(hashed)
     if (sub) {
       sub.close()
-      this.#subs.delete(hashed)
+      subs.delete(hashed)
     }
   }
 
-  #cleanup() {
-    this.#unsubCache?.()
-    this.#unsubCache = null
-    for (const sub of this.#subs.values()) {
+  function cleanup() {
+    unsubCache?.()
+    unsubCache = null
+    for (const sub of subs.values()) {
       sub.close()
     }
-    this.#subs.clear()
+    subs.clear()
   }
 
-  override unmount() {
-    this.#cleanup()
-    super.unmount()
+  const defaultOptions = queryClient.getDefaultOptions()
+  const userPersister = defaultOptions.queries?.persister
+  const persister: QueryPersister = (queryFn, context, query) => {
+    const queryKey = context.queryKey
+    const wrappedQueryFn = isGlobalKey(queryKey)
+      ? withContext(() => queryFn(context), {
+          extensions: { [EXTENSION_NAME]: { queryKey } satisfies TanstackQueryExtensionData },
+        })
+      : () => queryFn(context)
+    const execute = userPersister ? () => userPersister(wrappedQueryFn, context, query) : wrappedQueryFn
+    const result = execute()
+    if (isPromise(result)) {
+      return result.then((resolved) => handleResult(queryKey, resolved))
+    }
+    return handleResult(queryKey, result)
   }
+  queryClient.setDefaultOptions(assignDeep(defaultOptions, { queries: { persister } }))
 
-  override defaultMutationOptions<T extends MutationOptions<any, any, any, any>>(options?: T): T {
+  let unsubCache: (() => void) | null = queryClient.getQueryCache().subscribe((event) => {
+    if (event.type === 'removed') teardown(event.query)
+  })
+
+  const defaultMutationOptionsOriginal = queryClient.defaultMutationOptions.bind(queryClient)
+  queryClient.defaultMutationOptions = <O extends MutationOptions<any, any, any, any>>(options?: O): O => {
     const invalidates = options?.meta?.invalidates
-    if (!Array.isArray(invalidates)) return super.defaultMutationOptions(options)
+    if (!Array.isArray(invalidates)) return defaultMutationOptionsOriginal(options)
 
     const [globalKeys, localKeys] = partition(invalidates, isGlobalKey)
 
     const userOnSuccess = options?.onSuccess
-    return super.defaultMutationOptions({
+    return defaultMutationOptionsOriginal({
       ...options,
       mutationFn:
         globalKeys.length > 0 && options?.mutationFn
@@ -116,15 +111,24 @@ class QueryClient extends BaseQueryClient {
       onSuccess:
         localKeys.length > 0
           ? (...args) => {
-              for (const key of localKeys) this.invalidateQueries({ queryKey: key })
+              for (const key of localKeys) queryClient.invalidateQueries({ queryKey: key })
               return userOnSuccess?.(...args)
             }
           : userOnSuccess,
-    } as T)
+    } as O)
   }
 
-  override clear() {
-    this.#cleanup()
-    super.clear()
+  const unmountOriginal = queryClient.unmount.bind(queryClient)
+  queryClient.unmount = () => {
+    cleanup()
+    unmountOriginal()
   }
+
+  const clearOriginal = queryClient.clear.bind(queryClient)
+  queryClient.clear = () => {
+    cleanup()
+    clearOriginal()
+  }
+
+  return queryClient
 }

--- a/test/playground/pages/live-query/+Page.tsx
+++ b/test/playground/pages/live-query/+Page.tsx
@@ -1,11 +1,11 @@
 export { Page }
 
 import React from 'react'
-import { QueryClientProvider } from '@tanstack/react-query'
-import { QueryClient } from '@telefunc/tanstack-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { withTelefunc } from '@telefunc/tanstack-query'
 import { TodoList } from './TodoList'
 
-const queryClient = new QueryClient()
+const queryClient = withTelefunc(new QueryClient())
 
 function Page() {
   return (


### PR DESCRIPTION
## Summary
Changed the TanStack Query integration from a custom `QueryClient` class to a `withTelefunc()` wrapper function that enhances an existing `QueryClient` instance. This approach is more flexible and doesn't require users to use a custom class.

## Key Changes
- **Removed custom `QueryClient` class** that extended `@tanstack/query-core`'s `BaseQueryClient`
- **Introduced `withTelefunc()` function** that accepts any `QueryClient` instance and returns it enhanced with Telefunc integration
- **Changed export** from `QueryClient` to `withTelefunc`
- **Converted class methods to closures** that operate on the passed `queryClient` instance:
  - `#handleResult()` → `handleResult()`
  - `#teardown()` → `teardown()`
  - `#cleanup()` → `cleanup()`
- **Replaced method overrides with instance method binding**:
  - `unmount()` override → wraps original `unmount()` method
  - `clear()` override → wraps original `clear()` method
  - `defaultMutationOptions()` override → wraps original method
- **Updated documentation** to reflect the new API pattern
- **Updated test playground** to use the new `withTelefunc()` wrapper

## Implementation Details
- The wrapper function maintains the same functionality: persister setup, subscription management, and mutation invalidation
- Works on client-side only (checks `typeof window === 'undefined'`)
- Returns the same `QueryClient` instance for seamless integration
- Uses closure variables (`subs`, `unsubCache`) instead of private class fields
- Preserves all existing options and APIs — users can continue using `QueryClient` from `@tanstack/react-query` directly

https://claude.ai/code/session_01DjYpxQrmFjEFXcJdYqYUfz