### PR TITLE
docs: surface live telefunctions on the landing page (revert RPC pointer)

### DIFF
--- a/docs/pages/RPC/+Page.mdx
+++ b/docs/pages/RPC/+Page.mdx
@@ -45,8 +45,6 @@ async function hello({ name }) {
 
 The central aspect here is that `hello()` is always executed on the server side, which enables `hello()` to use server-side utilities such as SQL and ORMs.
 
-> Beyond plain request/response, telefunctions can also return and accept **live values** — streamed responses, files, and real-time channels. See <Link href="/live">Live telefunctions</Link>.
-
 
 ## ORM & SQL
 

--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -65,6 +65,17 @@ function Features() {
       </div>
       <div>
         <h2>
+          <Emoji name="red-circle" /> Real-time &amp; streaming
+        </h2>
+        <>
+          <p>
+            Telefunctions can <b>stream live values</b> — AI tokens, progress, file up/downloads — and power{' '}
+            <b>real-time</b> features with channels &amp; broadcasts, by returning or passing them like any other value.
+          </p>
+        </>
+      </div>
+      <div>
+        <h2>
           <Emoji name="typescript" /> TypeScript
         </h2>
         <>


### PR DESCRIPTION
Swaps the discovery surface for live telefunctions: **drop the inline RPC pointer, add a landing-page card instead.**

The discovery goal (Finding 2) stays the same — make the streaming/real-time capability visible from the top of the docs — but the front page is a better place for it than an aside in the RPC explainer.

- **Revert** the inline pointer added to `docs/pages/RPC/+Page.mdx` (merged in #302).
- **Add** a **🔴 Real-time & streaming** card to the landing feature grid, alongside the existing six (Simple, Permissions, Any Stack, Performance, TypeScript, Rock-solid).

Copy is a starting point — it's marketing surface, so reword freely.

## Verification
- `tsc --noEmit` — clean (the card's `Emoji name` is type-checked against the allowed union).
- `vike build` — clean.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_