### PR TITLE
docs: tighten and clarify the streaming docs

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -200,7 +200,7 @@ chat.send({ type: 'ping' }) // sent immediately, no await needed
 
 ## new Broadcast()
 
-`new Broadcast({ key })` creates one member of a broadcast group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to it. Return the broadcast instance directly from a telefunction — no `.client` needed (unlike channels, broadcast has no directional type flip).
+`new Broadcast({ key })` creates one member of a broadcast group. All instances created with the same `key`, on the server or on clients, form the group: `publish()` delivers a message to every subscriber of the key, including the publishing instance itself, and `subscribe()` receives every message published to the key. Return the broadcast instance directly from a telefunction — no `.client` needed (unlike channels, broadcast has no directional type flip).
 
 > **Keys are capabilities** — anyone who forms the same `key` joins the group. Secure a broadcast one of two ways:
 > - **Guard the key**: derive it from **authorized server-side context** (e.g. the user from <Link text="getContext()" href="/getContext" />), never from raw client input — see <Link href="/real-time#authorization" />.
@@ -312,7 +312,7 @@ You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast
 | Topology | One server ↔ one client | All members sharing a `key` (server and client) |
 | Methods | `send()` / `listen()` | `publish()` / `subscribe()` |
 | Delivery | The other end | Every subscriber of the `key`, including the publisher |
-| Message type | Asymmetric:<ul><li>Two different types: `Channel<ClientMessageType, ServerMessageType>`</li><li>The server uses the `channel = new Channel()` instance and returns `channel.client` for the client (asymmetric)</li></ul> | Symmetric:<ul><li>Same type for every member: `Broadcast<MessageType>`</li><li>The server uses and returns the same instance `Broadcast` (symmetric)</li></ul> |
+| Message type | Asymmetric:<ul><li>Two different types: `Channel<ClientMessageType, ServerMessageType>`</li><li>The server uses the `new Channel()` instance and returns `channel.client` to the client</li></ul> | Symmetric:<ul><li>Same type for every member: `Broadcast<MessageType>`</li><li>The server uses and returns the same `Broadcast` instance</li></ul> |
 | Message return | The other end's reply (if `{ ack: true }`) | A receipt: `{ key, seq, timestamp }` |
 | `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
 | Multi-server | <Link text="Sticky sessions" href="/scaling" /> | <Link text="Broadcast transport" href="#multi-server" /> |

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -176,7 +176,7 @@ A KV record is created on subscribe and deleted on unsubscribe. If a Durable Obj
 |---|---|
 | Ordering | Publishes for a given key are serialized and delivered in order. |
 | Delivery | `publish()` resolves after all Durable Objects with subscribers have received the message. Client delivery happens over the channel wire. |
-| Presence lag | Up to 90 seconds. A new subscriber may miss a publish until its KV record is written (typically a few milliseconds). |
+| Presence lag | A new subscriber may miss publishes until its KV presence record is written — typically a few milliseconds. |
 
 > Once a broadcast message reaches a Durable Object, it has the same buffering and replay guarantees as regular channel messages.
 

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -165,7 +165,7 @@ If the user's browser can't connect to your server:
 > `NetworkError` covers both regular telefunction calls and channels — read `err.isChannel` to tell them apart (`false` for regular calls, `true` for channels). Regular calls still throw `ConnectionError` (now a `NetworkError` subclass), so existing `instanceof ConnectionError` checks keep working.
 
 
-## Streaming and channel errors
+## Streaming
 
 The expected-vs-bug distinction above applies to <Link href="/stream">streamed</Link> and <Link href="/real-time">real-time</Link> values too.
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -5,7 +5,7 @@ import { StreamingBeta } from '../../components'
 
 Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) from a telefunction like any other value. The client receives a standard `File` / `Blob` ready for `URL.createObjectURL`, `<img src>`, `fetch({ body })`, `FormData`, etc.
 
-> For large downloads or bytes streamed through your server from an upstream source, use `download()` to get progress, cancel, and save-to-disk support without buffering the full payload — on the server OR the client.
+> For large downloads, or bytes streamed through your server from an upstream source, use `download()` — it adds progress, cancel, and save-to-disk, without ever buffering the full payload (on either the server or the client).
 
 
 ## Which one should I use?

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -213,7 +213,7 @@ export async function someTelefunction() {
 
 ## `onClose()`
 
-The context object returned by `getContext()` also includes `onClose()`, a callback that fires when the request lifecycle ends for any reason. Fires exactly once. Use it to release resources.
+The context object returned by `getContext()` also includes `onClose()`, a callback that fires exactly once, when the request lifecycle ends for any reason. Use it to release resources.
 
 ```ts
 const context = getContext()

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -5,7 +5,7 @@ import { StreamingBeta } from '../../components'
 
 Telefunc supports real-time use cases — chat, file upload progress, live updates, ...
 
