### PR TITLE
docs: remaining review findings (withContext, migration, testing, end-to-end, pitfalls)

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -414,6 +414,11 @@ config.channel = {
 }
 ```
 
+> **What to tune** — defaults suit typical chat/dashboard traffic; reach for these only if you hit one:
+> - Slow/flaky clients dropping with `ChannelNetworkError` → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).
+> - `ChannelOverflowError` while a peer is briefly offline → raise `bufferLimit` / `bufferLimitBinary`, or apply backpressure by `await`-ing your `send()`s.
+> - Reconnects should replay more history → raise the replay buffers; lower them to cap memory.
+
 
 ## See also
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -200,21 +200,7 @@ chat.send({ type: 'ping' }) // sent immediately, no await needed
 
 ## new Broadcast()
 
-`new Broadcast({ key })` creates one member of a broadcast group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to it.
-
-```ts
-// Chat.telefunc.ts
-// Environment: server
-
-import { Broadcast } from 'telefunc'
-
-export async function onJoinChat() {
-  const chat = new Broadcast<ChatMessage>({ key: 'chat:lobby' })
-  return chat
-}
-```
-
-Return the broadcast instance directly from a telefunction — no `.client` needed (unlike channels, broadcast has no directional type flip).
+`new Broadcast({ key })` creates one member of a broadcast group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to it. Return the broadcast instance directly from a telefunction — no `.client` needed (unlike channels, broadcast has no directional type flip).
 
 > **Keys are capabilities** — anyone who forms the same `key` joins the group. Secure a broadcast one of two ways:
 > - **Guard the key**: derive it from **authorized server-side context** (e.g. the user from <Link text="getContext()" href="/getContext" />), never from raw client input — see <Link href="/real-time#authorization" />.

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -422,6 +422,7 @@ config.channel = {
 
 ## See also
 
+- <Link href="/live" />
 - <Link href="/real-time" />
 - <Link href="/stream" />
 - <Link href="/file-upload" />

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -68,6 +68,8 @@ export async function* onChat(prompt: string) {
 }
 ```
 
+> **Pitfall:** anything a long-lived telefunction opens — `setInterval`, an event subscription, a DB cursor, an upstream stream — outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down here.
+
 
 ## Automatic cleanup (GC)
 

