### PR TITLE
docs: cohesion pass across the streaming docs

### DIFF
--- a/docs/pages/Telefunc/+Page.mdx
+++ b/docs/pages/Telefunc/+Page.mdx
@@ -1,10 +1,15 @@
 import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
 
 **Environment**: server.
 
 `new Telefunc()` is the runtime adapter that processes telefunction requests — including <Link href="/stream">streaming</Link> and <Link href="/real-time">real-time</Link> (channels, WebSocket). Import it from the entry point for your runtime:
 
 ```ts
+// Environment: server
+
 import { Telefunc } from 'telefunc/node' // or telefunc/bun, telefunc/deno, telefunc/cloudflare
 
 const tf = new Telefunc()

--- a/docs/pages/next/+Page.mdx
+++ b/docs/pages/next/+Page.mdx
@@ -5,7 +5,7 @@ Using Telefunc with [Next.js](https://nextjs.org).
 
 ## 1. Install
 
-```shell
+```bash
 npm install telefunc
 ```
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -81,7 +81,7 @@ edits.next({ userId: 'alice', text: 'Hello' })
 
 
 
-## Click heatmap (client to server)
+## Click heatmap (client → server)
 
 Pass an Observable as a telefunction argument. The server subscribes and processes the stream — useful for telemetry, analytics, or any client-driven event stream.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -14,6 +14,8 @@ Low-level function that processes telefunction requests and returns an HTTP resp
 Pass the web standard [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object:
 
 ```ts
+// Environment: server
+
 import { serve } from 'telefunc'
 
 const httpResponse = await serve({ request })

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -56,7 +56,7 @@ tf.installWebSocket(server)
 
 > The Node.js adapter auto-detects your HTTP server from the request socket. `installWebSocket()` is idempotent — calling it multiple times is safe.
 
-> **Performance tip:** prefer `{ req, res }` over `{ request }` when you have access to the raw Node.js objects (Express, raw `http`, Connect-style middleware). The `req`/`res` path reads the request body directly from the Node `Readable` and writes the response straight to the Node `Writable`, skipping the Web Streams conversion layer. Node's Web Streams implementation is slower than its internal streams; see [nodejs/performance#134](https://github.com/nodejs/performance/issues/134).
+> **Performance tip**: prefer `{ req, res }` over `{ request }` when you have access to the raw Node.js objects (Express, raw `http`, Connect-style middleware). The `req`/`res` path reads the request body directly from the Node `Readable` and writes the response straight to the Node `Writable`, skipping the Web Streams conversion layer. Node's Web Streams implementation is slower than its internal streams; see [nodejs/performance#134](https://github.com/nodejs/performance/issues/134).
 
 ### With context
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -145,6 +145,6 @@ Prefix matching — invalidating `['global:documents']` hits `['global:documents
 ## See also
 
 - <Link href="/channel" />
-- <Link href="/redis" text={<code>@telefunc/redis</code>} />
+- <Link href="/redis" />
 - <Link href="/real-time" />
 - <Link href="/cloudflare" />


### PR DESCRIPTION
A **whole-cluster** consistency audit of the streaming/real-time docs — not localized fixes. I built a matrix across all 16 new/feature pages for every cohesion dimension, then fixed each deviation. Most dimensions were already consistent (noted below); these were the outliers.

## Dimensions audited
preamble & `**Environment**` annotation · `<StreamingBeta />` marker · heading case · code-fence languages · in-code `// Environment:` headers · "See also" format · terminology · callout punctuation · internal-link style · cross-page duplication.

## Fixed
| Page | Fix | Why (the rule it now follows) |
|---|---|---|
| **`/Telefunc`** | add `<StreamingBeta />` | The only new streaming server/feature page missing the beta marker — all 13 siblings **and** `/serve` carry it. (`/getContext`, `/provideTelefuncContext` correctly omit it: core / non-streaming.) |
| **`/Telefunc`, `/serve`** | add `// Environment: server` to the primary code block | 6 of 8 single-environment reference pages already include it; these two were the only ones at zero. |
| **`/next`** | install fence `shell` → `bash` | Every other install command (`svelte-kit`, `vike`, `redis`, `rxjs`, `tanstack-query`) uses `bash`. |
| **`/rxjs`** | heading `(client to server)` → `(client → server)` | Matches the arrow in `/stream`'s `Client → server streaming` heading. |
| **`/server`** | `**Performance tip:**` → `**Performance tip**:` | Lone colon-inside-bold; every other callout is `**Label**:`. |
| **`/tanstack-query`** | "See also" `/redis` → bare `<Link>` | Every other See-also entry repo-wide is a bare `<Link>` (it already renders the `@telefunc/redis` nav title). |

## Verified already-consistent (no change)
Sentence-case headings · the `**Environment**` rule (single-env reference pages annotated, multi-env guides use per-block comments) · `on`-prefixed telefunction names · `Foo.telefunc.ts`/`Foo.tsx` example filenames · terminology (WebSocket, real-time, Durable Object — the only lowercase "websocket" are a URL + a code property; the only "real time" is the correct adverbial form) · all internal links use `<Link>` (none bypass docpress validation).

## Deliberately scoped out (flagged, not silently ignored)
- **`/event-based`** mixes `bash`+`shell` fences (1 vs 3) on its **ASCII request-flow / file-listing diagrams** — these aren't shell commands, so the correct fix is plain ` ``` ` (as `/cloudflare` already does for its diagram), not `bash`. Pre-existing and unrelated to streaming; happy to do it in a separate PR so this one stays a clean streaming-cohesion change.
- **`/RPC`** uses `jsx` (×3) vs the `tsx` used everywhere else — content-dependent (typed vs untyped JSX) and on a pre-existing non-streaming page; left out for the same reason.

## Verification
`tsc --noEmit` — clean. `vike build` — clean; every `<Link>` resolves.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_