### PR TITLE
fix: type streaming wire-protocol bytes as Uint8Array&lt;ArrayBuffer&gt; (fix #264 CI)

### DIFF
--- a/packages/telefunc/wire-protocol/client/connection.ts
+++ b/packages/telefunc/wire-protocol/client/connection.ts
@@ -1565,7 +1565,10 @@ class SseTransport implements ClientChannelTransport {
       return
     }
 
-    const reader = createSseEventStreamReader(response.body.getReader(), abortController)
+    const reader = createSseEventStreamReader(
+      response.body.getReader() as ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>,
+      abortController,
+    )
 
     // Run the SSE loop concurrently with the handshake wait — frames (including the first
     // RECONCILED) can arrive while the open-ack is still in flight and must be dispatched.

--- a/packages/telefunc/wire-protocol/client/response/parse.ts
+++ b/packages/telefunc/wire-protocol/client/response/parse.ts
@@ -64,7 +64,7 @@ async function parseResponse(
   // HTTP streaming (binary / SSE)
   if (isStreaming) {
     assert(response.body)
-    const reader = response.body.getReader()
+    const reader = response.body.getReader() as ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>
     const isSSE = contentType.includes('text/event-stream')
     const streamReader = isSSE
       ? //

--- a/packages/telefunc/wire-protocol/frame.ts
+++ b/packages/telefunc/wire-protocol/frame.ts
@@ -12,7 +12,10 @@ export {
   textDecoder,
 }
 
-const textEncoder = new TextEncoder()
+const textEncoderInstance = new TextEncoder()
+const textEncoder = {
+  encode: (input?: string): Uint8Array<ArrayBuffer> => textEncoderInstance.encode(input) as Uint8Array<ArrayBuffer>,
+}
 const textDecoder = new TextDecoder()
 
 const U32_SIZE = 4 // byte size of a uint32

--- a/packages/telefunc/wire-protocol/server/sse.ts
+++ b/packages/telefunc/wire-protocol/server/sse.ts
@@ -9,6 +9,7 @@ import { CHANNEL_TRANSPORT } from '../constants.js'
 import { createPushReadableStream, type PushReadableStream } from '../push-readable-stream.js'
 import { createPushReadable, type PushReadable } from '../push-readable.js'
 import { uint8ArrayToBase64url } from '../base64url.js'
+import { textEncoder } from '../frame.js'
 import { parseSseRequestMetadata } from '../sse-request.js'
 import { StreamReader } from './request/StreamReader.js'
 import { getChannelMux } from './mux.js'
@@ -39,7 +40,6 @@ type SseConnection = {
   pendingDispatches: Set<Promise<unknown>>
 }
 
-const textEncoder = new TextEncoder()
 const sseOpenComment = textEncoder.encode(': open\n\n')
 
 const globalObject = getGlobalObject('wire-protocol/server/sse.ts', {


### PR DESCRIPTION
## Fix CI: TypeScript build failure on PR #264

`tsc --build` was failing in `packages/telefunc`, which blocked every downstream CI job (Vitest, TypeScript, Vite, Next.js, SvelteKit, all Playground SSE/WS jobs, etc.).

### Root cause
The new streaming `wire-protocol` code is uniformly typed `Uint8Array<ArrayBuffer>`, but two Web/Node APIs produce the wider `Uint8Array<ArrayBufferLike>` under `@types/node`'s globals (`ArrayBufferLike = ArrayBuffer | SharedArrayBuffer`), causing 9 type errors across 7 files:

- `TextEncoder.encode()` → `Uint8Array<ArrayBufferLike>`
- `Response.body.getReader()` → `ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>>`

### Fix (type-only — bytes are always `ArrayBuffer`-backed at runtime)
- **`frame.ts`** — wrap the shared `TextEncoder` so `encode()` returns `Uint8Array<ArrayBuffer>` (fixes 7 of 9 errors centrally, no call-site churn).
- **`sse.ts`** — use the shared encoder instead of a private `new TextEncoder()`.
- **`parse.ts` / `connection.ts`** — narrow `getReader()` at the boundary, matching the existing cast pattern used for `StreamReader`, `value.stream()`, etc.

### Verification (local, branch at the same SHA as PR #264 head)
- ✅ `pnpm run build` — all 4 packages build clean (the previously failing step)
- ✅ Biome formatting on changed files
- ✅ 97 wire-protocol unit tests pass

Merging this into `nitedani/streaming` will re-trigger and green PR #264's CI.

https://claude.ai/code/session_01N2X7da9GBNYjfUiAwA7akn

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2X7da9GBNYjfUiAwA7akn)_