### PR TITLE
docs: readability pass over the streaming docs

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -303,7 +303,7 @@ Only the two ends of a channel can use it, while anything that knows a `key` can
 
 ### Technically
 
-You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods tap directly.
+You can think of `new Broadcast()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods publish to and subscribe from directly.
 
 ### Comparison
 

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -42,4 +42,4 @@ Whatever you return or pass:
 
 ## Shipping to production
 
-Channels are stateful — a `Channel` lives in one server process and holds a connection open — so real-time needs a **long-running server**, not typical serverless (Vercel, Lambda), where function timeouts cut SSE connections short and there's no sticky routing for reconnects. Across multiple instances you also need sticky sessions and a cross-instance broadcast transport — see <Link href="/scaling" />. On Cloudflare Workers it's handled via Durable Objects — see <Link href="/cloudflare" />.
+Channels are **stateful** — a `Channel` lives in one server process and holds a connection open — so real-time needs a **long-running server**. Typical serverless (Vercel, Lambda) doesn't fit: function timeouts cut the connection short, and a reconnect isn't routed back to the process that holds the channel. Running several servers also needs sticky sessions and a cross-instance broadcast transport — see <Link href="/scaling" />. On Cloudflare Workers, Durable Objects handle all of this — see <Link href="/cloudflare" />.

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -161,7 +161,7 @@ export async function onJoinTeam(teamId: string) {
 }
 ```
 
-`getContext()` and `throw Abort()` only work **synchronously, before the telefunction returns** (see <Link href="/getContext#access" />). A channel outlives that — its `listen()` runs later — so **capture what you need in a closure** and check it per message:
+`getContext()` and `throw Abort()` only work **synchronously, before the telefunction returns** (see <Link href="/getContext#access" />). A channel outlives that window — its `listen()` callback runs later, after the telefunction has returned — so **capture what you need in a closure** and check it on each message:
 
 ```ts
 // Room.telefunc.ts

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -29,7 +29,7 @@ For values **passed** to a telefunction (client → server), pass a `ReadableStr
 
 ## `AsyncGenerator`
 
-The usual choice for incremental structured values.
+The usual choice for structured values that arrive one piece at a time.
 
 ```ts
 // Chat.telefunc.ts
@@ -91,7 +91,7 @@ while (true) {
 
 ## Nested `Promise`
 
-Return unawaited promises inside the response object — the client gets the surrounding values immediately while each promise resolves independently.
+Put promises inside the response object **without awaiting them**. The client receives the rest of the object immediately, and each promise resolves on its own.
 
 ```ts
 // Dashboard.telefunc.ts


### PR DESCRIPTION
A deep **readability + structure** pass over the streaming/real-time docs. I read every sentence across all 16 pages against one bar: *understandable with zero effort and minimal prerequisite knowledge*. After the prior clarity (#315) and cohesion (#316) passes, most prose already clears that bar — so this is a small, surgical set of fixes on the sentences that still made the reader decode, plus a structure review.

## Structure review (no changes — it's sound)
- **Entry point**: the landing-page "Real-time & streaming" card → `/live`, whose **"What are you moving?"** table routes the reader by use case. That's the right front door, and it answers "what do I need next?" immediately.
- **Separation of concerns**: guides (`/live`, `/stream`, `/real-time`, `/scaling`, `/cloudflare`, files, integrations) vs API references (`/channel`, `/close`, `/transport`, `/serve`, `/Telefunc`, context) are cleanly split across the Guides/API nav groups.
- **Within-page flow** is consistent: overview → decision aid → details → advanced/production. Genuinely dense material (channel "Technically", Cloudflare fan-out internals, `BroadcastTransport`) is confined to clearly-labeled advanced/skippable sections — so the main path stays easy and the depth is there when wanted.

## Sentences simplified
| Page | Before → After |
|---|---|
| **`/live`** "Shipping to production" | One run-on of six concepts with unexplained jargon (*"no sticky routing for reconnects"*) → three sentences, cause stated plainly: *"a reconnect isn't routed back to the process that holds the channel."* |
| **`/stream`** | *"incremental structured values"* → *"structured values that arrive one piece at a time"*; nested-`Promise` intro (*"unawaited promises … the surrounding values"*) → *"Put promises … without awaiting them. The client receives the rest of the object…"* |
| **`/real-time`** | closure-capture note: *"A channel outlives that — its `listen()` runs later"* (vague "that", unexplained "later") → *"outlives that window — its `listen()` callback runs later, after the telefunction has returned."* |
| **`/channel`** | *"…the keyed broadcast group that the static methods tap directly"* → *"…publish to and subscribe from directly"* (dropped the vague "tap"). |

## Verification
`tsc --noEmit` — clean. `vike build` — clean.

> Note on edit count: I deliberately did **not** churn already-clear prose — manufacturing edits would degrade good writing and add review noise. Every page was read sentence-by-sentence; these four are where a reader genuinely had to stop and decode.

https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8hPAsXZeXpqAHHCUSGk2T)_