### PR TITLE
docs: whole-cluster cohesion pass (de-duplication + consistency)

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -393,7 +393,7 @@ If the connection drops, Telefunc reconnects automatically and resumes existing 
 | `ChannelOverflowError` | A buffered send was dropped — backlog exceeded `config.channel.bufferLimit` while the peer was disconnected | **Open** | Only the dropped `send()` rejects; `await` sends to apply backpressure |
 
 
-## Config
+## Configuration
 
 ```ts
 // Environment: server
@@ -416,7 +416,7 @@ config.channel = {
 }
 ```
 
-> **What to tune** — defaults suit typical chat/dashboard traffic; reach for these only if you hit one:
+> **What to tune**: defaults suit typical chat/dashboard traffic; reach for these only if you hit one:
 > - Slow/flaky clients dropping with `ChannelNetworkError` → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).
 > - `ChannelOverflowError` while a peer is briefly offline → raise `bufferLimit` / `bufferLimitBinary`, or apply backpressure by `await`-ing your `send()`s.
 > - Reconnects should replay more history → raise the replay buffers; lower them to cap memory.

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -315,7 +315,7 @@ You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast
 | Message type | Asymmetric:<ul><li>Two different types: `Channel<ClientMessageType, ServerMessageType>`</li><li>The server uses the `channel = new Channel()` instance and returns `channel.client` for the client (asymmetric)</li></ul> | Symmetric:<ul><li>Same type for every member: `Broadcast<MessageType>`</li><li>The server uses and returns the same instance `Broadcast` (symmetric)</li></ul> |
 | Message return | The other end's reply (if `{ ack: true }`) | A receipt: `{ key, seq, timestamp }` |
 | `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
-| Multi-server | [Sticky sessions](/scaling) | [Broadcast transport](#multi-server) |
+| Multi-server | <Link text="Sticky sessions" href="/scaling" /> | <Link text="Broadcast transport" href="#multi-server" /> |
 
 
 ## Multi-server

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -68,7 +68,7 @@ export async function* onChat(prompt: string) {
 }
 ```
 
-> **Pitfall:** anything a long-lived telefunction opens — `setInterval`, an event subscription, a DB cursor, an upstream stream — outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down here.
+> **Pitfall**: anything a long-lived telefunction opens — `setInterval`, an event subscription, a DB cursor, an upstream stream — outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down here.
 
 
 ## Automatic cleanup (GC)

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -16,7 +16,7 @@ Telefunc supports real-time use cases — chat, file upload progress, live updat
 | **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE), or <Link text="WebSocket server setup" href="/server" /> (WS) |
 | **`new Broadcast()`** | Broadcast messaging — chat rooms, live feeds, notifications | Same as channels |
 
