### PR TITLE
docs: cross-page structural consistency (beta marker, Environment, integration spine)

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 `close()` and `onClose()` manage the lifecycle of telefunction values — anything returned from or passed to a telefunction that holds an open connection.
 

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 **Environment**: server.
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) from a telefunction like any other value. The client receives a standard `File` / `Blob` ready for `URL.createObjectURL`, `<img src>`, `fetch({ body })`, `FormData`, etc.
 

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Pass `File` or `Blob` arguments to a telefunction like any other value. Single file, multiple files, `File[]` arrays, mixed with other arguments — it just works.
 

--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Redis-backed `Broadcast` fan-out across Telefunc instances — `publish()` on one instance reaches `subscribe()` on every other instance subscribed to the same key.
 

--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -3,6 +3,8 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
+**Environment**: server.
+
 Redis-backed `Broadcast` fan-out across Telefunc instances — `publish()` on one instance reaches `subscribe()` on every other instance subscribed to the same key.
 
 ## Install

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 For reactive streams with full operator support, you can use [RxJS](https://rxjs.dev).
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -16,7 +16,9 @@ The `@telefunc/rxjs` integration lets you pass RxJS `Observable` and `Subject` t
 npm install @telefunc/rxjs rxjs
 ```
 
-> The Telefunc bundler plugin (Vite, webpack, Next.js, Babel) detects `@telefunc/rxjs` in your dependencies and registers it automatically. Without a Telefunc bundler plugin, register it manually — `import '@telefunc/rxjs/server'` in your server entry and `import '@telefunc/rxjs/client'` in your client entry.
+## Setup
+
+The Telefunc bundler plugin (Vite, webpack, Next.js, Babel) detects `@telefunc/rxjs` in your dependencies and registers it automatically. Without a Telefunc bundler plugin, register it manually — `import '@telefunc/rxjs/server'` in your server entry and `import '@telefunc/rxjs/client'` in your client entry.
 
 
 ## Live stock ticker

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 To scale Telefunc horizontally across several server processes (multiple Node instances, multiple containers, multiple machines), two pieces have to be set up.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 **Environment**: server.
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -1,4 +1,7 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 Live queries for [TanStack Query](https://tanstack.com/query) — server-side query key invalidation that automatically refetches connected clients with a matching query key.
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -12,6 +12,8 @@ Live queries for [TanStack Query](https://tanstack.com/query) — server-side qu
 npm install @telefunc/tanstack-query
 ```
 
+## Setup
+
 Wrap your `QueryClient` with `withTelefunc()`:
 
 ```tsx


### PR DESCRIPTION
Cross-page **structural consistency** pass over the streaming/real-time cluster — one commit per suggestion.

| Commit | What |
|---|---|
| `docs: <StreamingBeta> feature-wide` | The beta marker was on 5 pages but missing from 9 others equally part of the feature (and the split didn't match its stated rule — `transport` had it, `cloudflare`/`rxjs`/`tanstack-query` didn't). Applied feature-wide so the maturity signal shows wherever a reader lands: `close`, `serve`, `scaling`, `cloudflare`, `redis`, `rxjs`, `tanstack-query`, `file-upload`, `file-download`. |
| `docs(redis): Environment annotation` | Single-environment setup pages (`serve`, `channel`, `cloudflare`, `transport`) carry a top `**Environment**:` line; `redis` is server-only setup but lacked it. (`scaling` left as-is — it's load-balancer/infra config, not single-env telefunc code.) |
| `docs: integration Install/Setup spine` | `rxjs`/`tanstack-query`/`redis` are all `@telefunc/*` packages but structured differently. Split the install step from the wiring step on `rxjs` and `tanstack-query` so all three read as a family (`Install → Setup → …`), matching `redis`. |

Kept consistent on purpose: `See also` on every page except `/live` (the router), decision tables only where a choice exists.

## Verification
- `tsc --noEmit` — clean.
- `vike build` — clean; `<StreamingBeta>` resolves on every page.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_