### PR TITLE
Fix race conditions in streaming and broadcast tests

### DIFF
--- a/test/playground/.testRun.ts
+++ b/test/playground/.testRun.ts
@@ -105,9 +105,16 @@ function testRun(cmd: 'pnpm dev' | 'pnpm preview') {
         const resp = await makeTelefuncHttpRequest(1337)
         expect(resp.status).toBe(422)
         expect(await resp.text()).toBe('Shield Validation Error')
-        expectLog('Shield Validation Error', {
-          filter: (log) =>
-            log.logSource === 'stderr' && log.logText.includes('onLoad()') && log.logText.includes('Hello.telefunc.ts'),
+        // The server's stderr line can reach the harness's log capture a few
+        // milliseconds after the HTTP response resolves, and expectLog() only
+        // checks logs captured so far. Poll instead of asserting once.
+        await autoRetry(async () => {
+          expectLog('Shield Validation Error', {
+            filter: (log) =>
+              log.logSource === 'stderr' &&
+              log.logText.includes('onLoad()') &&
+              log.logText.includes('Hello.telefunc.ts'),
+          })
         })
       }
     })

--- a/test/playground/pages/publish/Publish.telefunc.ts
+++ b/test/playground/pages/publish/Publish.telefunc.ts
@@ -4,10 +4,13 @@ import { Broadcast } from 'telefunc'
 
 type TextMsg = { text: string; from: string }
 
