### PR TITLE
Add resilient navigation for Chromium-in-Docker network errors

### DIFF
--- a/test/playground/.testRun-docker.ts
+++ b/test/playground/.testRun-docker.ts
@@ -2,7 +2,7 @@ export { testRunDocker }
 
 import { page, test, expect, expectLog, run, skip, isCI, getServerUrl, autoRetry, fetchHtml } from '@brillout/test-e2e'
 import { execSync } from 'node:child_process'
-import { waitForHydration } from './e2e-utils'
+import { resilientGoto, waitForHydration } from './e2e-utils'
 import { testCounter } from '../utils'
 import { testFileUpload } from './pages/file-upload/e2e-test'
 import { testFileDownload } from './pages/file-download/e2e-test'
@@ -79,7 +79,7 @@ function testRunDocker() {
       expect(html).not.toContain('Eva')
     }
     {
-      await page.goto(`${getServerUrl()}/`, { waitUntil: 'load' })
+      await resilientGoto(`${getServerUrl()}/`, { waitUntil: 'load' })
       await waitForHydration()
       await autoRetry(
         async () => {

--- a/test/playground/e2e-utils.ts
+++ b/test/playground/e2e-utils.ts
@@ -1,4 +1,14 @@
-export { resetCleanupState, getCleanupState, waitForHydration, getResult, sleep, restartProxy, stopProxy, startProxy }
+export {
+  resetCleanupState,
+  getCleanupState,
+  resilientGoto,
+  waitForHydration,
+  getResult,
+  sleep,
+  restartProxy,
+  stopProxy,
+  startProxy,
+}
 
 import { page, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
 import { execSync } from 'node:child_process'
@@ -39,6 +49,23 @@ async function getCleanupState(): Promise<Record<string, string>> {
   return resp.json()
 }
 
+/**
+ * `page.goto()` that retries the navigation on transient Chromium-in-Docker network errors.
+ * Right after the containers come up, Chromium's `NetworkChangeNotifier` can abort the in-flight
+ * navigation with `ERR_NETWORK_CHANGED` (and connection-family friends) when the Docker bridge
+ * interface state shifts. Re-navigating recovers, so retry a few times before giving up.
+ */
+async function resilientGoto(url: string, options?: Parameters<typeof page.goto>[1]) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      await page.goto(url, options)
+      return
+    } catch (err) {
+      if (attempt === 3 || !isTransientNetworkError(err)) throw err
+    }
+  }
+}
+
 async function waitForHydration() {
   // Chromium-in-Docker can drop in-flight asset fetches with `ERR_NETWORK_CHANGED`
   // when the bridge interface state shifts, leaving the page un-hydrated. Retry
@@ -49,9 +76,31 @@ async function waitForHydration() {
       return
     } catch {
       if (attempt === 3) throw new Error('Page never hydrated after 4 attempts')
-      await page.reload({ waitUntil: 'load' })
+      // The reload can itself hit a transient `ERR_NETWORK_CHANGED`; swallow it and let the
+      // next attempt retry, instead of failing the whole test on the recovery step.
+      try {
+        await page.reload({ waitUntil: 'load' })
+      } catch (err) {
+        if (!isTransientNetworkError(err)) throw err
+      }
     }
   }
+}
+
+// Transient errors Chromium-in-Docker surfaces when the bridge interface state shifts. Mirrors
+// the connection-family errors `.testRun-docker.ts`'s `tolerateError()` already allows in logs.
+const transientNetworkErrors = [
+  'ERR_NETWORK_CHANGED',
+  'ERR_CONNECTION_CLOSED',
+  'ERR_CONNECTION_RESET',
+  'ERR_CONNECTION_REFUSED',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_ALPN_NEGOTIATION_FAILED',
+  'ERR_SSL_PROTOCOL_ERROR',
+]
+function isTransientNetworkError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return transientNetworkErrors.some((code) => message.includes(code))
 }
 
 async function getResult<T = any>(selector: string): Promise<T> {


### PR DESCRIPTION
## Summary
This PR improves test reliability in Docker environments by adding resilient navigation that automatically retries on transient network errors that occur when the Docker bridge interface state shifts.

## Key Changes
- **New `resilientGoto()` function**: A wrapper around `page.goto()` that retries navigation up to 4 times when transient network errors occur (e.g., `ERR_NETWORK_CHANGED`, `ERR_CONNECTION_CLOSED`, etc.)
- **Enhanced `waitForHydration()` error handling**: Added try-catch around `page.reload()` to gracefully handle transient network errors during the recovery step instead of failing the entire test
- **Shared error detection**: Introduced `isTransientNetworkError()` helper function and `transientNetworkErrors` list that mirrors the connection-family errors already tolerated in Docker test logs
- **Updated exports**: Added `resilientGoto` to the e2e-utils exports
- **Updated test usage**: Changed the initial page navigation in `.testRun-docker.ts` to use `resilientGoto()` instead of `page.goto()`

## Implementation Details
The solution addresses a known issue where Chromium running in Docker can abort in-flight navigations with network errors when the Docker bridge interface state changes. Rather than failing immediately, the code now:
1. Retries the navigation operation up to 4 times
2. Only throws if the error is not transient or all retries are exhausted
3. Applies the same resilience pattern to both initial navigation and hydration recovery steps

https://claude.ai/code/session_01M9zveeEGjemXMAHZZUTF7k