### PR TITLE
docs: close public-API documentation gaps (abort, provideTelefuncContext, config namespaces)

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -46,6 +46,16 @@ await channel.close()
 
 All of these signal the server to stop producing and release resources.
 
+> `close()` ends a value **gracefully** (buffered data is flushed). To stop a call **immediately** instead, pass the pending call to `abort()` — the underlying request is cancelled and the result rejects with an `Abort` error (mid-stream, the next read rejects):
+> ```ts
+> // Environment: client
+>
+> import { abort } from 'telefunc/client'
+>
+> const call = onLoadDashboard()
+> abort(call) // cancels the in-flight call
+> ```
+
 
 ## `onClose()` (server)
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -118,6 +118,15 @@ app.all('/_telefunc', async (req, res, next) => {
   </TabPanel>
 </Tabs>
 
+> **Outside `serve()`** (server-side rendering, unit tests) — when a telefunction isn't reached through `tf.serve()`, provide the context with `provideTelefuncContext()` before it runs:
+> ```ts
+> // Environment: server
+>
+> import { provideTelefuncContext } from 'telefunc'
+>
+> provideTelefuncContext({ user })
+> ```
+
 ## Access
 
 If you get this error:

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 Telefunc integrates with any server. For production deployments with streaming, channels, and WebSocket support, use `new Telefunc()`.
 
-> **Upgrading from `telefunc()`?** The old `telefunc(req)` middleware has been replaced — use `new Telefunc()` (full runtime: streaming, channels, WebSocket) as shown below, or the low-level <Link text="serve()" href="/serve" /> if you just need a request handler.
+> **Upgrading from `telefunc()`?** `telefunc()` was renamed to <Link text="serve()" href="/serve" /> — it still works but is deprecated. Use `serve()` for a low-level request handler, or `new Telefunc()` (below) for the full runtime: streaming, channels, WebSocket.
 
 
 ## Node.js

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -116,6 +116,14 @@ for await (const token of gen) {
 ```
 
 
+## Channel & broadcast config
+
+Beyond transport, channels and broadcasts expose more `config` (server-side):
+
+- **`config.channel`** — reconnect/idle timeouts and per-peer buffer limits. See <Link href="/channel#configuration" />.
+- **`config.broadcast.transport`** — cross-instance broadcast for multi-server deployments. See <Link href="/channel#multi-server" />, or <Link href="/redis" /> for the Redis adapter.
+
+
 ## See also
 
 - <Link href="/stream" />


### PR DESCRIPTION
From the API-coverage + page-structure review. Each commit closes one gap I verified against the actual exports.

| Commit | Gap |
|---|---|
| `docs(close)` | **`abort()` (client)** — "immediately abort a telefunc call" — was a public API documented nowhere. Added it to `/close`, contrasted with graceful `close()`. |
| `docs(getContext)` | **`provideTelefuncContext()`** — provide context outside `serve()` (SSR, tests) — appeared only inside the real-time Testing example. Gave it a brief home in the Provide section. |
| `docs(transport)` | **`config.channel` / `config.broadcast`** were documented only on `/channel`, absent from the Config section. Added a pointer on `/transport` (the Config-section streaming page). |
| `docs(server)` | **`telefunc()` clarification** — it isn't removed; it's a `@deprecated` alias of `serve()`. Reworded the upgrade note to say so (my earlier note implied it was gone). |

## Deliberately NOT done (with reasons — flagging, not skipping silently)

- **`telefunc/react` (`useGenerator`) and `telefunc/react-streaming` (`useData`)** — `useGenerator` is marked **`@experimental — DO NOT USE unless you reached out to a maintainer — will break on minor releases`**. So these are intentionally undocumented; I'm not documenting an API you've gated. (Heads-up in case that marker is stale.)
- **`provideTelefuncContext` has a commented-out deprecation TODO** (tied to Async Hooks for Nuxt). It's currently supported (deprecation inactive) so I documented it briefly — but if you intend to deprecate it, say so and I'll reframe both this and the Testing example.
- **Page restructures you flagged as your call** — the `/serve`↔`/server` merge, and re-grouping `Scaling`/`Cloudflare`/`redis` (which you already kept as-is). Not touched.
- **Minor:** `download()` has the `/file-download` guide but no API-section entry; `DefaultBroadcastAdapter`/`BroadcastAdapter` (custom-transport types) left undocumented as advanced. Say the word if you want either.

## Verification
- `tsc --noEmit` — clean. `vike build` — clean; all `Link`s (incl. `/channel#configuration`, `/channel#multi-server`) resolve.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_