### PR TITLE
docs: tidy within-page structure in the streaming docs

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -253,7 +253,7 @@ const unsub = Broadcast.subscribe('room:lobby', (msg, info) => {
 })
 ```
 
-### API
+### Methods
 
 | Method | Description |
 |---|---|

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -236,3 +236,8 @@ await chat.publish({ user: 'Alice', text: 'Hello!' })
 ```
 
 Server-side `publish()` calls (from inside a telefunction or via the static `Broadcast.publish(key, data)`) are not shield-validated — the server is the trust boundary, so values originating there flow through as-is.
+
+
+## See also
+
+- <Link href="/permissions" />


### PR DESCRIPTION
Follow-up to #297 (merged). A within-page structure pass over the new streaming/real-time docs as a first-time visitor. The pages are carefully structured, so this is small — two genuine consistency gaps:

| Page | Fix | Why |
|---|---|---|
| `channel` | rename Broadcast's `### API` → `### Methods` | The two parallel primitives named the same concept differently — `new Channel()` has `### Methods`, `new Broadcast()` had `### API`. |
| `shield` | add the missing `## See also` footer | It was the only new/expanded API reference page that ended abruptly with no footer. |

The `shield` footer points **only** to `/permissions` — the complementary protection topic (shield validates argument *types/values*; permissions handles *authorization*). The other related pages (`RPC`, `channel`, `rxjs`) are already linked inline in the body, so they're not repeated in `See also`.

## What I reviewed

Extracted the heading hierarchy of all 17 new/modified pages. They hold up well:
- Decision tables (`Which one should I use?`) match the section order that follows them.
- Parallel `H3`s are used consistently (`real-time`, `file-upload`/`file-download`, `scaling`, `server`).
- `cloudflare`'s "Architecture before Scaling" order is **correct** — Scaling references the *region* concept Architecture defines, so it can't move earlier.

## Verification

- `tsc --noEmit` on the docs — clean.
- Full `vike build` — clean; docpress validated every internal `Link`.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T