### PR TITLE
Remove /integrations link references from documentation

### DIFF
--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -46,4 +46,3 @@ Telefunc `duplicate()`s the client internally for its subscriber connection — 
 
 - <Link href="/scaling" />
 - <Link href="/channel" />
-- <Link href="/integrations" />

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -199,4 +199,3 @@ Unsubscribing stops data flow immediately. The underlying <Link href="/channel" 
 ## See also
 
 - <Link href="/real-time" />
-- <Link href="/integrations" />


### PR DESCRIPTION
## Summary
Removed references to the `/integrations` documentation page from two documentation files.

## Changes
- Removed `/integrations` link from Redis documentation page
- Removed `/integrations` link from RxJS documentation page

## Details
These changes remove "See also" references to an integrations page that may no longer be relevant or available in the documentation structure. The links were removed from the related resources sections at the end of both the Redis and RxJS documentation pages.

https://claude.ai/code/session_015DJeRFQSVmoQcUMudcZz3q