### PR TITLE
docs: dedicated pages for new Telefunc() and provideTelefuncContext()

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -218,6 +218,11 @@ const headings = [
     url: '/getContext',
   },
   {
+    level: 2,
+    title: '`provideTelefuncContext()`',
+    url: '/provideTelefuncContext',
+  },
+  {
     level: 4,
     title: 'Protection',
   },

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -238,6 +238,11 @@ const headings = [
   },
   {
     level: 2,
+    title: '`new Telefunc()`',
+    url: '/Telefunc',
+  },
+  {
+    level: 2,
     title: '`serve()`',
     url: '/serve',
   },

--- a/docs/pages/Telefunc/+Page.mdx
+++ b/docs/pages/Telefunc/+Page.mdx
@@ -1,0 +1,50 @@
+import { Link } from '@brillout/docpress'
+
+**Environment**: server.
+
+`new Telefunc()` is the runtime adapter that processes telefunction requests — including <Link href="/stream">streaming</Link> and <Link href="/real-time">real-time</Link> (channels, WebSocket). Import it from the entry point for your runtime:
+
+```ts
+import { Telefunc } from 'telefunc/node' // or telefunc/bun, telefunc/deno, telefunc/cloudflare
+
+const tf = new Telefunc()
+```
+
+> For per-runtime setup see <Link href="/server" />, and <Link href="/cloudflare" /> for Cloudflare specifics. For a low-level request handler without channels, use <Link href="/serve" />.
+
+
+## Methods
+
+| Method | Runtime | Description |
+|---|---|---|
+| `serve(input)` | all | Process a request and return the response. The input shape (`{ request }`, `{ req, res }`, `{ request, env, ctx }`, …) and return type vary by runtime — see <Link href="/server#return-value" />. |
+| `installWebSocket(server)` | Node | Enable WebSocket channels on your HTTP server. Idempotent. |
+| `websocket` | Bun | The WebSocket handler — pass it to `Bun.serve({ websocket })`. |
+| `TelefuncDurableObject` | Cloudflare | The Durable Object class to export — see <Link href="/cloudflare" />. |
+
+
+## Context
+
+Provide the <Link text="getContext()" href="/getContext" /> data per request — on Node/Bun/Deno via `serve({ context })`, on Cloudflare via the `context` constructor option:
+
+```ts
+// Node / Bun / Deno
+await tf.serve({ request, context: { user } })
+
+// Cloudflare
+const tf = new Telefunc({ context: (request, env) => ({ user }) })
+```
+
+See <Link href="/getContext#provide" />.
+
+
+## Configuration (Cloudflare)
+
+On Cloudflare the constructor also takes `bindingName`, `kvBindingName`, `scale`, `locationFallback`, `jurisdiction`, … — see <Link href="/cloudflare#configuration" />.
+
+
+## See also
+
+- <Link href="/server" />
+- <Link href="/serve" />
+- <Link href="/cloudflare" />

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -118,14 +118,7 @@ app.all('/_telefunc', async (req, res, next) => {
   </TabPanel>
 </Tabs>
 
-> **Outside `serve()`** (server-side rendering, unit tests) — when a telefunction isn't reached through `tf.serve()`, provide the context with `provideTelefuncContext()` before it runs:
-> ```ts
-> // Environment: server
->
-> import { provideTelefuncContext } from 'telefunc'
->
-> provideTelefuncContext({ user })
-> ```
+> **Outside `serve()`** (server-side rendering, unit tests): provide the context with <Link text={<code>provideTelefuncContext()</code>} href="/provideTelefuncContext" />.
 
 ## Access
 

--- a/docs/pages/provideTelefuncContext/+Page.mdx
+++ b/docs/pages/provideTelefuncContext/+Page.mdx
@@ -1,0 +1,24 @@
+import { Link } from '@brillout/docpress'
+
+**Environment**: server.
+
+`provideTelefuncContext()` makes the `context` object available to telefunctions via <Link href="/getContext" text="getContext()" /> — for when a telefunction runs **outside `tf.serve()`**, such as server-side rendering or unit tests.
+
+```ts
+// Environment: server
+
+import { provideTelefuncContext } from 'telefunc'
+
+provideTelefuncContext({ user })
+// getContext() inside telefunctions now returns { user }
+```
+
+Call it before the telefunction runs (e.g. in a test's setup, or your SSR request handler).
+
+> Through <Link text="serve()" href="/serve" /> / <Link text="new Telefunc()" href="/Telefunc" />, the context is provided for you — see <Link href="/getContext#provide" />. Reach for `provideTelefuncContext()` only when a telefunction runs without going through them.
+
+
+## See also
+
+- <Link href="/getContext" />
+- <Link href="/server" />


### PR DESCRIPTION
Two dedicated API pages, one commit each.

| Commit | Page | What |
|---|---|---|
| `docs: add /Telefunc` | **`/Telefunc`** (new) | The primary runtime API (`new Telefunc()`) had no reference page while the low-level `serve()` did. Added one — methods (per runtime), context (per-`serve()` on Node/Bun/Deno, constructor option on Cloudflare), CF options — verified against source. `/server` stays the integration guide. Nav: under Server Middleware. |
| `docs: add /provideTelefuncContext` | **`/provideTelefuncContext`** (new) | Promoted from the brief inline mention to a dedicated page; `/getContext` links to it. Nav: under Context. |

**`onClose()` stays defined on `/close`** (per your call) — the earlier `/onClose` promotion commit was dropped from this PR.

**Already shipped (merged #313), so not repeated here:** `abort()` docs, config-namespace discoverability, and the `telefunc()` deprecation clarification.

## Verification
- `tsc --noEmit` — clean (nav `HeadingsURL` types check the two new routes). `vike build` — clean; both pages render and every `Link` (incl. `/Telefunc`, `/provideTelefuncContext`, `/server#return-value`, `/cloudflare#configuration`) resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_