### PR TITLE
docs: split "Which primitive should I use?" into high-level usage + low-level primitives

### DIFF
--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -4,12 +4,24 @@ Telefunc handles real-time flows — chat, upload progress, live updates — usi
 
 ## Which primitive should I use?
 
+Reach for a **high-level integration** when one fits your use case — they wrap the primitives below with an ergonomic API. Drop down to a **low-level primitive** when you need full control.
+
+### High-level usage
+
+| Integration | Best for | Setup |
+|---|---|---|
+| <Link text={<code>@telefunc/tanstack-query</code>} href="/integrations/tanstack-query" /> | Data fetching with caching that stays fresh — server-side invalidation refetches every connected client with a matching query key | <Link text={<code>withTelefunc()</code>} href="/integrations/tanstack-query#install" /> |
+| <Link text={<code>@telefunc/rxjs</code>} href="/integrations/rxjs" /> | Reactive [RxJS](https://rxjs.dev/) streams with full operator support — pass `Observable` / `Subject` transparently in both directions | <Link text="install" href="/integrations/rxjs#install" /> |
+
+> Scaling across multiple servers? <Link text={<code>@telefunc/redis</code>} href="/integrations/redis" /> backs `Broadcast` fan-out with Redis Pub/Sub. See <Link href="/multiple-nodes" />.
+
+### Low-level primitives
+
 | Primitive | Best for | Setup |
 |---|---|---|
 | **Function passing** | Short-lived callbacks — progress updates, one-off server-to-client pushes | None |
 | **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE) or <Link text="WebSocket server setup" href="/server" /> (WS) |
 | **`new Broadcast()`** | Broadcast messaging — chat rooms, live feeds, notifications | Same as channels |
-| **[RxJS](https://rxjs.dev/) `Observable` / `Subject`** | Reactive streams with full operator support — pass rxjs primitives transparently | <Link href="/integrations/rxjs" text={<code>@telefunc/rxjs</code>} /> |
 | **`config.stream.transport = 'channel'`** | <Link href="/stream">Streamed values</Link> over the same reconnecting transport as channels | Same as channels |
 
 > See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -1,26 +1,16 @@
 import { Link } from '@brillout/docpress'
 
-Telefunc handles real-time flows — chat, upload progress, live updates — using the same function model as ordinary calls.
+Telefunc supports real-time use cases — chat, file upload progress, live updates, ...
+
+> Instead of using Telefunc's real-time primitives yourself, consider using high-level integrations such as <Link text={<code>@telefunc/tanstack-query</code>} href="/integrations/tanstack-query" /> — they wrap the primitives below with an ergonomic API.
+
 
 ## Which primitive should I use?
-
-Reach for a **high-level integration** when one fits your use case — they wrap the primitives below with an ergonomic API. Drop down to a **low-level primitive** when you need full control.
-
-### High-level usage
-
-| Integration | Best for | Setup |
-|---|---|---|
-| <Link text={<code>@telefunc/tanstack-query</code>} href="/integrations/tanstack-query" /> | Data fetching with caching that stays fresh — server-side invalidation refetches every connected client with a matching query key | <Link text={<code>withTelefunc()</code>} href="/integrations/tanstack-query#install" /> |
-| <Link text={<code>@telefunc/rxjs</code>} href="/integrations/rxjs" /> | Reactive [RxJS](https://rxjs.dev/) streams with full operator support — pass `Observable` / `Subject` transparently in both directions | <Link text="install" href="/integrations/rxjs#install" /> |
-
-> Scaling across multiple servers? <Link text={<code>@telefunc/redis</code>} href="/integrations/redis" /> backs `Broadcast` fan-out with Redis Pub/Sub. See <Link href="/scaling" />.
-
-### Low-level primitives
 
 | Primitive | Best for | Setup |
 |---|---|---|
 | **Function passing** | Short-lived callbacks — progress updates, one-off server-to-client pushes | None |
-| **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE) or <Link text="WebSocket server setup" href="/server" /> (WS) |
+| **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE), or <Link text="WebSocket server setup" href="/server" /> (WS) |
 | **`new Broadcast()`** | Broadcast messaging — chat rooms, live feeds, notifications | Same as channels |
 
 > See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -22,7 +22,6 @@ Reach for a **high-level integration** when one fits your use case — they wrap
 | **Function passing** | Short-lived callbacks — progress updates, one-off server-to-client pushes | None |
 | **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE) or <Link text="WebSocket server setup" href="/server" /> (WS) |
 | **`new Broadcast()`** | Broadcast messaging — chat rooms, live feeds, notifications | Same as channels |
-| **`config.stream.transport = 'channel'`** | <Link href="/stream">Streamed values</Link> over the same reconnecting transport as channels | Same as channels |
 
 > See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)
 


### PR DESCRIPTION
Splits the single decision table in the `/real-time` page's "Which primitive should I use?" section into two:

- **High-level usage** — `@telefunc/tanstack-query` and `@telefunc/rxjs`, with a note pointing to `@telefunc/redis` for multi-server `Broadcast` scaling.
- **Low-level primitives** — function passing, `Channel`, `Broadcast`, and the channel stream transport.

This surfaces the integrations (TanStack Query was missing from the table) and steers readers toward an ergonomic high-level API first, dropping down to a primitive when they need full control.

Targets `nitedani/streaming`, where the `/real-time` page lives.

https://claude.ai/code/session_01N86oyScQQ5j2zY8eJrSpSZ