### PR TITLE
Improve resilience of e2e navigation with retry delays and error detection

### DIFF
--- a/test/playground-streaming/e2e-utils.ts
+++ b/test/playground-streaming/e2e-utils.ts
@@ -53,7 +53,8 @@ async function getCleanupState(): Promise<Record<string, string>> {
  * `page.goto()` that retries the navigation on transient Chromium-in-Docker network errors.
  * Right after the containers come up, Chromium's `NetworkChangeNotifier` can abort the in-flight
  * navigation with `ERR_NETWORK_CHANGED` (and connection-family friends) when the Docker bridge
- * interface state shifts. Re-navigating recovers, so retry a few times before giving up.
+ * interface state shifts — sometimes surfacing as a bounce to `chrome-error://chromewebdata/`
+ * (see `isTransientNetworkError`). Re-navigating recovers, so retry a few times before giving up.
  */
 async function resilientGoto(url: string, options?: Parameters<typeof page.goto>[1]) {
   for (let attempt = 0; attempt < 4; attempt++) {
@@ -62,6 +63,9 @@ async function resilientGoto(url: string, options?: Parameters<typeof page.goto>
       return
     } catch (err) {
       if (attempt === 3 || !isTransientNetworkError(err)) throw err
+      // Pause before retrying so the next navigation lands after the bridge interface shift has
+      // settled, instead of hammering the same broken window with back-to-back attempts.
+      await sleep(500)
     }
   }
 }
@@ -100,6 +104,11 @@ const transientNetworkErrors = [
 ]
 function isTransientNetworkError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
+  // When a transient network error aborts an in-flight navigation, Chromium bounces to its internal
+  // error page and Playwright reports the original navigation as "interrupted by another navigation
+  // to chrome-error://chromewebdata/" — without surfacing the underlying ERR_* code. Treat that
+  // bounce as transient too, so the navigation still gets retried.
+  if (message.includes('chrome-error://chromewebdata')) return true
   return transientNetworkErrors.some((code) => message.includes(code))
 }
 


### PR DESCRIPTION
## Summary
Enhanced the `resilientGoto()` function to better handle transient network errors that occur during e2e test navigation in containerized environments. The changes add a retry delay and improve detection of network errors that manifest as bounces to Chrome's internal error page.

## Key Changes
- **Added retry delay**: Introduced a 500ms pause between navigation retry attempts to allow the Docker bridge interface to stabilize before retrying, preventing repeated failures against the same broken state
- **Improved error detection**: Extended `isTransientNetworkError()` to recognize when Chromium bounces to `chrome-error://chromewebdata/` as a result of transient network errors, since Playwright doesn't surface the underlying ERR_* code in these cases
- **Enhanced documentation**: Updated comments to explain the Docker bridge interface state shift behavior and the chrome-error bounce scenario

## Implementation Details
The changes address a specific issue in containerized test environments where Chromium's `NetworkChangeNotifier` can abort in-flight navigations when the Docker bridge interface state changes. Previously, the code would retry immediately, but the interface might still be unstable. Now it waits 500ms between attempts. Additionally, when such errors occur, Chromium may redirect to its internal error page rather than reporting the original error code, so the error detection now explicitly checks for this bounce pattern.

https://claude.ai/code/session_011gf8AcsMtbMRBTgBo8rVhy