### PR TITLE
Add resilient channel handshake and navigation for Docker e2e tests

### DIFF
--- a/test/playground-streaming/.testRun-docker.ts
+++ b/test/playground-streaming/.testRun-docker.ts
@@ -2,7 +2,7 @@ export { testRunDocker }
 
 import { page, test, expect, run, skip, isCI, getServerUrl, autoRetry } from '@brillout/test-e2e'
 import { execSync } from 'node:child_process'
-import { resilientGoto, waitForHydration } from './e2e-utils'
+import { navigate } from './e2e-utils'
 import { testCounter } from '../utils'
 import { testFileUpload } from './pages/file-upload/e2e-test'
 import { testFileDownload } from './pages/file-download/e2e-test'
@@ -73,8 +73,7 @@ function testRunDocker() {
   })
 
   test('home page', async () => {
-    await resilientGoto(`${getServerUrl()}/`, { waitUntil: 'load' })
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/`, { waitUntil: 'load' })
     await autoRetry(
       async () => {
         expect(await page.textContent('h1')).toBe('Welcome')

--- a/test/playground-streaming/.testRun.ts
+++ b/test/playground-streaming/.testRun.ts
@@ -1,6 +1,7 @@
 export { testRun }
 
 import { page, test, expect, run, getServerUrl, autoRetry } from '@brillout/test-e2e'
+import { navigate } from './e2e-utils'
 import { testCounter } from '../utils'
 import { testFileUpload } from './pages/file-upload/e2e-test'
 import { testFileDownload } from './pages/file-download/e2e-test'
@@ -53,7 +54,7 @@ function testRun(cmd: 'pnpm dev' | 'pnpm preview') {
   const isDev = cmd === 'pnpm dev'
 
   test('home page', async () => {
-    await page.goto(`${getServerUrl()}/`)
+    await navigate(`${getServerUrl()}/`)
     await autoRetry(async () => {
       expect(await page.textContent('h1')).toBe('Welcome')
     })

--- a/test/playground-streaming/e2e-utils.ts
+++ b/test/playground-streaming/e2e-utils.ts
@@ -1,16 +1,6 @@
-export {
-  resetCleanupState,
-  getCleanupState,
-  resilientGoto,
-  waitForHydration,
-  getResult,
-  sleep,
-  restartProxy,
-  stopProxy,
-  startProxy,
-}
+export { resetCleanupState, getCleanupState, navigate, getResult, sleep, restartProxy, stopProxy, startProxy }
 
-import { page, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
+import { page, getServerUrl } from '@brillout/test-e2e'
 import { execSync } from 'node:child_process'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -50,46 +40,46 @@ async function getCleanupState(): Promise<Record<string, string>> {
 }
 
 /**
- * `page.goto()` that retries the navigation on transient Chromium-in-Docker network errors.
- * Right after the containers come up, Chromium's `NetworkChangeNotifier` can abort the in-flight
- * navigation with `ERR_NETWORK_CHANGED` (and connection-family friends) when the Docker bridge
- * interface state shifts — sometimes surfacing as a bounce to `chrome-error://chromewebdata/`
- * (see `isTransientNetworkError`). Re-navigating recovers, so retry a few times before giving up.
+ * Loads a page and waits for it to hydrate — resiliently, because the Docker suite runs the browser
+ * against a Caddy container over the Docker bridge.
+ *
+ * When the bridge interface state shifts — right after the containers come up, and right after a
+ * reconnect test restarts the proxy (`restartProxy`/`startProxy`) — Chromium's `NetworkChangeNotifier`
+ * aborts whatever request is in flight with a transient `ERR_*` (see `isTransientNetworkError`). That
+ * can kill the navigation outright, or drop an asset fetch so the page never hydrates. Re-navigating
+ * recovers from both, so retry the navigate-and-hydrate as a unit before giving up.
+ *
+ * This is the navigation half of the suite's Docker-resilience story; the channel handshake half lives
+ * in `openChannel()` (pages/channel/Channel.tsx), which retries the telefunc call the same aborts can
+ * kill. Steady-state message delivery needs no such retry — telefunc's own reconnect/replay covers it.
+ *
+ * `target` defaults to the shared `page`; pass another page to load a second tab/context resiliently.
  */
-async function resilientGoto(url: string, options?: Parameters<typeof page.goto>[1]) {
-  for (let attempt = 0; attempt < 4; attempt++) {
+async function navigate(url: string, options?: Parameters<typeof page.goto>[1], target: typeof page = page) {
+  for (let attempt = 1; attempt <= NAVIGATE_ATTEMPTS; attempt++) {
+    const lastAttempt = attempt === NAVIGATE_ATTEMPTS
     try {
-      await page.goto(url, options)
+      await target.goto(url, options)
+    } catch (err) {
+      // A transient bridge error aborted the navigation itself; re-navigate. Surface anything else.
+      if (lastAttempt || !isTransientNetworkError(err)) throw err
+      await sleep(NAVIGATE_RETRY_DELAY)
+      continue
+    }
+    try {
+      await target.locator('#hydrated').waitFor({ state: 'attached', timeout: HYDRATION_TIMEOUT })
       return
     } catch (err) {
-      if (attempt === 3 || !isTransientNetworkError(err)) throw err
-      // Pause before retrying so the next navigation lands after the bridge interface shift has
-      // settled, instead of hammering the same broken window with back-to-back attempts.
-      await sleep(500)
+      // Navigated, but an asset fetch was dropped on the bridge shift so the page never hydrated.
+      // Re-navigate to refetch the missing chunks; the pause lets the interface shift settle first.
+      if (lastAttempt) throw err
+      await sleep(NAVIGATE_RETRY_DELAY)
     }
   }
 }
-
-async function waitForHydration() {
-  // Chromium-in-Docker can drop in-flight asset fetches with `ERR_NETWORK_CHANGED`
-  // when the bridge interface state shifts, leaving the page un-hydrated. Retry
-  // the navigation a few times before giving up.
-  for (let attempt = 0; attempt < 4; attempt++) {
-    try {
-      await page.locator('#hydrated').waitFor({ state: 'attached', timeout: 5_000 })
-      return
-    } catch {
-      if (attempt === 3) throw new Error('Page never hydrated after 4 attempts')
-      // The reload can itself hit a transient `ERR_NETWORK_CHANGED`; swallow it and let the
-      // next attempt retry, instead of failing the whole test on the recovery step.
-      try {
-        await page.reload({ waitUntil: 'load' })
-      } catch (err) {
-        if (!isTransientNetworkError(err)) throw err
-      }
-    }
-  }
-}
+const NAVIGATE_ATTEMPTS = 4
+const HYDRATION_TIMEOUT = 5_000
+const NAVIGATE_RETRY_DELAY = 500
 
 // Transient errors Chromium-in-Docker surfaces when the bridge interface state shifts. Mirrors
 // the connection-family errors `.testRun-docker.ts`'s `tolerateError()` already allows in logs.

--- a/test/playground-streaming/pages/abort/e2e-test.ts
+++ b/test/playground-streaming/pages/abort/e2e-test.ts
@@ -1,7 +1,7 @@
 export { testAbort }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { resetCleanupState, getCleanupState, waitForHydration, getResult } from '../../e2e-utils'
+import { resetCleanupState, getCleanupState, navigate, getResult } from '../../e2e-utils'
 
 /** Max elapsed time (ms) from t0 to server-side cleanup completion. */
 const ABORT_DEADLINE_MS = 2000
@@ -10,8 +10,7 @@ function testAbort() {
   // ── Generator abort mechanisms ──────────────────────────────────────
 
   test('abort: generator via abort(gen)', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     const t0 = Date.now()
@@ -32,8 +31,7 @@ function testAbort() {
   })
 
   test('abort: generator via gen.return()', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     const t0 = Date.now()
@@ -54,8 +52,7 @@ function testAbort() {
   })
 
   test('abort: generator via withContext(gen, signal)', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     const t0 = Date.now()
@@ -78,8 +75,7 @@ function testAbort() {
   // ── Stream abort mechanisms ─────────────────────────────────────────
 
   test('abort: stream via reader.cancel()', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     const t0 = Date.now()
@@ -100,8 +96,7 @@ function testAbort() {
   })
 
   test('abort: stream via withContext(stream, signal)', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     const t0 = Date.now()
@@ -124,8 +119,7 @@ function testAbort() {
   // ── Non-streaming abort ─────────────────────────────────────────────
 
   test('abort: non-streaming telefunc — client call throws Abort', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     await page.click('#test-slow-normal-telefunc')
@@ -147,8 +141,7 @@ function testAbort() {
 
   // 1MB file with sleep(100) between reads — client aborts at 300ms
   test('abort: single file upload — client cancel, server disconnect error', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     await page.click('#test-upload-abort-single')
@@ -170,8 +163,7 @@ function testAbort() {
   // Three 50MB files — file1 consumed fully, client aborts at 3s during
   // post-file1 sleep, file2+file3 error on disconnect
   test('abort: multiple file upload — file1 received, file2+file3 error on disconnect', async () => {
-    await page.goto(`${getServerUrl()}/abort`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/abort`)
     await resetCleanupState()
 
     await page.click('#test-upload-abort-multiple')

--- a/test/playground-streaming/pages/channel/Channel.tsx
+++ b/test/playground-streaming/pages/channel/Channel.tsx
@@ -1,7 +1,7 @@
 export { ChannelDemo }
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Abort as TelefuncAbort, abort } from 'telefunc/client'
+import { Abort as TelefuncAbort, abort, ConnectionError } from 'telefunc/client'
 import {
   onChannelInit,
   onChannelAbortTest,
@@ -26,6 +26,36 @@ import {
   onChannelShieldClient,
   onChannelShieldServerAck,
 } from './Channel.telefunc'
+
+/**
+ * Establishes a channel, retrying if the handshake's HTTP round-trip is dropped.
+ *
+ * Opening a channel is a one-shot telefunc call. In the Docker e2e environment, Chromium's
+ * NetworkChangeNotifier aborts in-flight requests with a transient `ConnectionError` when the Docker
+ * bridge interface shifts — most notably right after a reconnect test restarts the proxy container.
+ * If that abort lands on a channel handshake the channel never comes back, so retry until it does.
+ *
+ * This is the channel-handshake half of the suite's Docker-resilience story; the navigation half
+ * lives in `navigate()` (../../e2e-utils.ts). Steady-state message delivery needs no such retry —
+ * telefunc's own reconnect/replay covers it. Retrying the handshake is safe: each attempt opens an
+ * independent channel, so a superseded half-open one merely gets reaped server-side after its grace
+ * period.
+ */
+async function openChannel<T>(open: () => Promise<T>): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= OPEN_CHANNEL_ATTEMPTS; attempt++) {
+    try {
+      return await open()
+    } catch (err) {
+      if (!(err instanceof ConnectionError)) throw err
+      lastErr = err
+      await new Promise((resolve) => setTimeout(resolve, OPEN_CHANNEL_RETRY_DELAY_MS))
+    }
+  }
+  throw lastErr
+}
+const OPEN_CHANNEL_ATTEMPTS = 4
+const OPEN_CHANNEL_RETRY_DELAY_MS = 500
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -256,7 +286,7 @@ function ChannelDemo() {
   const connect = useCallback(async () => {
     if (channelRef.current && !channelRef.current.isClosed) return
     addLog('system', 'Calling onChannelInit()...')
-    const result = await onChannelInit()
+    const result = await openChannel(onChannelInit)
     initResultRef.current = result
     const { channel, serverTime } = result
     channelRef.current = channel
@@ -349,7 +379,7 @@ function ChannelDemo() {
 
   const testServerAbort = useCallback(async () => {
     addLog('system', 'Starting server-abort test...')
-    const { channel } = await onChannelAbortTest()
+    const { channel } = await openChannel(onChannelAbortTest)
     abortChannelRef.current = channel
     channel.onClose((err) => {
       const e = err as any
@@ -366,7 +396,7 @@ function ChannelDemo() {
 
   const testPerSendAck = useCallback(async () => {
     addLog('system', 'Starting per-send ack test...')
-    const { channel } = await onChannelPerSendAck()
+    const { channel } = await openChannel(onChannelPerSendAck)
     perSendChannelRef.current = channel
     const ack = await channel.send('per-send-test', { ack: true })
     addLog('system', `per-send ack: ${JSON.stringify(ack)}`)
@@ -376,7 +406,7 @@ function ChannelDemo() {
 
   const testHookInstrument = useCallback(async () => {
     addLog('system', 'Starting hook instrumentation test...')
-    const { channel, channelId } = await onChannelHookInstrument()
+    const { channel, channelId } = await openChannel(onChannelHookInstrument)
     hookChannelRef.current = channel
     setChannelState((s) => ({ ...s, hookChannelId: channelId }))
     channel.onClose((err) => {
@@ -394,7 +424,7 @@ function ChannelDemo() {
 
   const testMultiChannel = useCallback(async () => {
     addLog('system', 'Starting multi-channel test...')
-    const { channel1, channel2 } = await onChannelMulti()
+    const { channel1, channel2 } = await openChannel(onChannelMulti)
     multiCh1Ref.current = channel1
     multiCh2Ref.current = channel2
     let ch1Prev = 0
@@ -438,7 +468,7 @@ function ChannelDemo() {
     }
 
     addLog('system', 'Starting client-abort-server test...')
-    const { channel, channelId } = await onChannelClientAbortInstrument()
+    const { channel, channelId } = await openChannel(onChannelClientAbortInstrument)
     clientAbortServerChannelRef.current = channel
     setChannelState((s) => ({ ...s, clientAbortServerChannelId: channelId }))
     channel.abort()
@@ -448,7 +478,7 @@ function ChannelDemo() {
 
   const openClientAbortServerChannel = useCallback(async () => {
     addLog('system', 'Starting client-abort-server test...')
-    const { channel, channelId } = await onChannelClientAbortInstrument()
+    const { channel, channelId } = await openChannel(onChannelClientAbortInstrument)
     channel.onOpen(() => {
       addLog('system', `client-abort-server channel acknowledged: ${channelId}`)
       setChannelState((s) => ({ ...s, clientAbortServerOnOpenFired: true }))
@@ -460,7 +490,7 @@ function ChannelDemo() {
 
   const testEarlyClose = useCallback(async () => {
     addLog('system', 'Starting early-close test...')
-    const { channel, channelId } = await onChannelHookInstrument()
+    const { channel, channelId } = await openChannel(onChannelHookInstrument)
     setChannelState((s) => ({ ...s, earlyCloseChannelId: channelId }))
     channel.close()
     addLog('system', `early close() sent for channel ${channelId}`)
@@ -468,7 +498,7 @@ function ChannelDemo() {
 
   const testBinary = useCallback(async () => {
     addLog('system', 'Starting binary round-trip test...')
-    const { channel } = await onChannelBinary()
+    const { channel } = await openChannel(onChannelBinary)
     binaryChannelRef.current = channel
     const PATTERN_SIZE = 256
     const REPEAT = 4096 // 1 MB
@@ -497,7 +527,7 @@ function ChannelDemo() {
 
   const testAckListenerAbort = useCallback(async () => {
     addLog('system', 'Starting ack-listener-abort test...')
-    const { channel } = await onChannelAckListenerAbort()
+    const { channel } = await openChannel(onChannelAckListenerAbort)
     ackListenerAbortChannelRef.current = channel
     try {
       await channel.send('trigger', { ack: true })
@@ -518,7 +548,7 @@ function ChannelDemo() {
 
   const testAckListenerBug = useCallback(async () => {
     addLog('system', 'Starting ack-listener-bug test...')
-    const { channel } = await onChannelAckListenerBug()
+    const { channel } = await openChannel(onChannelAckListenerBug)
     ackListenerBugChannelRef.current = channel
     try {
       await channel.send('bug', { ack: true })
@@ -536,7 +566,7 @@ function ChannelDemo() {
 
   const testClientAckListenerBug = useCallback(async () => {
     addLog('system', 'Starting client-ack-listener-bug test...')
-    const { channel, channelId } = await onChannelClientAckListenerBug()
+    const { channel, channelId } = await openChannel(onChannelClientAckListenerBug)
     clientAckListenerBugChannelRef.current = channel
     setChannelState((s) => ({ ...s, clientAckListenerBugChannelId: channelId }))
     channel.listen((msg) => {
@@ -550,7 +580,7 @@ function ChannelDemo() {
 
   const testServerPendingAckAbort = useCallback(async () => {
     addLog('system', 'Starting server-pending-ack-abort test...')
-    const { channel, channelId } = await onChannelServerPendingAckAbort()
+    const { channel, channelId } = await openChannel(onChannelServerPendingAckAbort)
     serverPendingAckAbortChannelRef.current = channel
     setChannelState((s) => ({ ...s, serverPendingAckAbortChannelId: channelId }))
     channel.listen(() => new Promise(() => {}))
@@ -563,7 +593,7 @@ function ChannelDemo() {
 
   const testAbortThenSend = useCallback(async () => {
     addLog('system', 'Starting server abort-then-send test...')
-    const { channel, channelId } = await onChannelAbortThenSend()
+    const { channel, channelId } = await openChannel(onChannelAbortThenSend)
     abortThenSendChannelRef.current = channel
     setChannelState((s) => ({ ...s, abortThenSendChannelId: channelId }))
     channel.onClose(() => {
@@ -573,7 +603,7 @@ function ChannelDemo() {
 
   const testPendingAckAbort = useCallback(async () => {
     addLog('system', 'Starting server pending-ack-abort test...')
-    const { channel, channelId } = await onChannelPendingAckAbort()
+    const { channel, channelId } = await openChannel(onChannelPendingAckAbort)
     pendingAckAbortChannelRef.current = channel
     setChannelState((s) => ({ ...s, pendingAckAbortChannelId: channelId }))
     channel.onClose(() => {
@@ -583,7 +613,7 @@ function ChannelDemo() {
 
   const testClientAbortThenSend = useCallback(async () => {
     addLog('system', 'Starting client abort-then-send test...')
-    const { channel } = await onChannelClientAbortThenSend()
+    const { channel } = await openChannel(onChannelClientAbortThenSend)
     clientAbortThenSendChannelRef.current = channel
     channel.onOpen(() => {
       channel.abort()
@@ -599,7 +629,7 @@ function ChannelDemo() {
 
   const testClientPendingAckClose = useCallback(async () => {
     addLog('system', 'Starting client pending-ack-close test...')
-    const { channel } = await onChannelClientPendingAckClose()
+    const { channel } = await openChannel(onChannelClientPendingAckClose)
     clientPendingAckCloseChannelRef.current = channel
     channel.onOpen(async () => {
       const p = channel.send('test', { ack: true })
@@ -616,7 +646,7 @@ function ChannelDemo() {
 
   const openClientPendingAckCloseReconnectChannel = useCallback(async () => {
     addLog('system', 'Starting client pending-ack-close reconnect test...')
-    const { channel, channelId } = await onChannelClientPendingAckCloseReconnect()
+    const { channel, channelId } = await openChannel(onChannelClientPendingAckCloseReconnect)
     channel.onOpen(() => {
       addLog('system', `client-pending-ack-close reconnect channel acknowledged: ${channelId}`)
       setChannelState((s) => ({ ...s, clientPendingAckCloseReconnectOnOpenFired: true }))
@@ -652,7 +682,7 @@ function ChannelDemo() {
 
   const openServerPendingAckCloseReconnectChannel = useCallback(async () => {
     addLog('system', 'Starting server pending-ack-close reconnect test...')
-    const { channel, channelId } = await onChannelServerPendingAckCloseReconnectOpen()
+    const { channel, channelId } = await openChannel(onChannelServerPendingAckCloseReconnectOpen)
     channel.onOpen(() => {
       addLog('system', `server-pending-ack-close reconnect channel acknowledged: ${channelId}`)
       setChannelState((s) => ({ ...s, serverPendingAckCloseReconnectOnOpenFired: true }))
@@ -675,7 +705,7 @@ function ChannelDemo() {
 
   const testUpstreamReconnectOpen = useCallback(async () => {
     addLog('system', 'Opening upstream-reconnect channel...')
-    const { channel, channelId } = await onChannelUpstreamReconnect()
+    const { channel, channelId } = await openChannel(onChannelUpstreamReconnect)
     upstreamReconnectChannelRef.current = channel
     upstreamReconnectSeqRef.current = 0
     setChannelState((s) => ({ ...s, upstreamReconnectChannelId: channelId }))
@@ -692,7 +722,7 @@ function ChannelDemo() {
 
   const testNoListenerAckServer = useCallback(async () => {
     addLog('system', 'Starting no-listener-ack-server test...')
-    const { channel, channelId } = await onChannelNoListenerAckServer()
+    const { channel, channelId } = await openChannel(onChannelNoListenerAckServer)
     setChannelState((s) => ({ ...s, noListenerAckServerChannelId: channelId }))
     // No listener — server's send({ ack: true }) should reject
     channel.onClose(() => {
@@ -702,7 +732,7 @@ function ChannelDemo() {
 
   const testNoListenerAckClient = useCallback(async () => {
     addLog('system', 'Starting no-listener-ack-client test...')
-    const { channel } = await onChannelNoListenerAckClient()
+    const { channel } = await openChannel(onChannelNoListenerAckClient)
     channel.onOpen(async () => {
       try {
         await channel.send('hello', { ack: true })
@@ -717,7 +747,7 @@ function ChannelDemo() {
 
     // ── A1/A2/B1/B2 — client sends, server validates incoming data ────────────
     {
-      const { channel, getReceived } = await onChannelShieldClient()
+      const { channel, getReceived } = await openChannel(onChannelShieldClient)
       await new Promise<void>((resolve) => channel.onOpen(resolve))
 
       // A1: valid no-ack — server listener should receive.
@@ -755,7 +785,7 @@ function ChannelDemo() {
 
     // ── C1 — server sends, client listener returns valid ──────────────────────
     {
-      const { channel, trigger, getOutcome } = await onChannelShieldServerAck()
+      const { channel, trigger, getOutcome } = await openChannel(onChannelShieldServerAck)
       channel.listen((msg: number) => `got-${msg}`)
       await trigger()
       const outcome = await getOutcome()
@@ -764,7 +794,7 @@ function ChannelDemo() {
 
     // ── C2 — server sends, client listener returns invalid (wrong type) ───────
     {
-      const { channel, trigger, getOutcome } = await onChannelShieldServerAck()
+      const { channel, trigger, getOutcome } = await openChannel(onChannelShieldServerAck)
       ;(channel.listen as any)((msg: number) => msg * 9) // returns number, expected string
       await trigger()
       const outcome = await getOutcome()

--- a/test/playground-streaming/pages/channel/e2e-test.ts
+++ b/test/playground-streaming/pages/channel/e2e-test.ts
@@ -1,7 +1,7 @@
 export { testChannel }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult, getCleanupState, restartProxy, stopProxy, startProxy } from '../../e2e-utils'
+import { navigate, getResult, getCleanupState, restartProxy, stopProxy, startProxy } from '../../e2e-utils'
 
 type ChannelState = {
   connected: boolean
@@ -90,8 +90,7 @@ function testChannel(isDev: boolean, inDocker = false) {
   // ── Basic connection ─────────────────────────────────────────────────
 
   test('channel: connect — client onOpen fires, server responds with welcome via ping', async () => {
-    await page.goto(`${getServerUrl()}/channel`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/channel`)
 
     await page.click('#channel-connect')
 
@@ -287,8 +286,7 @@ function testChannel(isDev: boolean, inDocker = false) {
 
   if (!isDev) {
     test('channel: reconnect — ticks resume after network goes offline then online', async () => {
-      await page.goto(`${getServerUrl()}/channel`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/channel`)
       await page.click('#channel-connect')
       await autoRetry(async () => {
         const state = await getResult<ChannelState>('#channel-state')
@@ -340,8 +338,7 @@ function testChannel(isDev: boolean, inDocker = false) {
 
   if (!isDev) {
     test('channel: reconnect — client messages sent while offline are delivered exactly once after reconnect', async () => {
-      await page.goto(`${getServerUrl()}/channel`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/channel`)
 
       // Open the upstream channel (client→server only, no server ticks)
       await page.click('#channel-test-upstream-open')
@@ -410,8 +407,7 @@ function testChannel(isDev: boolean, inDocker = false) {
   // owning playground container in a cluster regardless. Leave for the single-instance paths.
   if (!isDev && !inDocker) {
     test('channel: reconnect + close — client onClose stays clean when server closes with pending ack while client is offline', async () => {
-      await page.goto(`${getServerUrl()}/channel`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/channel`)
       await page.click('#channel-connect')
       await autoRetry(async () => {
         const state = await getResult<ChannelState>('#channel-state')
@@ -454,8 +450,7 @@ function testChannel(isDev: boolean, inDocker = false) {
 
   if (!isDev) {
     test('channel: reconnect + close — server onClose stays clean when client closes with pending ack while offline', async () => {
-      await page.goto(`${getServerUrl()}/channel`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/channel`)
       await page.click('#channel-connect')
       await autoRetry(async () => {
         const state = await getResult<ChannelState>('#channel-state')

--- a/test/playground-streaming/pages/close/e2e-test.ts
+++ b/test/playground-streaming/pages/close/e2e-test.ts
@@ -1,14 +1,13 @@
 export { testClose }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { resetCleanupState, getCleanupState, waitForHydration, getResult, sleep } from '../../e2e-utils'
+import { resetCleanupState, getCleanupState, navigate, getResult, sleep } from '../../e2e-utils'
 
 function testClose() {
   // ── Targeted: generator ──────────────────────────────────────────────
 
   test('close: generator — close(gen) terminates cleanly; done=true, no error, finally block runs', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-gen')
@@ -29,8 +28,7 @@ function testClose() {
   // ── Targeted: stream ─────────────────────────────────────────────────
 
   test('close: stream — close(stream) terminates cleanly; cancel callback fires on server', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-stream')
@@ -51,8 +49,7 @@ function testClose() {
   // ── Targeted: channel ────────────────────────────────────────────────
 
   test('close: channel — close(channel) fires clean onClose on client and server, even before channel acknowledgement', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-channel')
@@ -71,8 +68,7 @@ function testClose() {
   // ── Targeted: fn ─────────────────────────────────────────────────────
 
   test('close: fn — close(fn) closes backing channel; call after close throws ChannelClosedError', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-fn')
@@ -92,8 +88,7 @@ function testClose() {
   // ── context.onClose waits for channel to close ───────────────────────
 
   test('close: channel onClose ordering — context.onClose fires only after channel closes', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-channel-onclose')
@@ -113,8 +108,7 @@ function testClose() {
   // ── context.onClose waits for both stream and channel ────────────────
 
   test('close: stream + channel onClose ordering — context.onClose fires only after channel closes, not after stream ends', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-stream-channel-onclose')
@@ -153,8 +147,7 @@ function testClose() {
   // ── Passed function: context.onClose waits for request-side channel ──
 
   test('close: passed function onClose ordering — context.onClose does not fire while request-side channel is open', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-passed-fn-onclose')
@@ -195,8 +188,7 @@ function testClose() {
   // ── Mixed close: { generator, stream, channel, fn } ──────────────────
 
   test('close: mixed { generator, stream, channel, fn } — close(result) terminates all value types cleanly; passed and returned functions work', async () => {
-    await page.goto(`${getServerUrl()}/close`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/close`)
     await resetCleanupState()
 
     await page.click('#test-close-mixed')

--- a/test/playground-streaming/pages/file-download/e2e-test.ts
+++ b/test/playground-streaming/pages/file-download/e2e-test.ts
@@ -1,7 +1,7 @@
 export { testFileDownload }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult } from '../../e2e-utils'
+import { navigate, getResult } from '../../e2e-utils'
 
 const TEXT = 'Hello, file download!'
 const TEXT_BYTES = TEXT.length // ASCII — 1 byte per char
@@ -9,8 +9,7 @@ const FIXED_LAST_MODIFIED = 1700000000000
 
 function testFileDownload() {
   test('file download: native File auto-materializes on client', async () => {
-    await page.goto(`${getServerUrl()}/file-download`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/file-download`)
 
     await page.click('#test-file-eager')
     await autoRetry(async () => {

--- a/test/playground-streaming/pages/file-upload/e2e-test.ts
+++ b/test/playground-streaming/pages/file-upload/e2e-test.ts
@@ -1,12 +1,11 @@
 export { testFileUpload }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult } from '../../e2e-utils'
+import { navigate, getResult } from '../../e2e-utils'
 
 function testFileUpload() {
   test('file upload: single file + text arg', async () => {
-    await page.goto(`${getServerUrl()}/file-upload`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/file-upload`)
 
     await page.click('#test-single')
     await autoRetry(async () => {

--- a/test/playground-streaming/pages/function/e2e-test.ts
+++ b/test/playground-streaming/pages/function/e2e-test.ts
@@ -1,12 +1,11 @@
 export { testFunction }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult } from '../../e2e-utils'
+import { navigate, getResult } from '../../e2e-utils'
 
 function testFunction() {
   test('function: simple greeter returns correct string', async () => {
-    await page.goto(`${getServerUrl()}/function`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/function`)
 
     await page.click('#greeter-run')
 

--- a/test/playground-streaming/pages/live-query/e2e-test.ts
+++ b/test/playground-streaming/pages/live-query/e2e-test.ts
@@ -1,14 +1,13 @@
 export { testLiveQuery }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration } from '../../e2e-utils'
+import { navigate } from '../../e2e-utils'
 
 function testLiveQuery() {
   // ── Local key: invalidation stays on the current client ──────────────
 
   test('live-query: local key — mutation invalidates only the current client', async () => {
-    await page.goto(`${getServerUrl()}/live-query`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/live-query`)
 
     // Wait for initial load
     await autoRetry(async () => {
@@ -30,8 +29,7 @@ function testLiveQuery() {
   // ── Global key: invalidation reaches all connected clients ──────────
 
   test('live-query: global key — mutation invalidates across clients', async () => {
-    await page.goto(`${getServerUrl()}/live-query`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/live-query`)
 
     // Wait for global todos to load on tab 1
     await autoRetry(async () => {
@@ -43,10 +41,7 @@ function testLiveQuery() {
     const browser = page.context().browser()!
     const context2 = await browser.newContext()
     const page2 = await context2.newPage()
-    await page2.goto(`${getServerUrl()}/live-query`)
-    await autoRetry(async () => {
-      expect(await page2.locator('#hydrated').count()).toBe(1)
-    })
+    await navigate(`${getServerUrl()}/live-query`, undefined, page2)
 
     // Tab 2 should also see existing global todos
     await autoRetry(async () => {

--- a/test/playground-streaming/pages/publish/e2e-test.ts
+++ b/test/playground-streaming/pages/publish/e2e-test.ts
@@ -1,7 +1,7 @@
 export { testPublish }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult } from '../../e2e-utils'
+import { navigate, getResult } from '../../e2e-utils'
 
 type ShieldState = {
   validReceiptKey: string | null
@@ -28,8 +28,7 @@ type ServerBroadcastResult = {
 
 function testPublish() {
   test('broadcast: paired text publish/subscribe roundtrip', async () => {
-    await page.goto(`${getServerUrl()}/publish`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/publish`)
     await page.click('#test-text-broadcast')
 
     await autoRetry(async () => {
@@ -48,8 +47,7 @@ function testPublish() {
   })
 
   test('broadcast: paired binary publish/subscribe roundtrip', async () => {
-    await page.goto(`${getServerUrl()}/publish`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/publish`)
     await page.click('#test-binary-broadcast-pair')
 
     await autoRetry(async () => {
@@ -68,8 +66,7 @@ function testPublish() {
   })
 
   test('broadcast: server publishes binary frames, client subscribes', async () => {
-    await page.goto(`${getServerUrl()}/publish`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/publish`)
     await page.click('#test-binary-broadcast')
 
     await autoRetry(async () => {
@@ -84,8 +81,7 @@ function testPublish() {
   })
 
   test('broadcast: shield validates client→server publishes', async () => {
-    await page.goto(`${getServerUrl()}/publish`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/publish`)
     await page.click('#test-broadcast-shield')
 
     await autoRetry(async () => {

--- a/test/playground-streaming/pages/rxjs/e2e-test.ts
+++ b/test/playground-streaming/pages/rxjs/e2e-test.ts
@@ -1,14 +1,13 @@
 export { testRxjs }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult, resetCleanupState, getCleanupState } from '../../e2e-utils'
+import { navigate, getResult, resetCleanupState, getCleanupState } from '../../e2e-utils'
 
 function testRxjs(inDocker = false) {
   // ── Observable: server → client ──────────────────────────────────────
 
   test('rxjs: observable — server emits 5 ticks then completes', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-obs-ticks')
 
@@ -20,8 +19,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: observable — synchronous emit + complete', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-obs-complete')
 
@@ -33,8 +31,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: observable — error propagates to client subscriber', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-obs-error')
 
@@ -47,8 +44,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: observable — close() stops after 2 values', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-obs-close')
 
@@ -62,8 +58,7 @@ function testRxjs(inDocker = false) {
   // ── Subject: bidirectional ───────────────────────────────────────────
 
   test('rxjs: subject — receives server pushes and client can send', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-subject-bidir')
 
@@ -76,8 +71,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject — close() from client triggers server cleanup', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
     await resetCleanupState()
 
     await page.click('#test-subject-close')
@@ -95,8 +89,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject echo — server subscribes and echoes back', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-subject-echo')
 
@@ -108,8 +101,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject — server-initiated complete propagates to client', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-subject-server-complete')
 
@@ -127,8 +119,7 @@ function testRxjs(inDocker = false) {
   // instance multicast would require Redis pub/sub bridging the Subject — out of scope.
   if (!inDocker) {
     test('rxjs: shared subject — client A sends, client B receives', async () => {
-      await page.goto(`${getServerUrl()}/rxjs`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/rxjs`)
 
       await page.click('#test-shared-subject')
 
@@ -145,8 +136,7 @@ function testRxjs(inDocker = false) {
   // ── Observable: client → server ──────────────────────────────────────
 
   test('rxjs: observable client→server — server receives all values', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
     await resetCleanupState()
 
     await page.click('#test-obs-from-client')
@@ -165,8 +155,7 @@ function testRxjs(inDocker = false) {
   // ── Subject: multiple local subscriptions ────────────────────────────
 
   test('rxjs: subject — multiple local subscribers both receive all values', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-subject-multi-sub')
 
@@ -181,8 +170,7 @@ function testRxjs(inDocker = false) {
 
   // ── Server-initiated error propagation ─────────────────────────────
   test('rxjs: observable — server calls subscriber.error(), client subscription errors', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-obs-server-error')
 
@@ -196,8 +184,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject — server calls subject.error(), client subscription errors', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-subject-server-error')
 
@@ -209,8 +196,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject arg — server without error handler survives client-errored Subject', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
     await resetCleanupState()
 
     await page.click('#test-subject-arg-no-handler')
@@ -236,8 +222,7 @@ function testRxjs(inDocker = false) {
   // Skipped in docker — same shared-Subject cross-instance limitation.
   if (!inDocker) {
     test('rxjs: shared subject — one client errors, shared Subject dies for all', async () => {
-      await page.goto(`${getServerUrl()}/rxjs`)
-      await waitForHydration()
+      await navigate(`${getServerUrl()}/rxjs`)
 
       await page.click('#test-shared-error-one')
 
@@ -258,8 +243,7 @@ function testRxjs(inDocker = false) {
   // receives `msg.v` from the client. Invalid values are silently dropped — the
   // server's subscription never sees them.
   test('rxjs: shield — Subject arg / Subject return / Observable arg reject invalid next values', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
 
     await page.click('#test-shield-all')
 
@@ -275,8 +259,7 @@ function testRxjs(inDocker = false) {
   })
 
   test('rxjs: subject — server subscribes without error handler, no crash on error', async () => {
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
     await resetCleanupState()
 
     await page.click('#test-subject-no-handler')
@@ -296,8 +279,7 @@ function testRxjs(inDocker = false) {
     // Confirm server is still alive — navigation closes the channel (triggering
     // onClose cleanup) and a follow-up telefunction call confirms the process
     // didn't crash.
-    await page.goto(`${getServerUrl()}/rxjs`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/rxjs`)
     await page.click('#test-obs-complete')
     await autoRetry(async () => {
       const result = await getResult('#rxjs-result')

--- a/test/playground-streaming/pages/stream-to-server/e2e-test.ts
+++ b/test/playground-streaming/pages/stream-to-server/e2e-test.ts
@@ -1,12 +1,11 @@
 export { testStreamToServer }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { waitForHydration, getResult } from '../../e2e-utils'
+import { navigate, getResult } from '../../e2e-utils'
 
 function testStreamToServer() {
   test('stream-to-server: echo', async () => {
-    await page.goto(`${getServerUrl()}/stream-to-server`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/stream-to-server`)
     await page.click('#test-echo')
     await autoRetry(async () => {
       const result = await getResult('#stream-result')

--- a/test/playground-streaming/pages/streaming/e2e-test.ts
+++ b/test/playground-streaming/pages/streaming/e2e-test.ts
@@ -1,15 +1,14 @@
 export { testStreaming }
 
 import { page, test, expect, autoRetry, getServerUrl, skip } from '@brillout/test-e2e'
-import { resetCleanupState, getCleanupState, waitForHydration, getResult } from '../../e2e-utils'
+import { resetCleanupState, getCleanupState, navigate, getResult } from '../../e2e-utils'
 
 const channelTransports = parseChannelTransports(process.env.PUBLIC_ENV__CHANNEL_TRANSPORTS)
 const channelTransport = channelTransports[channelTransports.length - 1]!
 
 function testStreaming() {
   test('streaming: ReadableStream return', async () => {
-    await page.goto(`${getServerUrl()}/streaming`)
-    await waitForHydration()
+    await navigate(`${getServerUrl()}/streaming`)
 
     await page.click('#test-readable-stream')
     await autoRetry(async () => {


### PR DESCRIPTION
## Summary

This PR adds retry logic for channel handshakes and page navigation in the Docker e2e test environment to handle transient network errors caused by Docker bridge interface state shifts.

## Key Changes

- **Channel handshake resilience**: Added `openChannel()` wrapper function that retries channel initialization calls (`onChannelInit`, `onChannelAbortTest`, etc.) up to 4 times with 500ms delays when `ConnectionError` is encountered. This handles transient connection drops during the critical handshake phase that would otherwise leave channels permanently closed.

- **Navigation resilience**: Refactored `resilientGoto()` and `waitForHydration()` into a unified `navigate()` function that:
  - Retries the full navigate-and-hydrate cycle as a unit (4 attempts, 500ms delays)
  - Handles both navigation failures and asset fetch drops that prevent hydration
  - Accepts an optional `target` parameter to support multi-tab testing
  - Provides clearer error handling and recovery semantics

- **Updated all e2e tests**: Replaced all `page.goto()` + `waitForHydration()` call pairs with single `navigate()` calls across 12+ test files (channel, rxjs, abort, close, publish, live-query, file-upload, file-download, function, stream-to-server, streaming tests).

- **Applied channel retry pattern**: Wrapped all 20+ channel initialization calls in the Channel demo component with `openChannel()` to ensure resilience.

## Implementation Details

- `ConnectionError` is now imported from `telefunc/client` to identify transient connection failures
- Constants defined for retry attempts (4) and delays (500ms) to keep configuration centralized
- Comprehensive JSDoc comments explain the Docker-specific resilience strategy and how it complements telefunc's built-in reconnect/replay for steady-state message delivery
- The retry logic is safe because each channel attempt opens an independent channel; superseded half-open channels are reaped server-side after their grace period

https://claude.ai/code/session_01H1ZiHVVmVeCE1vrXEBCyXP