### PR TITLE
docs: streaming-docs review batch 2 (serverless constraint, key security, serialization)

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -214,6 +214,10 @@ export async function onJoinChat() {
 
 Return the broadcast instance directly from a telefunction — no `.client` needed (unlike channels, broadcast has no directional type flip).
 
+> **Keys are capabilities** — anyone who forms the same `key` joins the group. Secure a broadcast one of two ways:
+> - **Guard the key**: derive it from **authorized server-side context** (e.g. the user from <Link text="getContext()" href="/getContext" />), never from raw client input — see <Link href="/real-time#authorization" />.
+> - **Guard the payload**: whatever you `publish()` reaches every subscriber, so broadcast only non-sensitive data. That's how <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> stays safe — it broadcasts only a *"refetch"* signal (the query key), and each client loads the actual data through its own authorized telefunction.
+
 ### Chat example
 
 ```ts

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -15,6 +15,8 @@ Both are returned from a telefunction — they serialize into client-side object
 
 > By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background, see <Link href="/transport" />.
 
+> **Not for serverless**: "no extra setup" still means a **long-running server** — a channel holds a connection open, which serverless functions (Vercel, Lambda) cut short. See <Link href="/scaling" />, or <Link href="/cloudflare" /> for Cloudflare Workers.
+
 > For short-lived callbacks (e.g. progress updates), <Link href="/real-time">function passing</Link> is usually simpler.
 
 

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -42,4 +42,4 @@ Whatever you return or pass:
 
 ## Shipping to production
 
-Channels are stateful, so a multi-instance deployment needs sticky sessions and a cross-instance broadcast transport — see <Link href="/scaling" />. On Cloudflare Workers it's handled via Durable Objects — see <Link href="/cloudflare" />.
+Channels are stateful — a `Channel` lives in one server process and holds a connection open — so real-time needs a **long-running server**, not typical serverless (Vercel, Lambda), where function timeouts cut SSE connections short and there's no sticky routing for reconnects. Across multiple instances you also need sticky sessions and a cross-instance broadcast transport — see <Link href="/scaling" />. On Cloudflare Workers it's handled via Durable Objects — see <Link href="/cloudflare" />.

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -37,6 +37,7 @@ Whatever you return or pass:
 - **Validation** — values arriving at the server are runtime-checked against your TypeScript types. See <Link href="/shield" />.
 - **Cleanup** — when the client stops reading or disconnects, your telefunction is notified so it can release resources. See <Link href="/close" />.
 - **Transport & reconnection** — streams and channels negotiate a working transport (HTTP, SSE, WebSocket) and recover from dropped connections automatically. Tune it only if you need to — see <Link href="/transport" />.
+- **Serialization** — structured values use Telefunc's serializer, so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip (not just JSON); raw bytes travel as `Uint8Array` / `File` / `Blob`.
 
 
 ## Shipping to production

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -20,6 +20,8 @@ Telefunc supports real-time use cases — chat, file upload progress, live updat
 
 > **Runtime safety**: whichever primitive you use, every value the client sends to the server is shield-validated against your TypeScript types before it reaches your code — function-call <Link href="/shield#function-arguments" text="arguments" />, <Link href="/shield#channels" text="channel messages" />, and broadcast <Link href="/shield#broadcast" text="publishes" />. A failing check is rejected with `ShieldValidationError`.
 
+> **Deployment**: channels and broadcasts hold a connection open, so they need a long-running server — typical serverless (Vercel, Lambda) cuts them off. See <Link href="/scaling" />, or <Link href="/cloudflare" /> for Cloudflare's Durable Objects.
+
 
 ## Function passing
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -24,6 +24,8 @@ For values **returned** from a telefunction (server → client):
 
 For values **passed** to a telefunction (client → server), pass a `ReadableStream` argument — covered in the *Client → server streaming* section below.
 
+> Structured values cross the wire via Telefunc's serializer — `Date`, `Map`, `Set`, `BigInt`, etc., not just JSON. Binary travels as `Uint8Array` (or `File` / `Blob`).
+
 
 ## `AsyncGenerator`
 


### PR DESCRIPTION
Second review batch — **one commit per finding** (continuing the numbering).

| Commit | Finding | What |
|---|---|---|
| `docs: long-running server` | **17** | The "channels are stateful → not a fit for serverless" constraint lived only on `scaling`, while `channel`/`real-time` advertise *"SSE, no extra setup."* A serverless (Vercel/Next.js) reader could build real-time and hit a wall at deploy time. Surfaces it where readers learn channels: `/live` "Shipping to production", a `/real-time` deployment note, and a caveat next to `channel`'s "no extra setup" line. |
| `docs(channel): keys are capabilities` | **12** | Security: a `Broadcast` key is joinable by anyone who forms it. Documents the **two ways to secure a broadcast** — **guard the key** (derive it from authorized server-side context, never raw client input) or **guard the payload** (broadcast only non-sensitive data — the way `@telefunc/tanstack-query` does it: only a query-key "refetch" signal is broadcast, and each client reloads the data through its own authorized telefunction). |
| `docs: serialization` | **13** | The `stream` table said *"JSON-serializable"* and `channel` said nothing, but Telefunc streams via `@brillout/json-serializer` (`Date`/`Map`/`Set`/`BigInt`, richer than JSON — confirmed in source). Adds a **Serialization** entry to `/live`'s "Handled for you" and a clarifying note under the `stream` table. |

### Still open (from the review list, not in this PR)
F14 (`withContext` discoverability), F15 (cleanup pitfall), F16 (`onJoinChat` dup), F18 (migration note for `telefunc()` → `serve()`), F19 (framework example repos), F20 (`config.channel` tuning guidance).

## Verification
- `tsc --noEmit` — clean.
- `vike build` — clean; every `Link` resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T