### PR TITLE
Rename node/bun/deno serve factory to `new Telefunc()`

### DIFF
--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -46,10 +46,10 @@ For example:
 // Server entry (Hono)
 
 import { Hono } from 'hono'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = telefunc()
+const tf = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
   const response = await tf.serve({
@@ -90,10 +90,10 @@ app.use(async (c, next) => {
 // Server entry (Express.js)
 
 import express from 'express'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 
 const app = express()
-const tf = telefunc()
+const tf = new Telefunc()
 
 // Telefunc middleware
 app.all('/_telefunc', async (req, res, next) => {

--- a/docs/pages/next/+Page.mdx
+++ b/docs/pages/next/+Page.mdx
@@ -29,12 +29,12 @@ export default nextConfig
 // app/api/telefunc/route.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 import { config } from 'telefunc'
 
 config.telefuncUrl = '/api/telefunc'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 async function handler(request: Request) {
   const response = await tf.serve({ request })

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -4,7 +4,7 @@ import { Link } from '@brillout/docpress'
 
 Low-level function that processes telefunction requests and returns an HTTP response. It's a pure function with no side effects.
 
-> For most setups, use the runtime-specific `Telefunc` class from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
+> For most setups, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
 
 ## Basic usage
 
@@ -72,7 +72,7 @@ const httpResponse = await serve({
 
 ## Runtime adapters
 
-For production deployments with channels and WebSocket support, use the runtime-specific `Telefunc` class from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare`. See <Link href="/server" /> for examples.
+For production deployments with channels and WebSocket support, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare`. See <Link href="/server" /> for examples.
 
 
 ## See also

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -4,7 +4,7 @@ import { Link } from '@brillout/docpress'
 
 Low-level function that processes telefunction requests and returns an HTTP response. It's a pure function with no side effects.
 
-> For most setups, use the runtime-specific `telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
+> For most setups, use the runtime-specific `Telefunc` class from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
 
 ## Basic usage
 
@@ -72,7 +72,7 @@ const httpResponse = await serve({
 
 ## Runtime adapters
 
-For production deployments with channels and WebSocket support, use the runtime-specific `telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare`. See <Link href="/server" /> for examples.
+For production deployments with channels and WebSocket support, use the runtime-specific `Telefunc` class from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare`. See <Link href="/server" /> for examples.
 
 
 ## See also

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -1,6 +1,6 @@
 import { Link } from '@brillout/docpress'
 
-Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use the runtime-specific `Telefunc` class.
+Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use `new Telefunc()`.
 
 
 ## Node.js

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -1,6 +1,6 @@
 import { Link } from '@brillout/docpress'
 
-Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use the runtime-specific `telefunc()` factory.
+Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use the runtime-specific `Telefunc` class.
 
 
 ## Node.js
@@ -13,10 +13,10 @@ Telefunc integrates with any server. For production deployments with streaming, 
 
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = telefunc()
+const tf = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
   const response = await tf.serve({ request: c.req.raw })
@@ -36,10 +36,10 @@ tf.installWebSocket(server)
 // Environment: server
 
 import express from 'express'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 
 const app = express()
-const tf = telefunc()
+const tf = new Telefunc()
 
 app.all('/_telefunc', async (req, res, next) => {
   const handled = await tf.serve({ req, res })
@@ -79,9 +79,9 @@ app.all('/_telefunc', async (c) => {
 // server.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/bun'
+import { Telefunc } from 'telefunc/bun'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 Bun.serve({
   port: 3000,
@@ -103,9 +103,9 @@ Bun.serve({
 // server.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/deno'
+import { Telefunc } from 'telefunc/deno'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 Deno.serve({ port: 3000 }, async (request, info) => {
   const response = await tf.serve({ request, info })

--- a/docs/pages/svelte-kit/+Page.mdx
+++ b/docs/pages/svelte-kit/+Page.mdx
@@ -29,10 +29,10 @@ export default defineConfig({
 // src/routes/_telefunc/+server.ts
 // Environment: server
 
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 import type { RequestHandler } from './$types'
 
-const tf = telefunc()
+const tf = new Telefunc()
 
 const handler: RequestHandler = async (event) => {
   const response = await tf.serve({ request: event.request })

--- a/docs/pages/vike/+Page.mdx
+++ b/docs/pages/vike/+Page.mdx
@@ -35,10 +35,10 @@ Install the Telefunc server middleware. For example with Hono:
 
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = telefunc()
+const tf = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
   const response = await tf.serve({ request: c.req.raw })

--- a/packages/telefunc/node/vite/plugins/pluginDev.ts
+++ b/packages/telefunc/node/vite/plugins/pluginDev.ts
@@ -45,8 +45,8 @@ function pluginDev(): Plugin[] {
               // Skip for @cloudflare/vite-plugin: it runs the worker in its own
               // environment with a custom WS handler — registering the Node.js
               // upgrade listener would steal WS upgrades from Cloudflare's handler.
-              const { telefunc } = await import('../../../serve/node.js')
-              telefunc().installWebSocket(server.httpServer)
+              const { Telefunc } = await import('../../../serve/node.js')
+              new Telefunc().installWebSocket(server.httpServer)
             }
           }
         },

--- a/packages/telefunc/serve/bun.ts
+++ b/packages/telefunc/serve/bun.ts
@@ -22,8 +22,6 @@ interface TelefuncServe {
   serve(input: ServeInput): Promise<Response | undefined>
 }
 
-// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
-// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
 interface Telefunc extends TelefuncServe {}
 class Telefunc {
   constructor() {

--- a/packages/telefunc/serve/bun.ts
+++ b/packages/telefunc/serve/bun.ts
@@ -1,8 +1,8 @@
-export { telefunc }
+export { Telefunc }
 
 import crossws from 'crossws/adapters/bun'
 import { serve as serveTelefunc } from '../node/server/telefunc.js'
-import type { Telefunc } from '../node/server/context/getContext.js'
+import type { Telefunc as TelefuncNamespace } from '../node/server/context/getContext.js'
 import { getServerConfig, enableChannelTransports } from '../node/server/serverConfig.js'
 import { getTelefuncChannelHooks } from '../wire-protocol/server/ws.js'
 import { CHANNEL_TRANSPORT } from '../wire-protocol/constants.js'
@@ -14,12 +14,21 @@ type BunServer = Parameters<BunWs['handleUpgrade']>[1]
 type ServeInput = {
   request: Request
   server: BunServer
-  context?: Telefunc.Context
+  context?: TelefuncNamespace.Context
 }
 
 interface TelefuncServe {
   websocket: BunWs['websocket']
   serve(input: ServeInput): Promise<Response | undefined>
+}
+
+// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
+// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
+interface Telefunc extends TelefuncServe {}
+class Telefunc {
+  constructor() {
+    return telefunc()
+  }
 }
 
 function telefunc(): TelefuncServe {

--- a/packages/telefunc/serve/deno.ts
+++ b/packages/telefunc/serve/deno.ts
@@ -21,8 +21,6 @@ interface TelefuncServe {
   serve(input: ServeInput): Promise<Response | undefined>
 }
 
-// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
-// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
 interface Telefunc extends TelefuncServe {}
 class Telefunc {
   constructor() {

--- a/packages/telefunc/serve/deno.ts
+++ b/packages/telefunc/serve/deno.ts
@@ -1,8 +1,8 @@
-export { telefunc }
+export { Telefunc }
 
 import crossws from 'crossws/adapters/deno'
 import { serve as serveTelefunc } from '../node/server/telefunc.js'
-import type { Telefunc } from '../node/server/context/getContext.js'
+import type { Telefunc as TelefuncNamespace } from '../node/server/context/getContext.js'
 import { getServerConfig, enableChannelTransports } from '../node/server/serverConfig.js'
 import { getTelefuncChannelHooks } from '../wire-protocol/server/ws.js'
 import { CHANNEL_TRANSPORT } from '../wire-protocol/constants.js'
@@ -14,11 +14,20 @@ type DenoInfo = Parameters<DenoWs['handleUpgrade']>[1]
 type ServeInput = {
   request: Request
   info: DenoInfo
-  context?: Telefunc.Context
+  context?: TelefuncNamespace.Context
 }
 
 interface TelefuncServe {
   serve(input: ServeInput): Promise<Response | undefined>
+}
+
+// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
+// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
+interface Telefunc extends TelefuncServe {}
+class Telefunc {
+  constructor() {
+    return telefunc()
+  }
 }
 
 function telefunc(): TelefuncServe {

--- a/packages/telefunc/serve/node.ts
+++ b/packages/telefunc/serve/node.ts
@@ -1,8 +1,8 @@
-export { telefunc }
+export { Telefunc }
 
 import crossws from 'crossws/adapters/node'
 import { serve as serveTelefunc } from '../node/server/telefunc.js'
-import type { Telefunc } from '../node/server/context/getContext.js'
+import type { Telefunc as TelefuncNamespace } from '../node/server/context/getContext.js'
 import { getServerConfig, enableChannelTransports } from '../node/server/serverConfig.js'
 import { getTelefuncChannelHooks } from '../wire-protocol/server/ws.js'
 import { CHANNEL_TRANSPORT } from '../wire-protocol/constants.js'
@@ -18,12 +18,12 @@ type NodeRequest = IncomingMessage & { originalUrl?: string }
 type ServeInputNode<Req extends NodeRequest, Res extends ServerResponse> = {
   req: Req
   res: Res
-  context?: Telefunc.Context
+  context?: TelefuncNamespace.Context
 }
 
 type ServeInputRequest = {
   request: Request
-  context?: Telefunc.Context
+  context?: TelefuncNamespace.Context
 }
 
 type ServeInput<Req extends NodeRequest, Res extends ServerResponse> = ServeInputNode<Req, Res> | ServeInputRequest
@@ -37,6 +37,18 @@ interface TelefuncServe<Req extends NodeRequest, Res extends ServerResponse> {
 const { registeredServers } = getGlobalObject('serve/node.ts', {
   registeredServers: new WeakSet<HttpServer>(),
 })
+
+// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
+// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
+interface Telefunc<
+  Req extends NodeRequest = NodeRequest,
+  Res extends ServerResponse = ServerResponse,
+> extends TelefuncServe<Req, Res> {}
+class Telefunc<Req extends NodeRequest = NodeRequest, Res extends ServerResponse = ServerResponse> {
+  constructor() {
+    return telefunc<Req, Res>()
+  }
+}
 
 function telefunc<Req extends NodeRequest = NodeRequest, Res extends ServerResponse = ServerResponse>(): TelefuncServe<
   Req,

--- a/packages/telefunc/serve/node.ts
+++ b/packages/telefunc/serve/node.ts
@@ -38,10 +38,8 @@ const { registeredServers } = getGlobalObject('serve/node.ts', {
   registeredServers: new WeakSet<HttpServer>(),
 })
 
-interface Telefunc<
-  Req extends NodeRequest = NodeRequest,
-  Res extends ServerResponse = ServerResponse,
-> extends TelefuncServe<Req, Res> {}
+interface Telefunc<Req extends NodeRequest = NodeRequest, Res extends ServerResponse = ServerResponse>
+  extends TelefuncServe<Req, Res> {}
 class Telefunc<Req extends NodeRequest = NodeRequest, Res extends ServerResponse = ServerResponse> {
   constructor() {
     return telefunc<Req, Res>()

--- a/packages/telefunc/serve/node.ts
+++ b/packages/telefunc/serve/node.ts
@@ -38,8 +38,6 @@ const { registeredServers } = getGlobalObject('serve/node.ts', {
   registeredServers: new WeakSet<HttpServer>(),
 })
 
-// `new Telefunc()` is a thin wrapper: a constructor that returns an object yields that object,
-// so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type.
 interface Telefunc<
   Req extends NodeRequest = NodeRequest,
   Res extends ServerResponse = ServerResponse,

--- a/test/playground/+server.ts
+++ b/test/playground/+server.ts
@@ -6,7 +6,7 @@ import vike from '@vikejs/hono'
 import IORedis from 'ioredis'
 import { installRedis } from '@telefunc/redis'
 import { config } from 'telefunc'
-import { telefunc } from 'telefunc/node'
+import { Telefunc } from 'telefunc/node'
 import { cleanupState, resetCleanupState, getCleanupStateSnapshot } from './cleanup-state'
 
 config.channel.pingInterval = 1000
@@ -28,7 +28,7 @@ for (const sig of ['SIGINT', 'SIGTERM'] as const) {
 
 const SERVER_CLOSE_RECONNECT_STORE_KEY = Symbol.for('telefunc__serverCloseReconnectStore')
 
-const tf = telefunc()
+const tf = new Telefunc()
 const app = new Hono()
 
 // Bench toggle: when `TELEFUNC_NATIVE=1` the `/_telefunc` route feeds the raw


### PR DESCRIPTION
## What

Follow-up to #268 (the `telefunc/cloudflare` rename). Apply the same public API to the other runtime serve entries so all four match.

`import { telefunc } from 'telefunc/node'` + `telefunc()` becomes `import { Telefunc } from 'telefunc/node'` + `new Telefunc()`, and likewise for `telefunc/bun` and `telefunc/deno`.

## How

Minimal-diff approach: the `telefunc()` factory is kept unchanged internally and exposed through a thin wrapper class.

```ts
interface Telefunc extends TelefuncServe {}
class Telefunc {
  constructor() {
    return telefunc()
  }
}
```

A constructor that returns an object yields that object, so `new Telefunc()` is exactly `telefunc()`. The merged interface gives instances the factory's type. The factory body is left byte-for-byte unchanged, so the diff is the export line, the wrapper, and the type-alias below.

- Alias the imported `Telefunc` context-namespace type to `TelefuncNamespace`, since the class now occupies the name `Telefunc` (same approach `serve/cloudflare.ts` already uses).
- Update the internal dev-plugin caller (`pluginDev.ts`), the playground server, and the docs (`server`, `serve`, `next`, `vike`, `getContext`, `svelte-kit`).

Out of scope: the package-root `telefunc()` middleware (`import { telefunc } from 'telefunc'`) and the `telefunc/vite` plugin are different exports and stay as they are.

## Verification

- `tsc --noEmit` on the package: passes.
- Built `dist`: emitted `.d.ts` expose `Telefunc` with the factory's members in all three entries.
- External-consumer type-check against the built package: passes, including a check that the constructor takes no arguments.
- Prettier: clean.

https://claude.ai/code/session_01Y7dvcj2H3yC28M7SwSrowT