### PR TITLE
Mark TypeScript code blocks as ts-only in getContext docs

### DIFF
--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -41,7 +41,7 @@ For example:
   </TabList>
   <TabPanel>
 
-```ts
+```ts ts-only
 // server/index.ts
 // Environment: server
 
@@ -87,7 +87,7 @@ app.use(async (c, next) => {
   </TabPanel>
   <TabPanel>
 
-```ts
+```ts ts-only
 // server/index.ts
 // Environment: server
 


### PR DESCRIPTION
## Summary
Updated the documentation for the `getContext` page to properly mark TypeScript code blocks with the `ts-only` syntax highlighting directive.

## Changes
- Added `ts-only` modifier to two TypeScript code blocks in the getContext documentation
- This ensures the code blocks are properly identified as TypeScript-specific examples in the documentation rendering

## Details
The changes update the code fence syntax from ` ```ts ` to ` ```ts ts-only ` for server-side context examples. This helps the documentation system correctly handle and display these TypeScript-specific code samples.

https://claude.ai/code/session_015kTQBiYh3J1vrCwLK9UHaX