### PR TITLE
docs: dedupe transport and reconnection in the streaming docs

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -366,7 +366,7 @@ chat.abort({ reason: 'session-expired' })
 If the connection drops, Telefunc reconnects automatically and resumes existing channels and broadcast instances:
 
 - Messages sent while offline are buffered and delivered in order on reconnect.
-- Both sides keep a bounded replay buffer; after reconnect, missing frames are replayed.
+- Both sides keep a bounded replay buffer; after reconnect, missing frames are replayed and duplicates are ignored.
 - `onOpen()` fires only on initial open, `onClose()` only on permanent close.
 
 > Reconnection is transparent — you don't need to handle it in your application code.

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -151,24 +151,14 @@ For reactive streams with full operator support, see <Link href="/integrations/r
 
 ## Reconnection
 
-If the connection drops, Telefunc reconnects automatically and resumes existing channels. Messages sent while offline are buffered and delivered in order on reconnect.
+If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. It's transparent to your application code.
 
-- `onOpen()` fires only for the initial open.
-- `onClose()` fires only when the channel is permanently closed.
-
-> Both sides keep a bounded replay buffer. After reconnect, missing frames are replayed and duplicates are ignored.
+See <Link href="/channel#reconnection" text="Channel reconnection" /> for details.
 
 
 ## Transport
 
-Channels start on **SSE** and automatically upgrade to **WebSocket** when WebSocket is enabled in your <Link text="server setup" href="/server" />. No client-side configuration needed.
-
-| Transport | Throughput | Recovery | CDN-friendly |
-|---|---|---|---|
-| SSE (initial) | 🟡 | ✅ | ✅ |
-| WebSocket (upgraded) | ✅ | ✅ | 🟡 |
-
-All channels share a single multiplexed connection per server URL. The upgrade happens transparently in the background — no interruption to active channels.
+Channels start on **SSE** and automatically upgrade to **WebSocket** when it's enabled in your <Link text="server setup" href="/server" />, with no client-side configuration. All channels share a single multiplexed connection per server URL, and the upgrade is transparent to active channels.
 
 See <Link href="/transport" /> for the full comparison.
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -227,36 +227,9 @@ See <Link href="/close" /> for all cancellation methods (`close()`, `break`, `ge
 
 ## Transport
 
-By default, streamed values are sent as raw binary chunks over HTTP (`application/octet-stream`). You can switch transport globally or per call.
+By default, streamed values are sent as raw binary chunks over HTTP. Switch to `'sse-inline'` (for proxies that buffer binary responses) or `'channel'` (to stream over a reconnecting channel), globally or per call.
 
-| Transport | Description |
-|---|---|
-| `'binary-inline'` (default) | Raw binary chunked HTTP response. Lowest overhead. |
-| `'sse-inline'` | Base64url-encoded Server-Sent Events — works through proxies that buffer binary |
-| `'channel'` | Delivers over the configured channel transport (`'sse'` or `'ws'`) with reconnection support |
-
-```ts
-// Environment: client
-
-import { config } from 'telefunc/client'
-
-config.stream.transport = 'sse-inline'
-```
-
-Override per call:
-
-```ts
-// Environment: client
-
-import { onChat } from './Chat.telefunc'
-import { withContext } from 'telefunc/client'
-
-const gen = withContext(onChat, {
-  stream: { transport: 'channel' },
-})('Tell me a joke')
-```
-
-See <Link href="/transport" /> for a full comparison.
+See <Link href="/transport" /> for the options, trade-offs, and how to configure them.
 
 
 ## Error handling

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -61,6 +61,8 @@ Controls how <Link text={<code>new Channel()</code>} href="/channel" /> connecti
 
 The client default is `['sse', 'ws']` — start on SSE, upgrade to WebSocket when the server supports it. The server enables SSE only until a WebSocket adapter is installed (see <Link href="/server" />).
 
+All channels share a single multiplexed connection per server URL, so opening many channels doesn't open many connections.
+
 ### Comparison
 
 | | Throughput | Recovery | Proxy/CDN | Setup |


### PR DESCRIPTION
Tier 2 of the streaming docs structure cleanup, following #280 and #281 (both merged). Single-sources the duplicated reference content:

- **Transport** is now documented once on `/transport`. The `## Transport` sections on `/stream` and `/real-time` are trimmed to a short summary plus a link (the duplicated comparison tables are removed).
- **Reconnection** is now documented once on `/channel`. The `## Reconnection` section on `/real-time` is trimmed to a one-line summary plus a link to `/channel#reconnection`.

The `## Transport` and `## Reconnection` headings are kept, so existing `#transport` / `#reconnection` anchors still resolve. No inbound links pointed at the removed table content. Net −42 / +5 lines.

Not run: `vike build` (docs deps aren't installed in this environment; CI covers the build).

https://claude.ai/code/session_01Lny4RQ3gQVHbgQzGy2zoSF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lny4RQ3gQVHbgQzGy2zoSF)_