### PR TITLE
docs: fix and strengthen `See also` cross-links

### DIFF
--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -212,6 +212,7 @@ config.channel = {
 
 ## See also
 
+- <Link href="/scaling" />
 - <Link href="/server" />
 - <Link href="/channel" />
 - <Link href="/real-time" />

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -232,5 +232,6 @@ const response = await fetch(url, { signal: context.signal })
 
 ## See also
 
+- <Link href="/permissions" />
 - <Link href="/server" />
-- <Link href="/getContext" />
+- <Link href="/close" />

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -199,3 +199,5 @@ Unsubscribing stops data flow immediately. The underlying <Link href="/channel" 
 ## See also
 
 - <Link href="/real-time" />
+- <Link href="/channel" />
+- <Link href="/stream" />

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -90,4 +90,5 @@ After deploying behind a sticky load balancer, open the browser network tab, ref
 ## See also
 
 - <Link href="/redis" />
+- <Link href="/cloudflare" />
 - <Link href="/channel" />


### PR DESCRIPTION
Reviewed the new streaming/real-time docs as a first-time visitor. The pages are already well-structured, so this PR is small — it fixes the bottom-of-page `See also` navigation, which is what a first-time visitor relies on to hop between related pages.

Targets `nitedani/streaming` (the branch that introduces these pages), so the diff is docs-only (4 files, +6/−1).

## Changes (`See also`)

- **`getContext`** — its `See also` linked to **itself**; now points to `permissions` (the primary use case), `server`, and `close`.
- **`scaling` ↔ `cloudflare`** — the two deployment pages discuss each other in-body but didn't cross-link; added reciprocal links.
- **`rxjs`** — had a single `See also` link while every sibling page has several; added `channel` and `stream`.

## Verification

- `tsc --noEmit` on the docs — clean.
- Full `vike build` — clean; docpress validated every internal `Link`, so all cross-references resolve.

> Note: an earlier revision also reorganized the Guides sidebar (`docs/headings.ts`) into a "Deployment" group; that was reverted at the maintainer's request and is no longer part of this PR.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T