### PR TITLE
Real-time Channel/Broadcast, file downloads, and shield runtime validation

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,6 +4,3 @@ TO-DO/soon:
 
 TO-DO/next-major-release:
 - rename `telefunc()` into `serve()`
-- Re-apply global namespace usage commit: https://github.com/brillout/telefunc/commit/7758568044edb4d4008c11be0667c13cedb7a149
-  - Revert the revert: https://github.com/brillout/telefunc/commit/616fd0933c3add63b754c1424fd585b0c9c700b2
-  - It's a breaking change => release a new major

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -163,21 +163,25 @@ export async function myTelefunction() {
 
 ## TypeScript
 
-You can use `Telefunc.Context` to globally set the type of `const context = getContext()`:
+You can use the `Telefunc.Context` interface to globally set the type of `const context = getContext()`:
 
 ```ts ts-only
 // TelefuncContext.d.ts
 
-import 'telefunc'
 import type { User } from './User.ts'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User
     }
   }
 }
+
+// Add this line if TypeScript complains about `declare global` (it requires the file
+// to have at least one `import` or `export` so that TypeScript treats it as a module).
+// https://typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined
+export {}
 ```
 ```ts ts-only
 // User.ts

--- a/examples/authentication/auth/TelefuncContext.d.ts
+++ b/examples/authentication/auth/TelefuncContext.d.ts
@@ -1,7 +1,6 @@
-import 'telefunc'
 import type { User } from '#app/db'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/next/TelefuncContext.d.ts
+++ b/examples/next/TelefuncContext.d.ts
@@ -1,7 +1,6 @@
-import 'telefunc'
 import type { User } from './auth/getUser'
 
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       user: null | User

--- a/examples/svelte-kit/src/telefunc.d.ts
+++ b/examples/svelte-kit/src/telefunc.d.ts
@@ -1,6 +1,4 @@
-import 'telefunc'
-
-declare module 'telefunc' {
+declare global {
   namespace Telefunc {
     interface Context {
       /* Globally define the type of the `context` object here, see https://telefunc.com/getContext#typescript
@@ -10,3 +8,5 @@ declare module 'telefunc' {
     }
   }
 }
+
+export {}

--- a/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
+++ b/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
@@ -1,4 +1,20 @@
+// TO-DO/next-major-release: remove
 export declare namespace Telefunc {
-  // Can be overridden by the user
-  export interface Context {}
+  /**
+   * @deprecated Replace `declare module 'telefunc'` with `declare global`
+   *
+   * https://telefunc.com/getContext#typescript
+   */
+  export interface Context extends globalThis.Telefunc.Context {}
+}
+
+declare global {
+  namespace Telefunc {
+    /**
+     * Set the type of the `context` object (`const context = getContext()`).
+     *
+     * https://telefunc.com/getContext#typescript
+     */
+    interface Context {}
+  }
 }

--- a/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
+++ b/packages/telefunc/node/server/getContext/TelefuncNamespace.ts
@@ -1,4 +1,4 @@
-// TO-DO/next-major-release: remove
+// TO-DO/next-major-release: remove, see https://github.com/telefunc/telefunc/commit/7758568044edb4d4008c11be0667c13cedb7a149
 export declare namespace Telefunc {
   /**
    * @deprecated Replace `declare module 'telefunc'` with `declare global`

--- a/packages/telefunc/node/server/index.ts
+++ b/packages/telefunc/node/server/index.ts
@@ -7,7 +7,7 @@ export { Abort } from './Abort.js'
 export { shield } from './shield.js'
 export { onBug } from './runTelefunc/onBug.js'
 
-// In order to allow users to override `Telefunc.Context`, we need to export `Telefunc` (even if the user never imports `Telefunc`)
+// TO-DO/next-major-release: remove
 export type { Telefunc } from './getContext/TelefuncNamespace.js'
 
 export { decorateTelefunction as __decorateTelefunction } from './runTelefunc/decorateTelefunction.js'


### PR DESCRIPTION
## Overview

This branch advances Telefunc across several feature areas on top of `main`. It was just brought up to date by merging `origin/main` (the `declare module 'telefunc'` → `declare global` context-type migration, #279) and resolving two conflicts (`TODO`, `index.ts`).

The summary below is grouped from the branch's commit history.

## Main changes

**Real-time — Channel & Broadcast**
- Class-based `Channel` / `Broadcast` API (renamed from pub/sub), with broadcast shield validation
- SSE ↔ WebSocket two-phase upgrade with handshake ack; reconnect when `RECONCILED` never arrives on a stalled SSE wire
- Cross-instance support via a Redis backend; single-instance kernel that requires sticky sessions
- Adaptive BDP flow control in the wire protocol

**File downloads**
- Native `File`/`Blob` responses and a `download()` helper with progress reporting and cancellation

**Shield**
- Branded `ShieldValidationError`; runtime shields for `never` / `void` / `undefined`
- Symbol-keyed `[TELEFUNC_SHIELDS]` marker; rxjs sub-shield validation

**API / packaging**
- `new Telefunc()` factory for Cloudflare and node/bun/deno serve
- Extension hook `onTransformResult` → `onTelefunctionResult`
- Renamed extensions → integrations (docs + Redis/rxjs pages); `@telefunc/tanstack-query` uses `withTelefunc()` instead of subclassing `QueryClient`

**Docs & tests**
- New streaming/real-time docs and navigation; Channel vs Broadcast comparison
- e2e/playground stabilization (Docker Chromium network-change recovery, deflaking)

## Merge conflict resolution
- `packages/telefunc/node/server/index.ts`: kept origin/main's `// TO-DO/next-major-release: remove` comment, adapted to this branch's `getContext/` → `context/` module rename.
- `TODO`: dropped the "Re-apply global namespace usage commit" item — now done via #279, which auto-merged into `context/TelefuncNamespace.ts` — while keeping the branch's `before-merge` section.

https://claude.ai/code/session_015Y26wT8g9KVMpGexKegKvP

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y26wT8g9KVMpGexKegKvP)_