### PR TITLE
fix: replace `declare module 'telefunc'` with `declare global`

### DIFF
--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -177,6 +177,11 @@ declare global {
     }
   }
 }
+
+// Add this line if TypeScript complains about `declare global` (it requires the file
+// to have at least one `import` or `export` so that TypeScript treats it as a module).
+// https://typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined
+export {}
 ```
 ```ts ts-only
 // User.ts

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -194,20 +194,6 @@ export async function someTelefunction() {
 }
 ```
 
-> [!NOTE]
-> Augmenting the `'telefunc'` module is deprecated, use the global `Telefunc` namespace shown above instead.
-> ```ts
-> // ❌ Deprecated
-> import 'telefunc'
-> declare module 'telefunc' {
->   namespace Telefunc {
->     interface Context {
->       user: null | User
->     }
->   }
-> }
-> ```
-
 You can also directly set `const context = getContext<MyContext>()`:
 
 ```ts ts-only

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -163,15 +163,14 @@ export async function myTelefunction() {
 
 ## TypeScript
 
-You can use `Telefunc.Context` to globally set the type of `const context = getContext()`:
+You can use the global `Telefunc.Context` interface to globally set the type of `const context = getContext()`:
 
 ```ts ts-only
 // TelefuncContext.d.ts
 
-import 'telefunc'
 import type { User } from './User.ts'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User
@@ -194,6 +193,20 @@ export async function someTelefunction() {
   const { user } = getContext()
 }
 ```
+
+> [!NOTE]
+> Augmenting the `'telefunc'` module is deprecated, use the global `Telefunc` namespace shown above instead.
+> ```ts
+> // ❌ Deprecated
+> import 'telefunc'
+> declare module 'telefunc' {
+>   namespace Telefunc {
+>     interface Context {
+>       user: null | User
+>     }
+>   }
+> }
+> ```
 
 You can also directly set `const context = getContext<MyContext>()`:
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -163,7 +163,7 @@ export async function myTelefunction() {
 
 ## TypeScript
 
-You can use the global `Telefunc.Context` interface to globally set the type of `const context = getContext()`:
+You can use the `Telefunc.Context` interface to globally set the type of `const context = getContext()`:
 
 ```ts ts-only
 // TelefuncContext.d.ts

--- a/examples/authentication/auth/TelefuncContext.d.ts
+++ b/examples/authentication/auth/TelefuncContext.d.ts
@@ -1,6 +1,7 @@
+import 'telefunc'
 import type { User } from '#app/db'
 
-declare global {
+declare module 'telefunc' {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/authentication/auth/TelefuncContext.d.ts
+++ b/examples/authentication/auth/TelefuncContext.d.ts
@@ -1,7 +1,6 @@
-import 'telefunc'
 import type { User } from '#app/db'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/next/TelefuncContext.d.ts
+++ b/examples/next/TelefuncContext.d.ts
@@ -1,7 +1,6 @@
-import 'telefunc'
 import type { User } from './auth/getUser'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/next/TelefuncContext.d.ts
+++ b/examples/next/TelefuncContext.d.ts
@@ -1,6 +1,7 @@
+import 'telefunc'
 import type { User } from './auth/getUser'
 
-declare global {
+declare module 'telefunc' {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/svelte-kit/src/telefunc.d.ts
+++ b/examples/svelte-kit/src/telefunc.d.ts
@@ -1,6 +1,4 @@
-import 'telefunc'
-
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       /* Globally define the type of the `context` object here, see https://telefunc.com/getContext#typescript
@@ -10,3 +8,5 @@ declare module 'telefunc' {
     }
   }
 }
+
+export {}

--- a/examples/svelte-kit/src/telefunc.d.ts
+++ b/examples/svelte-kit/src/telefunc.d.ts
@@ -1,4 +1,6 @@
-declare global {
+import 'telefunc'
+
+declare module 'telefunc' {
   namespace Telefunc {
     interface Context {
       /* Globally define the type of the `context` object here, see https://telefunc.com/getContext#typescript
@@ -8,5 +10,3 @@ declare global {
     }
   }
 }
-
-export {}

--- a/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
+++ b/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
@@ -1,10 +1,8 @@
+// TO-DO/next-major-release: remove
 export declare namespace Telefunc {
   /**
-   * Globally set the type of the `context` object (`const context = getContext()`).
+   * @deprecated Replace `declare module 'telefunc'` with `declare global`:
    *
-   * https://telefunc.com/getContext#typescript
-   *
-   * @deprecated Augment the global `Telefunc` namespace instead of the `'telefunc'` module:
    * ```ts
    * // TelefuncContext.d.ts
    *
@@ -25,11 +23,10 @@ export declare namespace Telefunc {
 declare global {
   namespace Telefunc {
     /**
-     * Globally set the type of the `context` object (`const context = getContext()`).
+     * Set the type of the `context` object (`const context = getContext()`).
      *
      * https://telefunc.com/getContext#typescript
      */
-    // Can be overridden by the user
     interface Context {}
   }
 }

--- a/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
+++ b/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
@@ -1,4 +1,35 @@
 export declare namespace Telefunc {
-  // Can be overridden by the user
-  export interface Context {}
+  /**
+   * Globally set the type of the `context` object (`const context = getContext()`).
+   *
+   * https://telefunc.com/getContext#typescript
+   *
+   * @deprecated Augment the global `Telefunc` namespace instead of the `'telefunc'` module:
+   * ```ts
+   * // TelefuncContext.d.ts
+   *
+   * import type { User } from './User.js'
+   *
+   * declare global {
+   *   namespace Telefunc {
+   *     interface Context {
+   *       user: null | User
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  export interface Context extends globalThis.Telefunc.Context {}
+}
+
+declare global {
+  namespace Telefunc {
+    /**
+     * Globally set the type of the `context` object (`const context = getContext()`).
+     *
+     * https://telefunc.com/getContext#typescript
+     */
+    // Can be overridden by the user
+    interface Context {}
+  }
 }

--- a/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
+++ b/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
@@ -1,21 +1,9 @@
 // TO-DO/next-major-release: remove
 export declare namespace Telefunc {
   /**
-   * @deprecated Replace `declare module 'telefunc'` with `declare global`:
+   * @deprecated Replace `declare module 'telefunc'` with `declare global`
    *
-   * ```ts
-   * // TelefuncContext.d.ts
-   *
-   * import type { User } from './User.js'
-   *
-   * declare global {
-   *   namespace Telefunc {
-   *     interface Context {
-   *       user: null | User
-   *     }
-   *   }
-   * }
-   * ```
+   * https://telefunc.com/getContext#typescript
    */
   export interface Context extends globalThis.Telefunc.Context {}
 }

--- a/packages/telefunc/node/server/index.ts
+++ b/packages/telefunc/node/server/index.ts
@@ -9,6 +9,7 @@ export { onBug } from './runTelefunc/onBug.js'
 
 // TO-DO/eventually: remove this export after we remove `declare module 'telefunc'`, see https://github.com/telefunc/telefunc/pull/279
 // In order to allow users to override `Telefunc.Context`, we need to export `Telefunc` (even if the user never imports `Telefunc`)
+export type { Telefunc } from './getContext/TelefuncNamespace.js'
 
 export { decorateTelefunction as __decorateTelefunction } from './runTelefunc/decorateTelefunction.js'
 

--- a/packages/telefunc/node/server/index.ts
+++ b/packages/telefunc/node/server/index.ts
@@ -9,7 +9,6 @@ export { onBug } from './runTelefunc/onBug.js'
 
 // TO-DO/eventually: remove this export after we remove `declare module 'telefunc'`, see https://github.com/telefunc/telefunc/pull/279
 // In order to allow users to override `Telefunc.Context`, we need to export `Telefunc` (even if the user never imports `Telefunc`)
-export type { Telefunc } from './getContext/TelefuncNamespace.js'
 
 export { decorateTelefunction as __decorateTelefunction } from './runTelefunc/decorateTelefunction.js'
 

--- a/packages/telefunc/node/server/index.ts
+++ b/packages/telefunc/node/server/index.ts
@@ -7,6 +7,7 @@ export { Abort } from './Abort.js'
 export { shield } from './shield.js'
 export { onBug } from './runTelefunc/onBug.js'
 
+// TO-DO/eventually: remove this export after we remove `declare module 'telefunc'`, see https://github.com/telefunc/telefunc/pull/279
 // In order to allow users to override `Telefunc.Context`, we need to export `Telefunc` (even if the user never imports `Telefunc`)
 export type { Telefunc } from './getContext/TelefuncNamespace.js'
 

--- a/packages/telefunc/node/server/index.ts
+++ b/packages/telefunc/node/server/index.ts
@@ -7,8 +7,7 @@ export { Abort } from './Abort.js'
 export { shield } from './shield.js'
 export { onBug } from './runTelefunc/onBug.js'
 
-// TO-DO/eventually: remove this export after we remove `declare module 'telefunc'`, see https://github.com/telefunc/telefunc/pull/279
-// In order to allow users to override `Telefunc.Context`, we need to export `Telefunc` (even if the user never imports `Telefunc`)
+// TO-DO/next-major-release: remove
 export type { Telefunc } from './getContext/TelefuncNamespace.js'
 
 export { decorateTelefunction as __decorateTelefunction } from './runTelefunc/decorateTelefunction.js'


### PR DESCRIPTION
## Summary
This PR migrates the TypeScript type augmentation pattern for `Telefunc.Context` from module augmentation (`declare module 'telefunc'`) to global namespace augmentation (`declare global`). This is a cleaner and more idiomatic approach that aligns with TypeScript best practices.

## Key Changes
- **Updated type definitions**: Modified `TelefuncNamespace.ts` to define `Context` in the global `Telefunc` namespace while maintaining backward compatibility through the module-level namespace
- **Deprecated old pattern**: Added deprecation notice and documentation for the old `declare module 'telefunc'` approach
- **Updated documentation**: Changed `getContext` TypeScript guide to show the new global namespace pattern as the recommended approach
- **Updated examples**: Migrated all example projects (`svelte-kit`, `authentication`, `next`) to use the new global namespace augmentation pattern
- **Added export statement**: Added `export {}` to example type definition files to ensure they are treated as modules

## Implementation Details
- The old module augmentation pattern is still supported through the exported `Telefunc.Context` interface that extends `globalThis.Telefunc.Context`, ensuring backward compatibility
- Users are encouraged to migrate to the new pattern via deprecation notices in both code comments and documentation
- The new pattern is simpler and doesn't require importing the `'telefunc'` module in type definition files

https://claude.ai/code/session_01PxTcqqUAFGh4eGmz7Cp3uG