-> See also: [`Channel` vs `Broadcast`](/channel#channel-vs-broadcast)
+> See also: <Link text={<><code>Channel</code> vs <code>Broadcast</code></>} href="/channel#channel-vs-broadcast" />
 
 > **Runtime safety**: whichever primitive you use, every value the client sends to the server is shield-validated against your TypeScript types before it reaches your code — function-call <Link href="/shield#function-arguments" text="arguments" />, <Link href="/shield#channels" text="channel messages" />, and broadcast <Link href="/shield#broadcast" text="publishes" />. A failing check is rejected with `ShieldValidationError`.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -149,15 +149,15 @@ See <Link href="/channel#new-broadcast" /> for the full `Broadcast` API.
 A channel or broadcast is opened by a telefunction, so you protect it like any other telefunction (see <Link href="/permissions" />): authorize **at open time** with <Link text="getContext()" href="/getContext" /> and `throw Abort()`.
 
 ```ts
-// Chat.telefunc.ts
+// Team.telefunc.ts
 // Environment: server
 
 import { Broadcast, getContext, Abort } from 'telefunc'
 
-export async function onJoinChat(roomId: string) {
+export async function onJoinTeam(teamId: string) {
   const { user } = getContext()
-  if (!user || !user.rooms.includes(roomId)) throw Abort()
-  return new Broadcast({ key: `chat:${roomId}` })
+  if (!user || !user.teams.includes(teamId)) throw Abort()
+  return new Broadcast({ key: `team:${teamId}` })
 }
 ```
 
@@ -199,15 +199,15 @@ See <Link href="/channel#reconnection" text="Channel reconnection" /> for detail
 Telefunctions are plain functions — unit-test them by importing and calling them directly. Supply the <Link text="context" href="/getContext" /> with `provideTelefuncContext()`:
 
 ```ts
-// Chat.telefunc.test.ts
+// Team.telefunc.test.ts
 // Environment: server
 
 import { provideTelefuncContext } from 'telefunc'
-import { onJoinChat } from './Chat.telefunc'
+import { onJoinTeam } from './Team.telefunc'
 
-test('rejects a non-member of the room', async () => {
-  provideTelefuncContext({ user: { id: 1, rooms: [] } })
-  await expect(onJoinChat('general')).rejects.toThrow() // throws Abort()
+test('rejects a non-member of the team', async () => {
+  provideTelefuncContext({ user: { id: 1, teams: [] } })
+  await expect(onJoinTeam('acme')).rejects.toThrow() // throws Abort()
 })
 ```
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -194,53 +194,20 @@ See <Link href="/channel#reconnection" text="Channel reconnection" /> for detail
 > Channels run over **SSE** and upgrade to **WebSocket** automatically when your <Link text="server" href="/server" /> enables it — no client config. See <Link href="/transport" /> for the comparison.
 
 
-## End-to-end example
-
-A complete chat room with the pieces assembled — authorize at open, broadcast a typed message (the type doubles as the runtime <Link href="/shield" text="shield" />), then deploy.
-
-```ts
-// ChatRoom.telefunc.ts
-// Environment: server
-
-import { Broadcast, getContext, Abort } from 'telefunc'
-
-type ChatMessage = { user: string; text: string }
-
-export async function onJoinRoom(roomId: string) {
-  const { user } = getContext()
-  if (!user || !user.rooms.includes(roomId)) throw Abort() // authorize at open
-  return new Broadcast<ChatMessage>({ key: `room:${roomId}` })
-}
-```
-
-```tsx
-// ChatRoom.tsx
-// Environment: client
-
-import { onJoinRoom } from './ChatRoom.telefunc'
-
-const room = await onJoinRoom('general')
-room.subscribe((msg) => appendMessage(msg))
-room.publish({ user: 'Alice', text: 'Hello!' }) // checked against ChatMessage on the server
-```
-
-Deploy it on a long-running server or Cloudflare Workers — not typical serverless. See <Link href="/scaling" /> and <Link href="/cloudflare" />.
-
-
 ## Testing
 
 Telefunctions are plain functions — unit-test them by importing and calling them directly. Supply the <Link text="context" href="/getContext" /> with `provideTelefuncContext()`:
 
 ```ts
-// ChatRoom.telefunc.test.ts
+// Chat.telefunc.test.ts
 // Environment: server
 
 import { provideTelefuncContext } from 'telefunc'
-import { onJoinRoom } from './ChatRoom.telefunc'
+import { onJoinChat } from './Chat.telefunc'
 
 test('rejects a non-member of the room', async () => {
   provideTelefuncContext({ user: { id: 1, rooms: [] } })
-  await expect(onJoinRoom('general')).rejects.toThrow() // throws Abort()
+  await expect(onJoinChat('general')).rejects.toThrow() // throws Abort()
 })
 ```
 

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -188,7 +188,7 @@ export async function getUser(id: string) {
 
 ### Channels
 
-[`new Channel<ClientToServer, ServerToClient>()`](/channel) declares two typed directions, each a function signature `(msg) => ack`. Telefunc generates two sub-shields that fire on the server:
+<Link href="/channel" text={<code>{'new Channel<ClientToServer, ServerToClient>()'}</code>} /> declares two typed directions, each a function signature `(msg) => ack`. Telefunc generates two sub-shields that fire on the server:
 
 - **`data`** — validates messages arriving from the client (input to `listen()`).
 - **`ack`** — validates the ack returned by the client's `listen()` to a server-initiated `send(..., { ack: true })`.
@@ -213,7 +213,7 @@ await events.send({ tick: 1 }, { ack: true })
 
 ### Broadcast
 
-[`new Broadcast<T>({ key })`](/channel#new-broadcast) declares the message type `T` flowing through a keyed broadcast topic. Telefunc generates a `data` sub-shield that fires on the server when a client calls `publish()` on a `Broadcast` returned from a telefunction:
+<Link href="/channel#new-broadcast" text={<code>{'new Broadcast<T>({ key })'}</code>} /> declares the message type `T` flowing through a keyed broadcast topic. Telefunc generates a `data` sub-shield that fires on the server when a client calls `publish()` on a `Broadcast` returned from a telefunction:
 
 ```ts
 // Chat.telefunc.ts

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -187,10 +187,10 @@ await onIngest(stream, 'data.txt')
 A telefunction can return any combination of generators, streams, and promises.
 
 ```ts
-// Dashboard.telefunc.ts
+// Feed.telefunc.ts
 // Environment: server
 
-export async function onLoadDashboard() {
+export async function onLoadFeed() {
   async function* notifications(): AsyncGenerator<string> {
     for (const n of await fetchNotifications()) {
       yield n.text
@@ -198,7 +198,7 @@ export async function onLoadDashboard() {
   }
 
   return {
-    title: 'Dashboard',
+    title: 'Feed',
     stream: notifications(),
     fast: Promise.resolve({ count: 42 }),
     slow: fetchExtensiveReport(),
@@ -207,12 +207,12 @@ export async function onLoadDashboard() {
 ```
 
 ```tsx
-// Dashboard.tsx
+// Feed.tsx
 // Environment: client
 
-import { onLoadDashboard } from './Dashboard.telefunc'
+import { onLoadFeed } from './Feed.telefunc'
 
-const res = await onLoadDashboard()
+const res = await onLoadFeed()
 
 // Static values — available immediately
 console.log(res.title)

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -8,7 +8,7 @@ Live queries for [TanStack Query](https://tanstack.com/query) — server-side qu
 
 ## Install
 
-```shell
+```bash
 npm install @telefunc/tanstack-query
 ```
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -72,6 +72,8 @@ All channels share a single multiplexed connection per server URL, so opening ma
 | `'sse'` | 🟡 | ✅ | ✅ | None |
 | `'ws'` | ✅ | ✅ | 🟡 | <Link text="Server setup" href="/server" /> |
 
+### When to use what
+
 - **Start with `'sse'`** — it works everywhere out of the box.
 - **Use `'ws'`** for chatty real-time traffic where you want full-duplex.
 


### PR DESCRIPTION
A whole-cluster cohesion pass — I audited every dimension across all 14 streaming/real-time pages, not localized patches. Each commit is one dimension.

## Fixed

**Duplication**
- **Removed the duplicate `End-to-end example`** (`real-time`): its auth'd-broadcast server function near-duplicated the Authorization example, its client mirrored Broadcast → Chat room, and its deploy line repeated the Deployment note. Rewired Testing to the Authorization example.
- **Conflicting same-file definitions** — two telefunctions claimed the same file with different bodies:
  - `real-time`: `Chat.telefunc.ts`/`onJoinChat` (Chat room **and** Authorization) → Authorization now `Team.telefunc.ts`/`onJoinTeam`.
  - `stream`: `Dashboard.telefunc.ts`/`onLoadDashboard` (Nested Promise **and** Mixed return types) → Mixed now `Feed.telefunc.ts`/`onLoadFeed`.

**Consistency**
- **Internal links**: 4 markdown `[…](/x)` links → `<Link>` (the cluster's convention), generics/braces handled with a `{'…'}` literal.
- **Code fences**: `tanstack-query` `npm install` used ` ```shell `; → ` ```bash ` to match `redis`/`rxjs`.
- **Headings**: `channel` `## Config` → `## Configuration` (matches `cloudflare`).
- **`transport`**: gave Channel transport the same `### When to use what` subsection as Stream transport.
- **Callout punctuation**: labeled notes now consistently `> **Label**:` (fixed `**Pitfall:**` and `**What to tune** —`).

## Audited and already cohesive (no change)
- **Terminology**: `WebSocket` (lowercase only in code/URLs), `real-time` adjective vs the correct adverbial "in real time", `telefunction`, `server-side`/`client-side` — all consistent.
- **`**Environment**` annotation**: consistent by rule — single-environment pages carry it; multi-environment pages annotate per code block.
- **Heading case**: uniformly sentence-case.
- **`See also`**: same format on every page except `/live` (the router, intentionally none).

## Deliberately left (with reason)
- `getContext`'s repeated `myTelefunction`/`someTelefunction`: deliberate ❌/✅ illustrations and `*.telefunc.ts` wildcards (generic placeholders, not conflicts).
- `file-upload`'s two `onUpload`: in two **different** self-contained example files (`FileUpload.telefunc.ts`, `Upload.telefunc.ts`) — not a same-file conflict.
- Cross-page scenario reuse (e.g. `onJoinRoom` on `channel` and `real-time`): each page is self-contained.

## Verification
- `tsc --noEmit` — clean. `vike build` — clean; every `Link` resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_