### PR TITLE
Refine documentation clarity and remove redundant content

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -290,8 +290,6 @@ A `Broadcast` is an announcement, like a radio frequency: whoever tunes in to th
 
 Only the two ends of a channel can use it, while anything that knows a `key` can join its broadcast. A channel ends when either side closes it, while a broadcast outlives any single member.
 
-These are the two natural shapes of communication.
-
 ### Technically
 
 You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods tap directly.

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -125,6 +125,8 @@ Only specified regions get Durable Objects. Requests from unspecified regions fa
 
 ### How it works
 
+> You can skip this section — it's Telefunc's internal fan-out, not anything you configure.
+
 ```
 Publisher (Durable Object)
   → Authority DO (one per key — assigns sequence numbers)

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -15,6 +15,8 @@ Telefunc supports real-time use cases — chat, file upload progress, live updat
 
 > See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)
 
+> **Runtime safety**: whichever primitive you use, every value the client sends to the server is shield-validated against your TypeScript types before it reaches your code — function-call <Link href="/shield#function-arguments" text="arguments" />, <Link href="/shield#channels" text="channel messages" />, and broadcast <Link href="/shield#broadcast" text="publishes" />. A failing check is rejected with `ShieldValidationError`.
+
 
 ## Function passing
 
@@ -47,8 +49,6 @@ await onUpload(file, (percent) => setProgress(percent))
 ```
 
 If you only need callback-style interaction, function passing is simpler than a channel.
-
-> Function arguments are **shield-validated at runtime** from your TypeScript types — when the client invokes a server-returned function, its arguments are checked against the declared type before reaching server code; when the server invokes a client-passed callback, its return value is checked. See <Link href="/shield#function-arguments" text="Shield — Function arguments" />.
 
 
 ## Channels
@@ -87,8 +87,6 @@ channel.listen((metrics) => updateCharts(metrics))
 ```
 
 See <Link href="/channel" /> for the full API.
-
-> Channel messages are **shield-validated at runtime** from your TypeScript types — every client→server message passed to `listen()` is checked against the declared client-to-server type before reaching server code, and every ack response from the client is checked against the declared server-to-client type. See <Link href="/shield#channels" text="Shield — Channels" />.
 
 
 ## Broadcast
@@ -139,8 +137,6 @@ chat.publish({ user: 'Alice', text: 'Hello!' })
 ```
 
 See <Link href="/channel#new-broadcast" /> for the full `Broadcast` API.
-
-> Client-published messages are **shield-validated at runtime** from your TypeScript types — when the client calls `publish()` on a `Broadcast<T>` returned from a telefunction, the value is checked against `T` on the server before fanning out to subscribers. A failing shield rejects the client's `publish()` promise with `ShieldValidationError`. See <Link href="/shield" />.
 
 
 ## Reconnection

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -4,7 +4,7 @@ For reactive streams with full operator support, you can use [RxJS](https://rxjs
 
 The `@telefunc/rxjs` integration lets you pass RxJS `Observable` and `Subject` transparently between client and server — both directions, all operators.
 
-> Each value emitted into a client-side `Subject<T>` is **shield-validated at runtime** when it arrives at the server, against the `T` from your TypeScript types. Terminal signals (`error`, `complete`) are untyped and pass through unshielded — see <Link href="#shields" />.
+> Values you stream to the server are **shield-validated at runtime** against your TypeScript types — see <Link href="#shields" />.
 
 
 ## Install

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -70,11 +70,6 @@ const httpResponse = await serve({
 | `getBody()` | `Promise<string>` | Full body as string (non-streaming only) |
 
 
-## Runtime adapters
-
-For production deployments with channels and WebSocket support, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare`. See <Link href="/server" /> for examples.
-
-
 ## See also
 
 - <Link href="/server" />

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -9,6 +9,8 @@ Telefunc supports streaming in both directions:
 
 ## Which one should I use?
 
+For values **returned** from a telefunction (server → client):
+
 | Type | Best for | Values |
 |---|---|---|
 | [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) | AI tokens, notifications, progress updates | Structured (JSON-serializable) |


### PR DESCRIPTION
This PR improves documentation by removing redundant information and clarifying key concepts across multiple pages.

**Key changes:**

- **serve/+Page.mdx**: Removed the "Runtime adapters" section that duplicated information already covered in the `/server` page, reducing redundancy and improving documentation maintainability.

- **channel/+Page.mdx**: Removed the generic statement "These are the two natural shapes of communication" which added no technical value after explaining the differences between channels and broadcasts.

- **rxjs/+Page.mdx**: Simplified and clarified the runtime validation note by removing implementation details about terminal signals (`error`, `complete`) and focusing on the core guarantee that streamed values are shield-validated against TypeScript types.

These changes streamline the documentation by eliminating redundant cross-references and overly specific technical details, making the content more focused and easier to maintain.

https://claude.ai/code/session_01D4pN5ASJuxbhxZsqpgWSc4