### PR TITLE
docs: add Live telefunctions overview (front door for streaming & real-time)

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -154,7 +154,13 @@ const headings = [
   },
   {
     level: 4,
-    title: 'Streaming & Real-Time',
+    title: 'Live telefunctions',
+  },
+  {
+    level: 2,
+    title: 'Overview',
+    titleDocument: 'Live telefunctions',
+    url: '/live',
   },
   {
     level: 2,

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -1,0 +1,41 @@
+import { Link } from '@brillout/docpress'
+
+Telefunc lets you move **live values** across the client/server boundary — async sequences, byte streams, files, and persistent connections — by returning them from, or passing them to, a telefunction like any other value.
+
+It works in **both directions**:
+- **Server → client** — return an `AsyncGenerator`, `ReadableStream`, `File`, nested `Promise`, `Channel`, or `Broadcast`.
+- **Client → server** — pass a `ReadableStream`, `File`, callback, or channel message as an argument.
+
+> Plain telefunction calls are unaffected — these capabilities kick in only when a live value is involved, with zero config.
+
+
+## What are you moving?
+
+| You want to… | Use | |
+|---|---|---|
+| Push a sequence one way — AI tokens, progress, notifications | `AsyncGenerator` | <Link href="/stream" /> |
+| Deliver parts of one response as they become ready | nested `Promise` | <Link href="/stream" /> |
+| Stream raw bytes one way | `ReadableStream` | <Link href="/stream" /> |
+| Download a file — name, size, progress, save-to-disk | `File` / `download()` | <Link href="/file-download" /> |
+| Upload a file | `File` argument | <Link href="/file-upload" /> |
+| Let the server call you back | function passing | <Link href="/real-time" /> |
+| Hold a two-way conversation with one client | `new Channel()` | <Link text="Channel" href="/channel" /> |
+| Broadcast to many — rooms, presence, live feeds | `new Broadcast()` | <Link text="Broadcast" href="/channel#new-broadcast" /> |
+| Reactive streams with operators | `@telefunc/rxjs` | <Link href="/rxjs" /> |
+| Auto-refetching queries | `@telefunc/tanstack-query` | <Link href="/tanstack-query" /> |
+
+> One-way or two-way? Reach for an `AsyncGenerator` or `ReadableStream` when data flows one way; use a <Link text="channel" href="/channel" /> only when the client also needs to send.
+
+
+## Handled for you
+
+Whatever you return or pass:
+
+- **Validation** — values arriving at the server are runtime-checked against your TypeScript types. See <Link href="/shield" />.
+- **Cleanup** — when the client stops reading or disconnects, your telefunction is notified so it can release resources. See <Link href="/close" />.
+- **Transport & reconnection** — streams and channels negotiate a working transport (HTTP, SSE, WebSocket) and recover from dropped connections automatically. Tune it only if you need to — see <Link href="/transport" />.
+
+
+## Shipping to production
+
+Channels are stateful, so a multi-instance deployment needs sticky sessions and a cross-instance broadcast transport — see <Link href="/scaling" />. On Cloudflare Workers it's handled via Durable Objects — see <Link href="/cloudflare" />.


### PR DESCRIPTION
## The problem this solves

The streaming/real-time feature is documented as ~12 sibling pages, each opening *inside* its own topic. There's no page that states the unifying idea or answers the question every newcomer actually arrives with: **"I have live data moving between client and server — what do I reach for?"** Today that decision is split across three local tables (`stream`, `real-time`, `file-download`), each of which assumes you already know which bucket you're in — and the buckets leak (the `stream` table itself routes you to `Channel`/`Broadcast`).

## The change

A single front door — **`/live`** — kept deliberately thin:

- States the one idea: *move live values across the client/server boundary by returning/passing them like any other value.*
- One master **"What are you moving?"** table routing to the right deep-dive (`stream`, `file-upload`/`file-download`, `real-time`, `channel`, `rxjs`, `tanstack-query`).
- A **"Handled for you"** section pointing the cross-cutting concerns at their pages (validation → `shield`, cleanup → `close`, transport/reconnection → `transport`).
- A **"Shipping to production"** pointer (`scaling` / `cloudflare`).

The existing pages stay as deep-dives you reach *from here*.

## Nav

- Renamed the sidebar group `Streaming & Real-Time` → **`Live telefunctions`** (shorter, on-brand — everything is a telefunction; these are the live ones).
- Added the page as nav title **`Overview`** (`titleDocument: "Live telefunctions"`) so the chip stays short and reads as "start here."

## Scope notes

- Placed minimally: `Overview` leads the `Live telefunctions` group. A fuller version would reorder so it leads the whole Files/Streaming/Integrations region — held off to keep nav churn low.
- Follow-on cleanups this overview enables (demoting the recurring `## Transport` sections in `stream`/`real-time`; a gentle on-ramp at the top of `channel`) are intentionally **not** in this PR — happy to do them next.

## Verification

- `tsc --noEmit` — clean.
- `vike build` — clean; docpress validated every `Link` in the routing table, so all routes resolve.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_