### PR TITLE
Clarify streaming and download behavior in documentation

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -15,7 +15,7 @@ import { onLoadDashboard } from './Dashboard.telefunc'
 const result = await onLoadDashboard()
 
 // Read what you need...
-const first = await result.stream.next()
+const { value } = await result.stream.next()
 
 // Then close everything at once
 close(result)

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -13,7 +13,7 @@ Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Bl
 | `download(file)` / `download(blob)` | Full payload | Depends on consumer<sup>†</sup> | Same + progress / cancel / save-to-disk |
 | `download(stream, opts)` | Constant (chunk-sized) | Depends on consumer<sup>†</sup> | Bytes streamed from upstream (S3, CDN, …) |
 
-<sup>†</sup> Constant when consumed via `dl.stream()` / `dl.saveToDisk()` / `dl.saveToOpfs()`; full payload when consumed via `dl.saveToMemory()` / `dl.text()` / `dl.arrayBuffer()`.
+<sup>†</sup> Constant when consumed via `dl.stream()`, `dl.saveToOpfs()`, or `dl.saveToDisk()` (except its `'memory'` fallback); full payload when consumed via `dl.saveToMemory()` / `dl.text()` / `dl.arrayBuffer()`.
 
 
 ## Example
@@ -134,10 +134,12 @@ The streaming download is a standard [`File`](https://developer.mozilla.org/en-U
 | `dl.arrayBuffer()` | `ArrayBuffer` | Full file in memory | Process entire file at once |
 | `dl.text()` | `string` | Full file in memory | Read text content |
 | `dl.saveToMemory()` | `File` / `Blob`<sup>‡</sup> | Full file in memory | Use with Web APIs (`URL.createObjectURL`, `<img src>`, ...) |
-| `dl.saveToDisk(opts?)` | `File` (disk-backed) | Constant (chunk-sized) | Save to user's filesystem (picker or Downloads folder) |
+| `dl.saveToDisk(opts?)` | `File` (disk-backed) | Constant<sup>§</sup> | Save to user's filesystem (picker or Downloads folder) |
 | `dl.saveToOpfs(path?)` | `File` (disk-backed) | Constant (chunk-sized) | Stash in browser-private storage [(OPFS)](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) |
 
 <sup>‡</sup> `File` for `FileDownload`, `Blob` for `BlobDownload`.
+
+<sup>§</sup> Constant in `'picker'` / `'opfs'` mode; the `'memory'` fallback (default when `showSaveFilePicker` is unavailable) buffers the full file in RAM.
 
 > For large files, prefer `dl.stream()` / `dl.saveToDisk()` / `dl.saveToOpfs()` — memory stays constant regardless of file size.
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 For reactive streams with full operator support, you can use [RxJS](https://rxjs.dev).
 
-The `@telefunc/rxjs` integration lets you pass all RxJS operators, such as `Observable` and `Subject`, transparently between client and server — both directions.
+The `@telefunc/rxjs` integration lets you pass RxJS `Observable`s and `Subject`s transparently between client and server, in both directions.
 
 > Each value emitted into a client-side `Subject<T>` is **shield-validated at runtime** when it arrives at the server, against the `T` from your TypeScript types. Terminal signals (`error`, `complete`) are untyped and pass through unshielded — see <Link href="#shields" />.
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -1,7 +1,7 @@
 import { Link } from '@brillout/docpress'
 
 Telefunc supports streaming in both directions:
-- **Server → client**: Return `AsyncGenerator`, `ReadableStream`, or nested `Promise` from a telefunction.
+- **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
 > Streaming works out of the box with zero config. Plain telefunction calls are unaffected.


### PR DESCRIPTION
## Summary
This PR improves the accuracy and clarity of documentation around streaming, downloads, and memory usage patterns across multiple pages.

## Key Changes
- **File Download page**: Clarified that `dl.saveToDisk()` has a `'memory'` fallback mode that buffers the full file in RAM when `showSaveFilePicker` is unavailable, and updated the footnote to reflect this distinction
- **Close page**: Fixed code example to properly destructure the `value` property from `stream.next()` result
- **RxJS page**: Improved grammar and clarity in the description of RxJS integration capabilities
- **Stream page**: Expanded the list of supported return types for server-to-client streaming to include `File`, `Blob`, and `download()` results

## Notable Details
- The memory usage footnote now accurately distinguishes between constant memory usage in `'picker'` and `'opfs'` modes versus the full-file buffering that occurs in the `'memory'` fallback mode
- Documentation now more comprehensively lists all streaming-capable return types from telefunctions

https://claude.ai/code/session_01JeN3imh8efMoohVQnmCsuv