### PR TITLE
Fix flaky Docker test by polling for shield validation logs

### DIFF
--- a/test/playground/.testRun-docker.ts
+++ b/test/playground/.testRun-docker.ts
@@ -118,9 +118,14 @@ function testRunDocker() {
       const resp = await makeTelefuncHttpRequest(1337)
       expect(resp.status).toBe(422)
       expect(await resp.text()).toBe('Shield Validation Error')
-      expectLog('Shield Validation Error', {
-        // Docker `2>&1` collapses container stderr into stdout, so don't filter on source.
-        filter: (log) => log.logText.includes('onLoad()') && log.logText.includes('Hello.telefunc.ts'),
+      // The container's stderr line can reach the harness's log capture a few milliseconds
+      // after the HTTP response resolves, and expectLog() only checks logs captured so far.
+      // Docker compose's log aggregation widens that window. Poll instead of asserting once.
+      await autoRetry(async () => {
+        expectLog('Shield Validation Error', {
+          // Docker `2>&1` collapses container stderr into stdout, so don't filter on source.
+          filter: (log) => log.logText.includes('onLoad()') && log.logText.includes('Hello.telefunc.ts'),
+        })
       })
     }
   })


### PR DESCRIPTION
## Summary
Fixed a race condition in the Docker integration test where log assertions were failing due to timing issues between container stderr output and the test harness's log capture.

## Key Changes
- Wrapped the `expectLog()` assertion in an `autoRetry()` call to poll for the expected log instead of asserting once
- Added explanatory comments documenting why the race condition occurs:
  - Container stderr can arrive at the harness's log capture several milliseconds after the HTTP response resolves
  - Docker Compose's log aggregation widens this timing window
  - A single assertion is insufficient; polling is required for reliability

## Implementation Details
The test was checking for shield validation error logs that include both 'onLoad()' and 'Hello.telefunc.ts' text. By wrapping this check in a retry loop, the test now waits for the logs to be captured rather than failing immediately if they haven't arrived yet, making the test more robust in containerized environments.

https://claude.ai/code/session_01NtokJ3Ad2PJ6G23c78Szh1