-> Instead of using Telefunc's real-time primitives yourself, consider using high-level integrations such as <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — they wrap the primitives below with an ergonomic API.
+> Before reaching for Telefunc's real-time primitives directly, consider a high-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in an ergonomic API.
 
 
 ## Which primitive should I use?

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,7 +7,7 @@ Telefunc supports streaming in both directions:
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
-> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting channel only if you need to). Plain telefunction calls are unaffected.
+> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting channel only if you need to).
 
 
 ## Which one should I use?
@@ -238,7 +238,7 @@ See <Link href="/close" /> for all cancellation methods (`close()`, `break`, `ge
 
 Telefunc distinguishes expected failures from bugs — even in streaming responses. If a generator or stream throws, the client receives a typed error while values already delivered remain available.
 
-See <Link href="/error-handling#streaming-and-channel-errors" text="Error handling — streaming & channels" /> for details.
+See <Link href="/error-handling#streaming" text="Error handling — streaming" /> for details.
 
 
 ## See also

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-Live queries for [TanStack Query](https://tanstack.com/query) — server-side query key invalidation that automatically refetches connected clients with a matching query key.
+Live queries for [TanStack Query](https://tanstack.com/query) — invalidate a query key on the server, and every connected client with a matching query refetches automatically.
 
 
 ## Install

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -61,7 +61,7 @@ Controls how <Link text={<code>new Channel()</code>} href="/channel" /> connecti
 | `'sse'` | HTTP requests + SSE stream. Works without extra server setup. |
 | `'ws'` | Multiplexed WebSocket. Requires <Link text="WebSocket server setup" href="/server" />. |
 
-The client default is `['sse', 'ws']` — start on SSE, upgrade to WebSocket when the server supports it. The server enables SSE only until a WebSocket adapter is installed (see <Link href="/server" />).
+The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE out of the box and adds WebSocket when you install an adapter (see <Link href="/server" />).
 
 All channels share a single multiplexed connection per server URL, so opening many channels doesn't open many connections.
 


### PR DESCRIPTION
A copy-editing pass over the streaming/real-time pages — succinctness, and removing ambiguity, read from a first-time visitor's perspective. One commit; prose-only, no behavior or nav changes.

**The two you flagged**
- **`/stream`** — dropped the redundant trailing `Plain telefunction calls are unaffected.`
- **`/error-handling`** — renamed the `## Streaming and channel errors` heading to `## Streaming` (and repointed the `/stream` cross-link to the new `#streaming` anchor).

**Clarity / ambiguity fixes found along the way**
- **`/transport`** — the line *"The server enables SSE only until a WebSocket adapter is installed"* read as "SSE turns off once WS is on", which contradicts the upgrade flow right below it (client *starts* on SSE, then upgrades). Reworded: the server offers SSE out of the box and **adds** WebSocket when you install an adapter.
- **`/cloudflare`** — the *Presence lag* delivery-guarantee cell conflated two different numbers (the few-ms new-subscriber window vs. the 90 s eviction TTL), so it read as self-contradictory. Kept the figure that answers the actual question ("could a new subscriber miss a publish?"); the 90 s TTL is already explained under *Presence*.
- **`/channel`** — resolved an ambiguous *"published to it"* → *"published to the key"*; dropped the redundant `(asymmetric)` / `(symmetric)` that just restated the cell's own label.
- **`/file-download`** — clarified the `download()` blurb (`on the server OR the client` → `on either the server or the client`).

**Tightening**
- **`/getContext`** — folded the `Fires exactly once.` fragment into the sentence.
- **`/real-time`** — removed a doubled "using … using".
- **`/tanstack-query`** — rewrote the one-liner intro so it doesn't say "query key" twice.

## Verification
- `tsc --noEmit` — clean. `vike build` — clean; every `<Link>` resolves, including the repointed `/error-handling#streaming` anchor.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_