--- a/docs/pages/httpHeaders/+Page.mdx
+++ b/docs/pages/httpHeaders/+Page.mdx
@@ -19,6 +19,8 @@ config.headers = {
 
 > **Note**: `config.httpHeaders` is deprecated — use `config.headers` instead.
 
+> For headers on a **single call** rather than globally, use <Link text={<code>withContext()</code>} href="/transport#per-call-overrides" />.
+
 <ConfigWhereClient />
 
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -227,6 +227,26 @@ room.publish({ user: 'Alice', text: 'Hello!' }) // checked against ChatMessage o
 Deploy it on a long-running server or Cloudflare Workers — not typical serverless. See <Link href="/scaling" /> and <Link href="/cloudflare" />.
 
 
+## Testing
+
+Telefunctions are plain functions — unit-test them by importing and calling them directly. Supply the <Link text="context" href="/getContext" /> with `provideTelefuncContext()`:
+
+```ts
+// ChatRoom.telefunc.test.ts
+// Environment: server
+
+import { provideTelefuncContext } from 'telefunc'
+import { onJoinRoom } from './ChatRoom.telefunc'
+
+test('rejects a non-member of the room', async () => {
+  provideTelefuncContext({ user: { id: 1, rooms: [] } })
+  await expect(onJoinRoom('general')).rejects.toThrow() // throws Abort()
+})
+```
+
+For the wire protocol itself — reconnection, multi-client broadcast, transport upgrades — use an end-to-end test against a running server.
+
+
 ## See also
 
 - <Link href="/live" />

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -194,6 +194,39 @@ See <Link href="/channel#reconnection" text="Channel reconnection" /> for detail
 > Channels run over **SSE** and upgrade to **WebSocket** automatically when your <Link text="server" href="/server" /> enables it — no client config. See <Link href="/transport" /> for the comparison.
 
 
+## End-to-end example
+
+A complete chat room with the pieces assembled — authorize at open, broadcast a typed message (the type doubles as the runtime <Link href="/shield" text="shield" />), then deploy.
+
+```ts
+// ChatRoom.telefunc.ts
+// Environment: server
+
+import { Broadcast, getContext, Abort } from 'telefunc'
+
+type ChatMessage = { user: string; text: string }
+
+export async function onJoinRoom(roomId: string) {
+  const { user } = getContext()
+  if (!user || !user.rooms.includes(roomId)) throw Abort() // authorize at open
+  return new Broadcast<ChatMessage>({ key: `room:${roomId}` })
+}
+```
+
+```tsx
+// ChatRoom.tsx
+// Environment: client
+
+import { onJoinRoom } from './ChatRoom.telefunc'
+
+const room = await onJoinRoom('general')
+room.subscribe((msg) => appendMessage(msg))
+room.publish({ user: 'Alice', text: 'Hello!' }) // checked against ChatMessage on the server
+```
+
+Deploy it on a long-running server or Cloudflare Workers — not typical serverless. See <Link href="/scaling" /> and <Link href="/cloudflare" />.
+
+
 ## See also
 
 - <Link href="/live" />

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -196,6 +196,7 @@ See <Link href="/channel#reconnection" text="Channel reconnection" /> for detail
 
 ## See also
 
+- <Link href="/live" />
 - <Link href="/tanstack-query" />
 - <Link href="/rxjs" />
 - <Link href="/redis" />

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -2,6 +2,8 @@ import { Link } from '@brillout/docpress'
 
 Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use `new Telefunc()`.
 
+> **Upgrading from `telefunc()`?** The old `telefunc(req)` middleware has been replaced — use `new Telefunc()` (full runtime: streaming, channels, WebSocket) as shown below, or the low-level <Link text="serve()" href="/serve" /> if you just need a request handler.
+
 
 ## Node.js
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -243,6 +243,7 @@ See <Link href="/error-handling#streaming-and-channel-errors" text="Error handli
 
 ## See also
 
+- <Link href="/live" />
 - <Link href="/real-time" />
 - <Link href="/file-upload" />
 - <Link href="/file-download" />

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -89,9 +89,9 @@ All channels share a single multiplexed connection per server URL, so opening ma
 | Full-duplex channels | `config.channel.transports = ['sse', 'ws']` + <Link text="Server setup" href="/server" /> |
 
 
-## Per-call override
+## Per-call overrides
 
-Override the transport for a single call using `withContext()`:
+`withContext(fn, context)` from `telefunc/client` wraps a telefunction with per-call client context — not only transport, but also an `AbortSignal`, extra headers, and a URL override:
 
 ```ts
 // Environment: client
@@ -99,11 +99,15 @@ Override the transport for a single call using `withContext()`:
 import { onAIChat } from './Chat.telefunc'
 import { withContext } from 'telefunc/client'
 
-const gen = withContext(onAIChat, {
-  stream: { transport: 'channel' },
-  channel: { transports: ['ws'] },
-})('Tell me a joke')
+const call = withContext(onAIChat, {
+  signal,                            // abort this call (and any channels it opens)
+  headers: { 'x-trace': traceId },   // extra HTTP headers, just for this call
+  telefuncUrl: '/api/_telefunc',     // override config.telefuncUrl for this call
+  stream: { transport: 'channel' },  // override config.stream.transport
+  channel: { transports: ['ws'] },   // override config.channel.transports
+})
 
+const gen = call('Tell me a joke')
 for await (const token of gen) {
   console.log(token)
 }


### PR DESCRIPTION
The remaining open review findings — **one commit each**.

| Commit | Finding | What |
|---|---|---|
| `docs: make withContext() discoverable` | **F14** | `withContext()` was shown only on `transport`, for transport only. Document everything it sets (`signal`, `headers`, `telefuncUrl`, `stream`, `channel`) and add a pointer from `httpHeaders` for per-call headers. |
| `docs(server): migration note` | **F18** | The `telefunc()` middleware was removed (no longer exported), its page deleted, examples moved — but nothing pointed existing users to `serve()` / `new Telefunc()`. One-line upgrade note. |
| `docs(real-time): testing` | **F10** | No guidance on testing real-time telefunctions. Documents the grounded approach — unit-test the plain function with `provideTelefuncContext()`; e2e for the wire protocol. |
| `docs(real-time): end-to-end example` | **F11** | The pieces existed in separate sections but no single assembled walkthrough. Adds a capstone chat-room example (auth at open + typed broadcast + deploy pointer). |
| `docs(close): cleanup pitfall` | **F15** | Callout that resources opened in a long-lived telefunction leak unless released in `onClose()`. |
| `docs(channel): drop duplicate onJoinChat` | **F16** | The Broadcast section defined `onJoinChat` twice; merged the bare one into the prose. |
| `docs(channel): config.channel tuning` | **F20** | "What to tune" note tied to the actual symptoms (`ChannelNetworkError`, `ChannelOverflowError`). |
| `docs: link deep-dives to the overview` | **F9** | Add `/live` to the See-also of `stream`/`real-time`/`channel` (reframed from the weaker "propagate the vocabulary" idea — which I'd otherwise skip as over-systematizing). |

**Not included — F19 (framework example repos):** this needs example *apps* to be created (there are no channel/real-time demos to link), so it isn't a docs-only change. Flagging rather than faking a link.

## Verification
- `tsc --noEmit` — clean (`withContext` field types, etc.).
- `vike build` — clean; every `Link` (incl. the new `/transport#per-call-overrides` anchor and `/live` back-links) resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_