### PR TITLE
docs: streaming-docs review batch (errors, beta notice, client→server)

### DIFF
--- a/docs/components/StreamingBeta.mdx
+++ b/docs/components/StreamingBeta.mdx
@@ -1,0 +1,1 @@
+> **Beta** — the streaming & real-time API is in beta and may still change before it's stabilized.

--- a/docs/components/index.ts
+++ b/docs/components/index.ts
@@ -1,6 +1,7 @@
 export * from './MostlyMutations'
 export { default as ConfigWhereClient } from './ConfigWhereClient.mdx'
 export { default as ConfigWhereServer } from './ConfigWhereServer.mdx'
+export { default as StreamingBeta } from './StreamingBeta.mdx'
 export * from './Example'
 export * from './ReadingRecommendation'
 export * from './EventBasedRecommendation'

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 **Environment**: server.
 

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -163,6 +163,15 @@ If the user's browser can't connect to your server:
 ```
 
 
+## Streaming and channel errors
+
+The expected-vs-bug distinction above applies to <Link href="/stream">streamed</Link> and <Link href="/real-time">real-time</Link> values too.
+
+A generator or stream that **throws mid-response** surfaces a typed error on the client for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
+
+**Channels and broadcasts** signal failure through dedicated errors — `ChannelNetworkError` (connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
+
+
 ## See also
 
 - <Link href="/onBug" />

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Telefunc lets you move **live values** across the client/server boundary — async sequences, byte streams, files, and persistent connections — by returning them from, or passing them to, a telefunction like any other value.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Telefunc supports real-time use cases — chat, file upload progress, live updates, ...
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Telefunc supports streaming in both directions:
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -19,6 +19,8 @@ For values **returned** from a telefunction (server → client):
 | <Link text={<code>download()</code>} href="/file-download#streaming-with-download" /> | File / Blob downloads with progress + cancel, or upstream-streamed bytes | Binary (`Uint8Array`) |
 | Nested [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) | Lazy parts of a response that resolve independently | Any serializable value |
 
+For values **passed** to a telefunction (client → server), pass a `ReadableStream` argument — covered in the *Client → server streaming* section below.
+
 
 ## `AsyncGenerator`
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -231,7 +231,7 @@ See <Link href="/close" /> for all cancellation methods (`close()`, `break`, `ge
 
 Telefunc distinguishes expected failures from bugs — even in streaming responses. If a generator or stream throws, the client receives a typed error while values already delivered remain available.
 
-See <Link href="/error-handling" /> for details.
+See <Link href="/error-handling#streaming-and-channel-errors" text="Error handling — streaming & channels" /> for details.
 
 
 ## See also

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -1,5 +1,7 @@
 import { Link } from '@brillout/docpress'
-import { ConfigWhereClient } from '../../components'
+import { ConfigWhereClient, StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 **Environment**: client.
 


### PR DESCRIPTION
A batch from the docs review — **one commit per finding**. Scoped to avoid friction with the in-flight PRs.

| Commit | Finding | What |
|---|---|---|
| `docs(error-handling)` | **5** | The central error guide had only Bugs / Expected / Network — yet `stream` pointed here "for details" on streaming errors that weren't present. Adds a **Streaming and channel errors** section and retargets the `stream` pointer. |
| `docs(stream)` | **8** | The "Which one should I use?" table was scoped to returned values only; adds a one-line pointer so client→server streaming is discoverable. |
| `docs: <StreamingBeta>` | **6** | The feature shipped with no maturity signal. Adds a reusable **`<StreamingBeta>`** MDX component (in `docs/components`) and applies it to the large/opinionated-API streaming pages: `live`, `stream`, `real-time`, `channel`, `transport`. |

### Changed from the first revision (per review)
- **Finding 7 (document `abort()` on `/close`) — dropped.** `abort()` is a channel method and is already fully documented on `/channel` (Methods table, Lifecycle with the close-vs-abort contrast, error table), so the `/close` section was redundant.
- **Finding 6 — reworked into a reusable component** (`<StreamingBeta>`) instead of a one-off `/live` blockquote, so the beta notice is consistent across the streaming pages. Currently applied to the 5 large-API pages — easy to extend to integrations/deployment if you want.

## Verification
- `tsc --noEmit` — clean.
- `vike build` — clean; the `<StreamingBeta>` component resolves on every page.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T