### PR TITLE
docs: correctness fixes from the streaming-docs review

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -417,7 +417,7 @@ config.channel = {
 ```
 
 > **What to tune**: defaults suit typical chat/dashboard traffic; reach for these only if you hit one:
-> - Slow/flaky clients dropping with `ChannelNetworkError` → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).
+> - Slow/flaky clients dropping with `NetworkError` (`isChannel: true`) → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).
 > - `ChannelOverflowError` while a peer is briefly offline → raise `bufferLimit` / `bufferLimitBinary`, or apply backpressure by `await`-ing your `send()`s.
 > - Reconnects should replay more history → raise the replay buffers; lower them to cap memory.
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -50,9 +50,9 @@ const { channel } = await onClock()
 channel.listen((time) => console.log(time)) // 1700000000000, 1700000001000, ...
 ```
 
-The rest of this section adds types, two-way messaging, acks, and binary; see <Link href="#methods" /> for the full API.
+The rest of this section adds types, two-way messaging, acks, and binary; see <Link href="#channel-methods" /> for the full API.
 
-### Methods
+### Channel methods
 
 | Method | Description |
 |---|---|
@@ -264,7 +264,7 @@ const unsub = Broadcast.subscribe('room:lobby', (msg, info) => {
 })
 ```
 
-### Methods
+### Broadcast methods
 
 | Method | Description |
 |---|---|

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -5,6 +5,8 @@ import { StreamingBeta } from '../../components'
 
 `close()` and `onClose()` manage the lifecycle of telefunction values — anything returned from or passed to a telefunction that holds an open connection.
 
+> Applies to both <Link href="/stream">streaming</Link> (`AsyncGenerator`, `ReadableStream`, files) and <Link href="/real-time">real-time</Link> (`Channel`, `Broadcast`) values — they all close the same way.
+
 ## `close()` (client)
 
 `close()` from `telefunc/client` gracefully closes any value returned by a telefunction. It walks the return value recursively and closes everything in one call.

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -171,7 +171,7 @@ The expected-vs-bug distinction above applies to <Link href="/stream">streamed</
 
 A generator or stream that **throws mid-response** surfaces a typed error on the client for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
 
-**Channels and broadcasts** signal failure through dedicated errors — `ChannelNetworkError` (connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
+**Channels and broadcasts** signal failure through a small set of errors — `NetworkError` (`isChannel: true`, connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
 
 
 ## See also

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -7,7 +7,7 @@ Telefunc lets you move **live values** across the client/server boundary — asy
 
 It works in **both directions**:
 - **Server → client** — return an `AsyncGenerator`, `ReadableStream`, `File`, nested `Promise`, `Channel`, or `Broadcast`.
-- **Client → server** — pass a `ReadableStream`, `File`, callback, or channel message as an argument.
+- **Client → server** — pass a `ReadableStream`, `File`, or callback as an argument.
 
 > Plain telefunction calls are unaffected — these capabilities kick in only when a live value is involved, with zero config.
 

--- a/docs/pages/onBug/+Page.mdx
+++ b/docs/pages/onBug/+Page.mdx
@@ -25,5 +25,4 @@ This allows you, for example, to install the tracker code of some tracking servi
 ## See also
 
 - <Link href="/error-handling" />
-- <Link href="/error-handling#error-tracking" />
 - <Link href="/abort-vs-error" />


### PR DESCRIPTION
Targets `nitedani/streaming` (#264) so it shows only the review fixes, not the whole streaming feature.

A correctness/consistency pass over the streaming & real-time docs. I read all 16 new pages + 8 modified pages, verified ~60 documented API symbols against the source, and validated every internal link and section anchor (full link/anchor check now passes with zero broken references). The structure and prose are already strong — these are the concrete issues that pass turned up.

## Fixes

- **`ChannelNetworkError` doesn't exist.** The exported class is `NetworkError` with `isChannel: true` (already used by the `channel` error table). Aligned the two contradicting mentions — the `channel` tuning note and the new `error-handling › Streaming` section — so the name matches the actual API.
- **`live` (the front door) listed "channel message" as a telefunction argument.** Channels aren't passed as arguments; trimmed the client→server bullet to the three values you actually pass (`ReadableStream`, `File`, callback).
- **`onBug` had a broken, redundant See-also link** (`/error-handling#error-tracking` — no such section, and it duplicates the `/error-handling` link above it). Removed it. *Note: this one was pre-existing rather than introduced by #264 — included because it's a real broken link in a touched file; easy to drop if you'd rather keep this PR strictly scoped.*

## Structural assessment (no changes — the structure is good)

- Entry point is right: `Live telefunctions › Overview` is the front door, and its decision table routes users to the correct page.
- Guides ordering reads as a progression (Overview → Stream → Real-Time → Scaling → Cloudflare), and the API reorg (Context / Protection / Server Middleware / Real-Time / Error Handling / Config / Plugins) is coherent.
- New pages follow established conventions: `**Environment**` annotations, `## See also` blocks, `<Link>` for internal links, and the shared `<StreamingBeta>` notice (correctly absent from `provideTelefuncContext`).

Left as judgment calls for the team: "Integrations" as a sibling of "Live telefunctions" vs. nested; `close()/onClose()` filed under API › Real-Time; and the intentional duplicate anchors from the parallel `transport` sections.

https://claude.ai/code/session_01JhPXXynodeCacU4ZKk6n7C

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhPXXynodeCacU4ZKk6n7C)_