### PR TITLE
Remove descriptive text from "See also" link sections

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -408,9 +408,9 @@ config.channel = {
 
 ## See also
 
-- <Link href="/real-time" /> — choosing between function passing and channels
-- <Link href="/stream" /> — streaming server values
-- <Link href="/file-upload" /> — file uploads with progress
-- <Link href="/file-download" /> — streaming file downloads
-- <Link href="/transport" /> — transport configuration
-- <Link href="/cloudflare" /> — Cloudflare Workers with distributed broadcast
+- <Link href="/real-time" />
+- <Link href="/stream" />
+- <Link href="/file-upload" />
+- <Link href="/file-download" />
+- <Link href="/transport" />
+- <Link href="/cloudflare" />

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -212,6 +212,6 @@ config.channel = {
 
 ## See also
 
-- <Link href="/server" /> — serve API for all runtimes
-- <Link href="/channel" /> — `Channel` and `Broadcast` API
-- <Link href="/real-time" /> — real-time patterns
+- <Link href="/server" />
+- <Link href="/channel" />
+- <Link href="/real-time" />

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -212,6 +212,6 @@ The streaming download can only be consumed once — calling `.stream()`, `.byte
 
 ## See also
 
-- <Link href="/file-upload" /> — file uploads (client → server)
-- <Link href="/stream" /> — `ReadableStream` and `AsyncGenerator` returns
-- <Link href="/transport" /> — transport configuration
+- <Link href="/file-upload" />
+- <Link href="/stream" />
+- <Link href="/transport" />

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -173,8 +173,8 @@ File bytes only flow through memory when you read them — and if you stream to 
 
 ## See also
 
-- <Link href="/file-download" /> — file downloads
-- <Link href="/real-time" /> — function passing for progress callbacks
-- <Link href="/stream" /> — streaming server responses
-- <Link href="/channel" /> — bidirectional channels
-- <Link href="/transport" /> — transport configuration
+- <Link href="/file-download" />
+- <Link href="/real-time" />
+- <Link href="/stream" />
+- <Link href="/channel" />
+- <Link href="/transport" />

--- a/docs/pages/integrations/redis/+Page.mdx
+++ b/docs/pages/integrations/redis/+Page.mdx
@@ -44,6 +44,6 @@ Telefunc `duplicate()`s the client internally for its subscriber connection — 
 
 ## See also
 
-- <Link href="/scaling" /> — running Telefunc across multiple instances
-- <Link href="/channel" /> — `Channel` and `Broadcast` primitives
-- <Link href="/integrations" /> — other Telefunc integrations
+- <Link href="/scaling" />
+- <Link href="/channel" />
+- <Link href="/integrations" />

--- a/docs/pages/integrations/tanstack-query/+Page.mdx
+++ b/docs/pages/integrations/tanstack-query/+Page.mdx
@@ -139,7 +139,7 @@ Prefix matching — invalidating `['global:documents']` hits `['global:documents
 
 ## See also
 
-- <Link href="/channel" /> — `Channel` and `Broadcast`
-- <Link href="/integrations/redis" text={<code>@telefunc/redis</code>} /> — multi-server pub/sub
-- <Link href="/real-time" /> — real-time patterns
-- <Link href="/cloudflare" /> — Cloudflare Workers
+- <Link href="/channel" />
+- <Link href="/integrations/redis" text={<code>@telefunc/redis</code>} />
+- <Link href="/real-time" />
+- <Link href="/cloudflare" />

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -89,5 +89,5 @@ After deploying behind a sticky load balancer, open the browser network tab, ref
 
 ## See also
 
-- <Link href="/integrations/redis" /> — Redis broadcast transport
-- <Link href="/channel" /> — `Channel` and `Broadcast` primitives
+- <Link href="/integrations/redis" />
+- <Link href="/channel" />

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -77,5 +77,5 @@ For production deployments with channels and WebSocket support, use the runtime-
 
 ## See also
 
-- <Link href="/server" /> — server integration examples
-- <Link href="/getContext" /> — request context
+- <Link href="/server" />
+- <Link href="/getContext" />

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -195,5 +195,5 @@ See <Link href="/serve" /> for details.
 
 ## See also
 
-- <Link href="/serve" /> — core `serve()` function reference
-- <Link href="/getContext" /> — request context
+- <Link href="/serve" />
+- <Link href="/getContext" />

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -241,8 +241,8 @@ See <Link href="/error-handling" /> for details.
 
 ## See also
 
-- <Link href="/real-time" /> — function passing, channels, and upload progress
-- <Link href="/file-upload" /> — streaming file uploads
-- <Link href="/file-download" /> — streaming file downloads
-- <Link href="/channel" /> — bidirectional channels
-- <Link href="/transport" /> — transport comparison and configuration
+- <Link href="/real-time" />
+- <Link href="/file-upload" />
+- <Link href="/file-download" />
+- <Link href="/channel" />
+- <Link href="/transport" />

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -110,6 +110,6 @@ for await (const token of gen) {
 
 ## See also
 
-- <Link href="/stream" /> — streaming values
-- <Link href="/real-time" /> — real-time patterns
-- <Link href="/channel" /> — channel API
+- <Link href="/stream" />
+- <Link href="/real-time" />
+- <Link href="/channel" />


### PR DESCRIPTION
## Summary
Simplified the "See also" sections across documentation pages by removing descriptive text from link items, keeping only the link references themselves.

## Changes
- Removed descriptive text (e.g., "— choosing between function passing and channels") from all "See also" link items across 11 documentation pages
- Affected pages:
  - `/channel`
  - `/file-upload`
  - `/stream`
  - `/integrations/tanstack-query`
  - `/cloudflare`
  - `/file-download`
  - `/integrations/redis`
  - `/transport`
  - `/scaling`
  - `/serve`
  - `/server`

## Rationale
This change streamlines the documentation by removing redundant descriptions from "See also" sections. The link text itself (e.g., "real-time", "stream", "channel") is now sufficient for users to understand the related topics, reducing visual clutter while maintaining the same navigation functionality.

https://claude.ai/code/session_01XkEwXS5ho1EgZwVYMWtCGF