### PR TITLE
docs(channel): make terminal vs recoverable explicit in the error table

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -365,12 +365,12 @@ chat.onOpen(() => {
 
 chat.onClose((err) => {
   if (!err) {
-    // Clean close
+    // Graceful close — `close()` completed, channel done
   } else if (err instanceof Abort) {
-    // Server called channel.abort(value)
+    // Either side called abort(value)
     console.log(err.abortValue)
-  } else {
-    // Network error or timeout
+  } else if (err instanceof NetworkError) {
+    // Connection lost beyond reconnectTimeout
   }
 })
 
@@ -397,12 +397,14 @@ If the connection drops, Telefunc reconnects automatically and resumes existing 
 
 ## Error handling
 
-| Error | When | Recovery |
-|---|---|---|
-| `Abort` | Server called `abort()` | Terminal — inspect `err.abortValue` |
-| `ChannelClosedError` | `send()` after close/abort | Terminal — recreate channel if needed |
-| `NetworkError` (`isChannel: true`) | Connection lost beyond timeout | Terminal — channel auto-closed |
-| `ChannelOverflowError` | Buffered sends exceeded `config.channel.bufferLimit` while the peer was disconnected | Pending `send()` promises reject — apply backpressure by awaiting sends |
+> A graceful `close()` is not an error — `onClose(err)` receives `undefined`.
+
+| Error | When | Channel after | Recovery |
+|---|---|---|---|
+| `Abort` | Either side called `abort(value)`, or a callback threw `Abort` | Closed | Inspect `err.abortValue` |
+| `NetworkError` (`isChannel: true`) | Connection lost beyond `reconnectTimeout` | Closed | Auto-closed — recreate if needed |
+| `ChannelClosedError` | `send()` on a closed channel (thrown synchronously); also rejects pending `ack` sends orphaned by close or close timeout | Closed | Recreate the channel |
+| `ChannelOverflowError` | A buffered send was dropped — backlog exceeded `config.channel.bufferLimit` while the peer was disconnected | **Open** | Only the dropped `send()` rejects; `await` sends to apply backpressure |
 
 
 ## Config


### PR DESCRIPTION
Follow-up to #307. The channel error table didn't surface the one distinction that actually matters when you catch these: **which errors close the channel and which leave it alive.** The "Recovery" column mixed three terminal errors with one recoverable one without saying so.

## Change

Adds a **`Channel after`** column (`Closed` / `Open`) to `docs/pages/channel/+Page.mdx`:

| Error | Channel after |
|---|---|
| `Abort` | Closed |
| `NetworkError` (`isChannel: true`) | Closed |
| `ChannelClosedError` | Closed |
| `ChannelOverflowError` | **Open** |

So it's clear at a glance that `ChannelOverflowError` is recoverable backpressure (a single buffered send was dropped to honor `config.channel.bufferLimit` while the peer was disconnected — the channel keeps working), whereas the other three are terminal.

Also in this PR:
- A note that a **graceful `close()` is not an error** — `onClose(err)` receives `undefined`.
- The `ChannelClosedError` row now covers its full surface: the synchronous send-after-close throw **and** the rejection of pending `ack` sends orphaned by a close / close timeout.
- `Abort` broadened — either side can `abort(value)`, and a callback that throws `Abort` auto-aborts.
- The `onClose` example branches on `NetworkError` instead of the vague "Network error or timeout".

Docs-only; no code changes.

https://claude.ai/code/session_015FgWpH5K8aA5N79XJCnjhk

---
_Generated by [Claude Code](https://claude.ai/code/session_015FgWpH5K8aA5N79XJCnjhk)_