### PR TITLE
docs: integrate Live telefunctions overview (discovery + page cleanups)

### DIFF
--- a/docs/pages/RPC/+Page.mdx
+++ b/docs/pages/RPC/+Page.mdx
@@ -45,6 +45,8 @@ async function hello({ name }) {
 
 The central aspect here is that `hello()` is always executed on the server side, which enables `hello()` to use server-side utilities such as SQL and ORMs.
 
+> Beyond plain request/response, telefunctions can also return and accept **live values** — streamed responses, files, and real-time channels. See <Link href="/live">Live telefunctions</Link>.
+
 
 ## ORM & SQL
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -19,17 +19,33 @@ Both are returned from a telefunction — they serialize into client-side object
 
 `new Channel()` creates a private, two-way message pipe between the server and the one client that called the telefunction. The server keeps the `Channel` object and hands the client its end by returning `chat.client`. The channel outlives the telefunction call: both ends can `send()` and `listen()` until one side closes it.
 
+The simplest case — the server pushes live updates to the one client that opened the channel:
+
 ```ts
-// Chat.telefunc.ts
+// Clock.telefunc.ts
 // Environment: server
 
 import { Channel } from 'telefunc'
 
-export async function onChat() {
-  const chat = new Channel<ClientToServer, ServerToClient>()
-  return { channel: chat.client }
+export async function onClock() {
+  const clock = new Channel()
+  const timer = setInterval(() => clock.send(Date.now()), 1000)
+  clock.onClose(() => clearInterval(timer))
+  return { channel: clock.client }
 }
 ```
+
+```ts
+// Clock.tsx
+// Environment: client
+
+import { onClock } from './Clock.telefunc'
+
+const { channel } = await onClock()
+channel.listen((time) => console.log(time)) // 1700000000000, 1700000001000, ...
+```
+
+The rest of this section adds types, two-way messaging, acks, and binary; see <Link href="#methods" /> for the full API.
 
 ### Methods
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -145,12 +145,7 @@ If the connection drops, Telefunc reconnects automatically, resumes existing cha
 
 See <Link href="/channel#reconnection" text="Channel reconnection" /> for details.
 
-
-## Transport
-
-Channels start on **SSE** and automatically upgrade to **WebSocket** when it's enabled in your <Link text="server setup" href="/server" />, with no client-side configuration. All channels share a single multiplexed connection per server URL, and the upgrade is transparent to active channels.
-
-See <Link href="/transport" /> for the full comparison.
+> Channels run over **SSE** and upgrade to **WebSocket** automatically when your <Link text="server" href="/server" /> enables it — no client config. See <Link href="/transport" /> for the comparison.
 
 
 ## See also

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -4,7 +4,7 @@ Telefunc supports streaming in both directions:
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
-> Streaming works out of the box with zero config. Plain telefunction calls are unaffected.
+> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting channel only if you need to). Plain telefunction calls are unaffected.
 
 
 ## Which one should I use?
@@ -225,13 +225,6 @@ const slow = await res.slow
 ## Cancellation & cleanup
 
 See <Link href="/close" /> for all cancellation methods (`close()`, `break`, `gen.return()`, `reader.cancel()`) and server-side cleanup via `onClose()`.
-
-
-## Transport
-
-By default, streamed values are sent as raw binary chunks over HTTP. Switch to `'sse-inline'` (for proxies that buffer binary responses) or `'channel'` (to stream over a reconnecting channel), globally or per call.
-
-See <Link href="/transport" /> for the options, trade-offs, and how to configure them.
 
 
 ## Error handling


### PR DESCRIPTION
Follow-up to the merged Live telefunctions overview (#301). Two threads from the review:

## Finding 2 — discovery (the capability was invisible from the top of the docs)

The Introduction mentioned streaming/real-time **zero times**; `RPC` mentioned it once, incidentally. A newcomer couldn't tell telefunctions can stream. A light touch:

- **RPC page** — a one-line pointer right after the basic example: *"telefunctions can also return and accept live values — streamed responses, files, real-time channels. See Live telefunctions."*

(A landing-page feature card was prototyped and pulled for now — to revisit separately.)

## Finding 3 — page cleanups the overview makes possible

Now that `/live`'s "Handled for you" section frames transport as automatic, the deep-dives no longer need to re-teach it:

- **`stream`** — folded the standalone `## Transport` section into the top "zero config" note.
- **`real-time`** — demoted `## Transport` to a one-line note after Reconnection.
- **`channel`** — added a complete, minimal on-ramp (server pushes live updates to one client; client `listen`s) before the Methods table.

## Verification

- `tsc --noEmit` — clean.
- `vike build` — clean; docpress validated every `Link`.

Independent of the other open PR (#298).

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T