-/** Two broadcast instances sharing a key — publish from one, subscribe on the other. */
+/** Two broadcast instances sharing a key — publish from one, subscribe on the other.
+ *  The key is unique per call: the in-memory adapter's seq counter is per-key, so a
+ *  fixed key would leak seq state across page loads and break the [1,2,3] assertion. */
 async function onTextBroadcast() {
-  const publisher = new Broadcast<TextMsg>({ key: 'room:text-test' })
-  const subscriber = new Broadcast<TextMsg>({ key: 'room:text-test' })
+  const key = `room:text-test:${crypto.randomUUID()}`
+  const publisher = new Broadcast<TextMsg>({ key })
+  const subscriber = new Broadcast<TextMsg>({ key })
 
   const received: Array<{ text: string; from: string; seq: number }> = []
   subscriber.subscribe((msg, info) => {
@@ -21,10 +24,12 @@ async function onTextBroadcast() {
   }
 }
 
-/** Two broadcast instances sharing a key — publishBinary from one, subscribeBinary on the other. */
+/** Two broadcast instances sharing a key — publishBinary from one, subscribeBinary on the other.
+ *  Unique key per call, same reason as onTextBroadcast(). */
 async function onBinaryBroadcastPair() {
-  const publisher = new Broadcast({ key: 'room:binary-test' })
-  const subscriber = new Broadcast({ key: 'room:binary-test' })
+  const key = `room:binary-test:${crypto.randomUUID()}`
+  const publisher = new Broadcast({ key })
+  const subscriber = new Broadcast({ key })
 
   const received: Array<{ size: number; firstByte: number; seq: number }> = []
   subscriber.subscribeBinary((data, info) => {

--- a/test/playground/pages/publish/Publish.tsx
+++ b/test/playground/pages/publish/Publish.tsx
@@ -34,17 +34,26 @@ function Publish() {
         id="test-text-broadcast"
         onClick={async () => {
           setResult('')
-          const { publisher, getReceived } = await onTextBroadcast()
+          const { publisher, subscriber, getReceived } = await onTextBroadcast()
           // Publish 3 messages from the publisher
           const acks = []
           for (let i = 0; i < 3; i++) {
             const ack = await publisher.publish({ text: `msg-${i}`, from: 'client' })
             acks.push({ seq: ack.seq, key: ack.key })
           }
-          // Small delay for delivery
-          await new Promise((r) => setTimeout(r, 200))
-          const received = await getReceived()
-          setResult(JSON.stringify({ acks, received }))
+          // Render every poll so the e2e autoRetry sees fresh data on each iteration.
+          // A one-shot snapshot freezes the DOM and turns slow delivery into a
+          // guaranteed test failure.
+          for (let poll = 0; poll < 50; poll++) {
+            const received = await getReceived()
+            setResult(JSON.stringify({ acks, received }))
+            if (received.length >= 3) break
+            await new Promise((r) => setTimeout(r, 200))
+          }
+          // `subscriber` is unused but must stay reachable until the scenario is over:
+          // it crosses the wire as a remote handle, and a GC pass would close it,
+          // tearing down the server-side subscription mid-test.
+          void subscriber
         }}
       >
         Text publish (3 messages)
@@ -56,7 +65,7 @@ function Publish() {
         id="test-binary-broadcast-pair"
         onClick={async () => {
           setResult('')
-          const { publisher, getReceived } = await onBinaryBroadcastPair()
+          const { publisher, subscriber, getReceived } = await onBinaryBroadcastPair()
           // Publish 3 binary frames
           const acks = []
           for (let i = 0; i < 3; i++) {
@@ -64,9 +73,15 @@ function Publish() {
             const ack = await publisher.publishBinary(data)
             acks.push({ seq: ack.seq, key: ack.key })
           }
-          await new Promise((r) => setTimeout(r, 200))
-          const received = await getReceived()
-          setResult(JSON.stringify({ acks, received }))
+          // Same poll-and-render pattern as the text broadcast above.
+          for (let poll = 0; poll < 50; poll++) {
+            const received = await getReceived()
+            setResult(JSON.stringify({ acks, received }))
+            if (received.length >= 3) break
+            await new Promise((r) => setTimeout(r, 200))
+          }
+          // Keep the unused remote handle reachable, see the text broadcast above.
+          void subscriber
         }}
       >
         Binary publish (3 frames)

--- a/test/playground/pages/publish/e2e-test.ts
+++ b/test/playground/pages/publish/e2e-test.ts
@@ -38,7 +38,7 @@ function testPublish() {
       // 3 publishes → 3 acks with monotonically increasing seq, all keyed to the shared topic.
       expect(result.acks.length).toBe(3)
       expect(result.acks.map((a) => a.seq)).deep.equal([1, 2, 3])
-      for (const ack of result.acks) expect(ack.key).toBe('room:text-test')
+      for (const ack of result.acks) expect(ack.key).match(/^room:text-test:/)
 
       // Subscriber on the same key received all 3 messages in publish order.
       expect(result.received.map((r) => r.text)).deep.equal(['msg-0', 'msg-1', 'msg-2'])
@@ -57,7 +57,7 @@ function testPublish() {
 
       expect(result.acks.length).toBe(3)
       expect(result.acks.map((a) => a.seq)).deep.equal([1, 2, 3])
-      for (const ack of result.acks) expect(ack.key).toBe('room:binary-test')
+      for (const ack of result.acks) expect(ack.key).match(/^room:binary-test:/)
 
       // Each frame is 128 bytes filled with i + 10 (10, 11, 12).
       expect(result.received.length).toBe(3)

--- a/test/playground/pages/streaming/Streaming.telefunc.ts
+++ b/test/playground/pages/streaming/Streaming.telefunc.ts
@@ -23,7 +23,7 @@ export {
 
 import { Abort, Channel, getContext } from 'telefunc'
 import { Subject, interval } from 'rxjs'
-import { map, take, tap } from 'rxjs/operators'
+import { map, take } from 'rxjs/operators'
 import { cleanupState } from '../../cleanup-state'
 import { sleep } from '../../sleep'
 
@@ -228,24 +228,21 @@ async function* onGeneratorBugMidStream(): AsyncGenerator<string> {
 }
 
 const onAbortOneOfManyStreamingValues = async () => {
-  // The observable and subject only start emitting after the client's SUBSCRIBE
-  // message arrives over the channel transport (SSE/WS), which connects
-  // asynchronously and may retry. A fixed sleep before the Abort races against
-  // that: if the transport is slow, the server aborts before any obs/subj value
-  // exists, and the test asserts both values and the abort error. Gate the
-  // Abort on the first emission of each instead.
-  let markObsEmitted!: () => void
-  let markSubjEmitted!: () => void
-  const obsEmitted = new Promise<void>((resolve) => {
-    markObsEmitted = resolve
-  })
-  const subjEmitted = new Promise<void>((resolve) => {
-    markSubjEmitted = resolve
+  // The test asserts that every sibling delivered at least one value to the
+  // client before the abort error. Gating the Abort on server-side emission is
+  // not enough: the abort and the inline stream chunks travel on different
+  // wires, so an abort fired on first server emission can still overtake the
+  // first other/stream chunk on the client. Gate on the client's confirmation
+  // instead: the page calls confirmAllReceived() once it holds one value from
+  // every source.
+  let markAllReceived!: () => void
+  const allReceived = new Promise<void>((resolve) => {
+    markAllReceived = resolve
   })
 
   async function* aborting(): AsyncGenerator<string> {
     yield 'abort-0'
-    await Promise.all([obsEmitted, subjEmitted])
+    await allReceived
     throw Abort({ reason: 'stream-abort', code: 101 })
   }
 
@@ -274,7 +271,6 @@ const onAbortOneOfManyStreamingValues = async () => {
   const observable = interval(20).pipe(
     map((i) => `obs-${i}`),
     take(1000),
-    tap(() => markObsEmitted()),
   )
 
   // rxjs Subject that the server pushes to
@@ -283,13 +279,20 @@ const onAbortOneOfManyStreamingValues = async () => {
   const subjectInterval = setInterval(() => {
     if (subject.observed) {
       subject.next(`subj-${subjectCount++}`)
-      markSubjEmitted()
     }
   }, 25)
   const { onClose } = getContext()
   onClose(() => clearInterval(subjectInterval))
 
-  return { aborting: aborting(), other: other(), stream, promise, observable, subject }
+  return {
+    aborting: aborting(),
+    other: other(),
+    stream,
+    promise,
+    observable,
+    subject,
+    confirmAllReceived: () => markAllReceived(),
+  }
 }
 
 const onChannelAbortAbortsSiblingStreamingValues = async () => {

--- a/test/playground/pages/streaming/Streaming.tsx
+++ b/test/playground/pages/streaming/Streaming.tsx
@@ -480,11 +480,29 @@ function Streaming() {
           let obsErr: { isAbort: boolean; abortValue: unknown } | null = null
           let subjectErr: { isAbort: boolean; abortValue: unknown } | null = null
 
+          // The telefunction gates its Abort on this confirmation, so the e2e
+          // assertions can rely on every source having delivered a value.
+          let confirmed = false
+          const maybeConfirmAllReceived = () => {
+            if (confirmed) return
+            if (
+              abortingValues.length > 0 &&
+              otherValues.length > 0 &&
+              streamChunks.length > 0 &&
+              obsValues.length > 0 &&
+              subjectValues.length > 0
+            ) {
+              confirmed = true
+              void res.confirmAllReceived()
+            }
+          }
+
           await Promise.all([
             (async () => {
               try {
                 for await (const v of res.aborting) {
                   abortingValues.push(v)
+                  maybeConfirmAllReceived()
                 }
               } catch (e: any) {
                 abortingErr = { isAbort: e instanceof TelefuncAbort, abortValue: e?.abortValue ?? null }
@@ -494,6 +512,7 @@ function Streaming() {
               try {
                 for await (const v of res.other) {
                   otherValues.push(v)
+                  maybeConfirmAllReceived()
                 }
               } catch (e: any) {
                 otherErr = { isAbort: e instanceof TelefuncAbort, abortValue: e?.abortValue ?? null }
@@ -506,6 +525,7 @@ function Streaming() {
                   const { done, value } = await reader.read()
                   if (done) break
                   streamChunks.push(decoder.decode(value, { stream: true }))
+                  maybeConfirmAllReceived()
                 }
               } catch (e: any) {
                 streamErr = { isAbort: e instanceof TelefuncAbort, abortValue: e?.abortValue ?? null }
@@ -522,6 +542,7 @@ function Streaming() {
               res.observable.subscribe({
                 next(v) {
                   obsValues.push(v as string)
+                  maybeConfirmAllReceived()
                 },
                 error(e: any) {
                   obsErr = { isAbort: e instanceof TelefuncAbort, abortValue: e?.abortValue ?? null }
@@ -534,6 +555,7 @@ function Streaming() {
               res.subject.subscribe({
                 next(v) {
                   subjectValues.push(v as string)
+                  maybeConfirmAllReceived()
                 },
                 error(e: any) {
                   subjectErr = { isAbort: e instanceof TelefuncAbort, abortValue: e?.abortValue ?? null }


### PR DESCRIPTION
## Summary
This PR fixes several race condition issues in the test suite that caused flaky test failures. The changes improve synchronization between client and server in streaming and broadcast scenarios by using explicit confirmation mechanisms instead of relying on timing assumptions.

## Key Changes

### Streaming Tests (`Streaming.telefunc.ts` and `Streaming.tsx`)
- **Replaced timing-based synchronization with explicit confirmation**: The `onAbortOneOfManyStreamingValues` function now gates the abort on client-side confirmation (`confirmAllReceived()`) rather than server-side emission markers. This ensures the abort doesn't overtake other stream chunks that travel on different wires.
- **Added client-side confirmation callback**: The client now calls `confirmAllReceived()` once it has received at least one value from every source (aborting, other, stream, observable, subject), preventing the server from aborting prematurely.
- **Removed unnecessary RxJS operator**: Removed the `tap` operator import and its usage for marking emissions, as it's no longer needed with the new confirmation approach.

### Broadcast/Publish Tests (`Publish.telefunc.ts` and `Publish.tsx`)
- **Added unique keys per test invocation**: Both `onTextBroadcast()` and `onBinaryBroadcastPair()` now generate unique keys using `crypto.randomUUID()` to prevent seq state leakage across page loads. The in-memory broadcast adapter's seq counter is per-key, so reusing fixed keys would cause assertion failures.
- **Implemented polling pattern for message delivery**: Replaced single fixed-delay waits with a polling loop (up to 50 iterations) that renders results after each poll. This allows e2e tests with autoRetry to see fresh data on each iteration rather than freezing on a one-shot snapshot.
- **Kept subscriber references alive**: Added explicit `void subscriber` statements to prevent garbage collection of remote handles that would tear down server-side subscriptions mid-test.

### Test Infrastructure (`test/playground/.testRun.ts`)
- **Added polling for stderr log assertions**: Wrapped the Shield Validation Error log expectation in `autoRetry()` since server stderr can arrive milliseconds after the HTTP response resolves.

### E2E Test Assertions (`publish/e2e-test.ts`)
- **Updated key assertions to use regex matching**: Changed from exact key matching (`toBe('room:text-test')`) to pattern matching (`match(/^room:text-test:/)`) to accommodate the new UUID-based unique keys.

## Implementation Details
- The confirmation mechanism in streaming tests uses a closure-based approach where the client-side code calls back to the server once all sources have emitted at least one value.
- The polling pattern in broadcast tests maintains backward compatibility while improving reliability for slow delivery scenarios.
- All changes maintain the original test intent while removing assumptions about timing and delivery order.

https://claude.ai/code/session_01KFN3yorm6hjTjYaLnT6bmC