### PR TITLE
docs: document authorization for channels & broadcasts

### DIFF
--- a/docs/pages/permissions/+Page.mdx
+++ b/docs/pages/permissions/+Page.mdx
@@ -62,6 +62,8 @@ function TodoItem({ id, text }: { id: string; text: string }) {
 }
 ```
 
+> The same `getContext()` + `throw Abort()` pattern protects <Link href="/real-time">real-time</Link> telefunctions — channels and broadcasts authorize at open time. See <Link href="/real-time#authorization" />.
+
 
 ## `getContext()` wrapping
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -139,6 +139,47 @@ chat.publish({ user: 'Alice', text: 'Hello!' })
 See <Link href="/channel#new-broadcast" /> for the full `Broadcast` API.
 
 
+## Authorization
+
+A channel or broadcast is opened by a telefunction, so you protect it like any other telefunction (see <Link href="/permissions" />): authorize **at open time** with <Link text="getContext()" href="/getContext" /> and `throw Abort()`.
+
+```ts
+// Chat.telefunc.ts
+// Environment: server
+
+import { Broadcast, getContext, Abort } from 'telefunc'
+
+export async function onJoinChat(roomId: string) {
+  const { user } = getContext()
+  if (!user || !user.rooms.includes(roomId)) throw Abort()
+  return new Broadcast({ key: `chat:${roomId}` })
+}
+```
+
+`getContext()` and `throw Abort()` only work **synchronously, before the telefunction returns** (see <Link href="/getContext#access" />). A channel outlives that — its `listen()` runs later — so **capture what you need in a closure** and check it per message:
+
+```ts
+// Room.telefunc.ts
+// Environment: server
+
+import { Channel, getContext, Abort } from 'telefunc'
+
+export async function onJoinRoom(roomId: string) {
+  const { user } = getContext() // captured once, at open time
+  if (!user) throw Abort()
+
+  const room = new Channel<RoomMessage, RoomMessage>()
+  room.listen((msg) => {
+    if (!canPost(user, msg)) return // per-message check uses the captured user
+    saveMessage(roomId, user.id, msg)
+  })
+  return { channel: room.client }
+}
+```
+
+> <Link href="/shield" /> validates the **type** of every client→server message; authorization — **who** may open a channel or send a message — is yours, via `getContext()` + `Abort()`.
+
+
 ## Reconnection
 
 If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. It's transparent to your application code.


### PR DESCRIPTION
## Finding 4 — the real-time docs dropped the "protect your telefunctions" thread

`channel`, `real-time`, and the `permissions` guide said **nothing** about permissions/auth — yet authed real-time (chat rooms, per-user dashboards, presence) is the headline use case, and *"can this user join this room?"* is the first question a reader has.

The pattern already works and is tested — channel/broadcast telefunctions are ordinary telefunctions — it was just never documented. I verified the exact behavior against the implementation and the `playground-streaming` tests:

- `getContext()` + `throw Abort()` work **synchronously at open** (before the telefunction returns) — the rxjs test even notes *"`throw Abort()` only works synchronously before the telefunction returns."*
- `listen()` callbacks fire later, outside the request's `AsyncLocalStorage` window, so `getContext()` isn't available there — you **capture the user in a closure** (as the rxjs "Live cursors" example already does).

## Changes

- **`real-time`** — new **Authorization** section: authorize at open with `getContext()` + `throw Abort()`; capture the user in a closure for per-message checks. Closes with the shield-vs-authorization distinction (shield = message *type*; you enforce *who*).
- **`permissions`** — one-line cross-link, so the feature isn't invisible from the page where someone starts looking for auth.

## Verification
- `tsc --noEmit` — clean.
- `vike build` — clean; every `Link` resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_