### PR TITLE
Add reconcile timeout watchdog to prevent connection wedging

### DIFF
--- a/packages/telefunc/wire-protocol/client/connection.spec.ts
+++ b/packages/telefunc/wire-protocol/client/connection.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { CHANNEL_RECONNECT_INITIAL_DELAY_MS, CHANNEL_TRANSPORT, RECONCILE_TIMEOUT_MS } from '../constants.js'
+import { ClientConnection } from './connection.js'
+
+/** Minimal `MuxChannel` — registering one is enough to make the connection open a wire. */
+function createChannel(id = crypto.randomUUID()) {
+  return {
+    id,
+    isClosed: false,
+    _onTransportOpen() {},
+    _dispatchFrame() {},
+    _onTransportClose() {},
+  }
+}
+
+/** A `fetch` whose SSE downstream body never emits a byte and never closes: a silently
+ *  stalled stream (no error, no FIN), so the RECONCILED frame that clears `reconciling`
+ *  never arrives. Counts how many times the downstream (`Accept: text/event-stream`) is
+ *  opened, i.e. how many connect attempts ran. */
+function createStalledTransport() {
+  let sseDownstreamOpens = 0
+  const fetchImpl = (async (_url: string, init: RequestInit) => {
+    const headers = (init.headers ?? {}) as Record<string, string>
+    if (headers.Accept === 'text/event-stream') sseDownstreamOpens++
+    return new Response(new ReadableStream<Uint8Array>({ start() {} }), { status: 200 })
+  }) as unknown as typeof fetch
+  return { fetchImpl, getSseDownstreamOpens: () => sseDownstreamOpens }
+}
+
+describe('SSE reconcile watchdog', () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  test('reconnects when RECONCILED never arrives on a stalled downstream', async () => {
+    vi.useFakeTimers()
+    const { fetchImpl, getSseDownstreamOpens } = createStalledTransport()
+
+    ClientConnection.getOrCreate('http://test.local/_telefunc', createChannel() as never, {
+      transports: [CHANNEL_TRANSPORT.SSE],
+      fetchImpl,
+      connectionKey: crypto.randomUUID(),
+    })
+
+    // `start()` defers the first openStream by one reconcile window; let it connect.
+    await vi.advanceTimersByTimeAsync(100)
+    expect(getSseDownstreamOpens()).toBe(1)
+
+    // The downstream is silent, so RECONCILED never lands. Without the watchdog the
+    // connection wedges here forever: pings keep flowing but `handlePongTimeout` is
+    // suppressed while reconciling, so the dead wire is never noticed. The watchdog must
+    // instead time out the reconcile and reconnect.
+    await vi.advanceTimersByTimeAsync(RECONCILE_TIMEOUT_MS + CHANNEL_RECONNECT_INITIAL_DELAY_MS + 500)
+    expect(getSseDownstreamOpens()).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/telefunc/wire-protocol/client/connection.ts
+++ b/packages/telefunc/wire-protocol/client/connection.ts
@@ -15,6 +15,7 @@ import {
   CHANNEL_RECONNECT_MAX_DELAY_MS,
   CHANNEL_RECONNECT_TIMEOUT_MS,
   CHANNEL_TRANSPORT,
+  RECONCILE_TIMEOUT_MS,
   SSE_FLUSH_THROTTLE_MS,
   SSE_POST_IDLE_FLUSH_DELAY_MS,
   SSE_RECONCILE_DEADLINE_MS,
@@ -258,8 +259,11 @@ class ClientConnection implements MuxConnection {
    *  first RECONCILED can arrive in either order on the SSE path. */
   private serverTransports: ReconciledPayload['transports'] | null = null
   /** RECONCILE sent, awaiting RECONCILED. SSE sets it true during connecting since the
-   *  initial reconcile is baked into the openStream POST body. */
+   *  initial reconcile is baked into the openStream POST body. Bounded by `reconcileTimer`:
+   *  written only via `enterReconciling`/`exitReconciling` so the deadline can never outlive
+   *  the state it guards. */
   private reconciling = false
+  private reconcileTimer: ReturnType<typeof setTimeout> | null = null
   private ttl: ReturnType<typeof setTimeout> | null = null
 
   private get closed(): boolean {
@@ -711,9 +715,37 @@ class ClientConnection implements MuxConnection {
     hb.start()
   }
 
-  /** Funnel for pong-timeouts. Suppress while reconciling — pings are delayed by the round-trip. */
+  /** Funnel for pong-timeouts. Suppress while reconciling — pings are delayed by the round-trip;
+   *  `reconcileTimer` (armed by `enterReconciling`) is the liveness bound for that window. */
   private handlePongTimeout(transport: ClientChannelTransport): void {
     if (this.reconciling) return
+    transport.detachHeartbeat()
+    transport.abandonActiveTransport()
+    this._onTransportClosed(transport, false)
+  }
+
+  /** Enter the await-RECONCILED window and arm its liveness bound. A follow-up RECONCILE for
+   *  late registrations re-enters and restarts the deadline from scratch. */
+  private enterReconciling(): void {
+    this.reconciling = true
+    if (this.reconcileTimer) clearTimeout(this.reconcileTimer)
+    this.reconcileTimer = setTimeout(() => this.onReconcileTimeout(), RECONCILE_TIMEOUT_MS)
+  }
+
+  /** Leave the await-RECONCILED window: RECONCILED settled, the wire was lost, or disposed. */
+  private exitReconciling(): void {
+    this.reconciling = false
+    if (this.reconcileTimer) {
+      clearTimeout(this.reconcileTimer)
+      this.reconcileTimer = null
+    }
+  }
+
+  /** RECONCILED never arrived on a silently-stalled wire — same outcome as a missed pong:
+   *  drop the wire and let `handleTransportLoss` reconnect. */
+  private onReconcileTimeout(): void {
+    if (this.closed || !this.reconciling) return
+    const transport = this.transport
     transport.detachHeartbeat()
     transport.abandonActiveTransport()
     this._onTransportClosed(transport, false)
@@ -901,7 +933,7 @@ class ClientConnection implements MuxConnection {
     // The wire is dying — cancel the queued RECONCILE (no point sending) and release
     // unconfirmed-releasing entries so they don't leak onto the post-reconnect RECONCILE.
     this.cancelPendingRegisterReconcile()
-    this.reconciling = false
+    this.exitReconciling()
     this.reconcileIxes.clear()
     if (this.ttl) {
       clearTimeout(this.ttl)
@@ -969,14 +1001,14 @@ class ClientConnection implements MuxConnection {
     this.lastSeqByChannel.clear()
     this.replayBuffers.clear()
     this.reconcileIxes.clear()
-    this.reconciling = false
+    this.exitReconciling()
     ClientConnection.cache.delete(this.cacheKey)
   }
 
   // ── Protocol internals ──
 
   buildReconcileFrame(): OutboundFrame {
-    this.reconciling = true
+    this.enterReconciling()
     this.reconcileIxes = new Set()
     const open: ReconcilePayload['open'] = []
     for (const [ix, entry] of this.channels) {
@@ -1062,7 +1094,7 @@ class ClientConnection implements MuxConnection {
       const reconcileBatch = this.stageReconcileBatch()
       this.appendReconcileBatch(releaseFrames, reconcileBatch)
     } else {
-      this.reconciling = false
+      this.exitReconciling()
     }
 
     return { frames: releaseFrames, channelsToOpen, reconcileComplete: !hasNewChannels }

--- a/packages/telefunc/wire-protocol/constants.ts
+++ b/packages/telefunc/wire-protocol/constants.ts
@@ -87,6 +87,13 @@ export const UPGRADE_DRAIN_TIMEOUT_MS = 2_000
  *  wire (cross-wire reordering can deliver FIN first) before aborting the upgrade. */
 export const UPGRADE_FIN_RECONCILED_TIMEOUT_MS = 2_000
 
+/** How long the client waits for RECONCILED after sending a RECONCILE before declaring the
+ *  wire dead and reconnecting. A downstream that stalls without erroring (bytes stop, no FIN)
+ *  otherwise wedges the connection: the upstream keeps sending pings but `handlePongTimeout`
+ *  is suppressed while reconciling, so nothing notices the dead wire and every call buffered
+ *  behind the un-acked RECONCILE hangs. */
+export const RECONCILE_TIMEOUT_MS = 10_000
+
 // ===== Multiplexed SSE transport =====
 
 /** Shorter flush delay for the first SSE batch POST after an idle period. */


### PR DESCRIPTION
## Summary
Adds a liveness timeout for the RECONCILE/RECONCILED handshake to prevent the client connection from wedging when the SSE downstream stalls silently (stops sending bytes without erroring or closing).

## Key Changes
- **New constant `RECONCILE_TIMEOUT_MS`** (10 seconds): Defines the maximum time to wait for a RECONCILED response before treating the wire as dead
- **Reconcile state management**: Introduced `enterReconciling()` and `exitReconciling()` methods to properly manage the reconciling state and its associated timeout
- **Watchdog timer**: Added `reconcileTimer` field that arms a timeout whenever entering the reconciling state; if RECONCILED doesn't arrive within the deadline, `onReconcileTimeout()` triggers wire closure and reconnection
- **Timeout handler**: New `onReconcileTimeout()` method treats a stalled reconcile the same as a missed pong—detaches heartbeat and abandons the transport to trigger reconnection
- **Comprehensive test**: Added `connection.spec.ts` with a test that verifies the watchdog reconnects when an SSE downstream stalls indefinitely

## Implementation Details
- The reconcile timer is cleared and restarted on each `enterReconciling()` call, allowing late-registration RECONCILEs to reset the deadline
- Timer cleanup is guaranteed via `exitReconciling()`, which is called on successful RECONCILED receipt, wire loss, or connection disposal
- The `handlePongTimeout()` suppression while reconciling is now explicitly bounded by the reconcile timer, preventing indefinite suppression on stalled streams
- The test uses fake timers and a mock fetch that returns a never-closing SSE stream to verify reconnection behavior

https://claude.ai/code/session_01HnZGW1bBQQwta2131tjZYr