### PR TITLE
docs: act on the streaming-docs audit (10 fixes)

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -223,6 +223,11 @@ const headings = [
     url: '/provideTelefuncContext',
   },
   {
+    level: 2,
+    title: '`withContext()`',
+    url: '/withContext',
+  },
+  {
     level: 4,
     title: 'Protection',
   },

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -258,7 +258,7 @@ const headings = [
   },
   {
     level: 4,
-    title: 'Real-Time',
+    title: 'Channels & Broadcast',
   },
   {
     level: 2,

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -395,6 +395,8 @@ If the connection drops, Telefunc reconnects automatically and resumes existing 
 
 ## Configuration
 
+> This is the **server-side** `config.channel` — reconnect/idle timeouts and buffer limits. It's a separate object from the **client-side** <Link text={<code>config.channel.transports</code>} href="/transport#channel-transport" /> (`telefunc/client`); the assignment below sets every server-side field at once and doesn't touch the client transports.
+
 ```ts
 // Environment: server
 

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -7,6 +7,25 @@ import { StreamingBeta } from '../../components'
 
 > Applies to both <Link href="/stream">streaming</Link> (`AsyncGenerator`, `ReadableStream`, files) and <Link href="/real-time">real-time</Link> (`Channel`, `Broadcast`) values — they all close the same way.
 
+
+## At a glance
+
+There's one umbrella API, `close()`, plus the per-type APIs. They all signal the server to stop producing and release resources — the difference is **graceful** (flush buffered data, then close) vs **immediate** (cancel in flight):
+
+| API | Side | Graceful / immediate | Closes |
+|---|---|---|---|
+| `close(value)` | client | Graceful | Everything in the returned value (walked recursively) |
+| `gen.return()` / `break` | client | Graceful | One `AsyncGenerator` |
+| `reader.cancel()` | client | Graceful | One `ReadableStream` |
+| <Link text={<code>channel.close()</code>} href="/channel#lifecycle" /> | either side | Graceful | One `Channel` / `Broadcast` (both ends) |
+| `abort(call)` | client | Immediate | The in-flight call and any channels it opened |
+| <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
+| <Link text={<code>channel.abort(value?)</code>} href="/channel#lifecycle" /> | either side | Immediate | One `Channel` / `Broadcast`, with an abort value |
+| `onClose(cb)` | server | — (cleanup hook) | Fires when the value ends, however it ended |
+
+The rest of this page covers `close()`, `abort()`, and `onClose()` in detail; channel-specific closing is on <Link href="/channel#lifecycle" />.
+
+
 ## `close()` (client)
 
 `close()` from `telefunc/client` gracefully closes any value returned by a telefunction. It walks the return value recursively and closes everything in one call.

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -5,7 +5,11 @@ import { StreamingBeta } from '../../components'
 
 Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) from a telefunction like any other value. The client receives a standard `File` / `Blob` ready for `URL.createObjectURL`, `<img src>`, `fetch({ body })`, `FormData`, etc.
 
-> For large downloads, or bytes streamed through your server from an upstream source, use `download()` — it adds progress, cancel, and save-to-disk, without ever buffering the full payload (on either the server or the client).
+> **Which API?**
+> - **Bytes already in memory** → return a native `File` / `Blob` (as above).
+> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />, which never buffers the full payload (on either the server or the client).
+>
+> The tables below break down the memory trade-offs.
 
 
 ## Which one should I use?

--- a/docs/pages/httpHeaders/+Page.mdx
+++ b/docs/pages/httpHeaders/+Page.mdx
@@ -19,7 +19,7 @@ config.headers = {
 
 > **Note**: `config.httpHeaders` is deprecated — use `config.headers` instead.
 
-> For headers on a **single call** rather than globally, use <Link text={<code>withContext()</code>} href="/transport#per-call-overrides" />.
+> For headers on a **single call** rather than globally, use <Link text={<code>withContext()</code>} href="/withContext" />.
 
 <ConfigWhereClient />
 

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -14,7 +14,7 @@ It works in **both directions**:
 
 ## What are you moving?
 
-| You want to… | Use | |
+| You want to… | Use | Docs |
 |---|---|---|
 | Push a sequence one way — AI tokens, progress, notifications | `AsyncGenerator` | <Link href="/stream" /> |
 | Deliver parts of one response as they become ready | nested `Promise` | <Link href="/stream" /> |

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-Telefunc supports real-time use cases — chat, file upload progress, live updates, ...
+Telefunc supports real-time use cases — chat, file upload progress, live updates, and more. They're powered by <Link href="/live">live values</Link> that flow across the client/server boundary.
 
 > Before reaching for Telefunc's real-time primitives directly, consider a high-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in an ergonomic API.
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -79,6 +79,8 @@ edits.subscribe(edit => applyEdit(edit))
 edits.next({ userId: 'alice', text: 'Hello' })
 ```
 
+> **Single server.** A module-level `Subject` lives in one server process. These multicast examples (the editor above, and *Live cursors* below) work as-is on a single instance; across multiple instances each process has its own `Subject`, so route shared state through a broadcast transport instead — see <Link href="/scaling" />.
+
 
 
 ## Click heatmap (client → server)
@@ -126,9 +128,10 @@ import { getContext } from 'telefunc'
 const cursors = new Subject<{ userId: string; x: number; y: number }>()
 
 export async function onCursors() {
-  const { user } = getContext()
+  const { user, onClose } = getContext()
   const input = new Subject<{ x: number; y: number }>()
-  input.subscribe(pos => cursors.next({ ...pos, userId: user.id }))
+  const sub = input.subscribe(pos => cursors.next({ ...pos, userId: user.id }))
+  onClose(() => sub.unsubscribe()) // release the per-client subscription on disconnect
   return { cursors, input }
 }
 ```
@@ -206,3 +209,4 @@ Unsubscribing stops data flow immediately. The underlying <Link href="/channel" 
 - <Link href="/real-time" />
 - <Link href="/channel" />
 - <Link href="/stream" />
+- <Link href="/scaling" />

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -1,7 +1,4 @@
 import { Link } from '@brillout/docpress'
-import { StreamingBeta } from '../../components'
-
-<StreamingBeta />
 
 **Environment**: server.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -70,6 +70,7 @@ const httpResponse = await serve({
 | `getReadableWebStream()` | `ReadableStream` | Web standard stream (Hono, Cloudflare, Deno, etc.) |
 | `pipe(writable)` | `void` | Pipe to Node.js writable (Express, Fastify) |
 | `getBody()` | `Promise<string>` | Full body as string (non-streaming only) |
+| `err` | `unknown` | The error thrown by your telefunction, if any (otherwise `undefined`) — see <Link href="/error-handling" /> |
 
 
 ## See also

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-Telefunc supports streaming in both directions:
+Streaming is one kind of <Link href="/live">live value</Link>. Telefunc streams in both directions:
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -93,7 +93,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 
 ## Per-call overrides
 
-`withContext(fn, context)` from `telefunc/client` wraps a telefunction with per-call client context — not only transport, but also an `AbortSignal`, extra headers, and a URL override:
+Override transport for a single call (instead of globally) with <Link text={<code>withContext()</code>} href="/withContext" /> from `telefunc/client`:
 
 ```ts
 // Environment: client
@@ -102,9 +102,6 @@ import { onAIChat } from './Chat.telefunc'
 import { withContext } from 'telefunc/client'
 
 const call = withContext(onAIChat, {
-  signal,                            // abort this call (and any channels it opens)
-  headers: { 'x-trace': traceId },   // extra HTTP headers, just for this call
-  telefuncUrl: '/api/_telefunc',     // override config.telefuncUrl for this call
   stream: { transport: 'channel' },  // override config.stream.transport
   channel: { transports: ['ws'] },   // override config.channel.transports
 })
@@ -114,6 +111,8 @@ for await (const token of gen) {
   console.log(token)
 }
 ```
+
+> `withContext()` also takes a per-call `signal`, `headers`, and `telefuncUrl` — see <Link href="/withContext" /> for the full list.
 
 
 ## Channel & broadcast config

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -25,6 +25,8 @@ config.channel.transports = ['sse', 'ws']   // default
 
 <ConfigWhereClient />
 
+> **Client vs server `config.channel`.** The settings on this page are **client-side** (`telefunc/client`). The server-side `config.channel` is a *different* object — reconnect/idle timeouts and buffer limits, imported from `telefunc` — see <Link href="/channel#configuration" />. They share a name but live on separate imports and don't overlap, so setting one never clears the other.
+
 
 ## Stream transport
 

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -1,0 +1,51 @@
+import { Link } from '@brillout/docpress'
+import { StreamingBeta } from '../../components'
+
+<StreamingBeta />
+
+**Environment**: client.
+
+`withContext(telefunction, context)` from `telefunc/client` wraps a telefunction with **per-call client context** — applied to that one call instead of the global `config`. Use it for an `AbortSignal`, extra headers, a URL override, or per-call <Link href="/transport">transport</Link> overrides.
+
+```ts
+// Environment: client
+
+import { onAIChat } from './Chat.telefunc'
+import { withContext } from 'telefunc/client'
+
+const call = withContext(onAIChat, {
+  signal,                            // abort this call (and any channels it opens)
+  headers: { 'x-trace': traceId },   // extra HTTP headers, just for this call
+  telefuncUrl: '/api/_telefunc',     // override config.telefuncUrl for this call
+  stream: { transport: 'channel' },  // override config.stream.transport
+  channel: { transports: ['ws'] },   // override config.channel.transports
+})
+
+const gen = call('Tell me a joke')
+for await (const token of gen) {
+  console.log(token)
+}
+```
+
+> `withContext()` returns a wrapped function with the same signature — call it exactly like the original telefunction.
+
+
+## Options
+
+| Option | Type | Description |
+|---|---|---|
+| `signal` | `AbortSignal` | Cancel this call and any channels it opens — see <Link href="/close" />. |
+| `headers` | `Record<string, string>` | Extra HTTP headers for this call. Global default: <Link text={<code>config.headers</code>} href="/httpHeaders" />. |
+| `telefuncUrl` | `string` | Override <Link text={<code>config.telefuncUrl</code>} href="/telefuncUrl" /> for this call and its channels. |
+| `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streamed values. |
+| `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
+| `channel.connectionKey` | `string` | Calls sharing a key share one connection; distinct keys stay isolated. |
+| `channel.idleTimeout` | `number` | How long (ms) to keep the transport alive after all channels close. Default `60_000`; `0` disposes immediately. |
+
+
+## See also
+
+- <Link href="/transport" />
+- <Link href="/httpHeaders" />
+- <Link href="/close" />
+- <Link href="/getContext" />

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -5,7 +5,7 @@ Redis-backed `Broadcast` fan-out for Telefunc — publishes on any instance reac
 ## Install
 
 ```sh
-pnpm add @telefunc/redis ioredis
+npm install @telefunc/redis ioredis
 ```
 
 ## Setup


### PR DESCRIPTION
Follow-up to a 360° technical-writing audit of the new streaming/live docs on `nitedani/streaming` (#264). Each audit suggestion is implemented as its own commit so they can be reviewed/dropped independently.

Targets `nitedani/streaming` (not `main`) because every page touched only exists on that branch.

## Changes (one commit each)

| # | Commit | Fixes |
|---|---|---|
| 1 | `docs(serve): drop the streaming Beta banner…` | `serve()` is the renamed, **stable** `telefunc()` — the `<StreamingBeta>` banner contradicted the page's own "use `new Telefunc()` for streaming" thesis. |
| 2 | `docs(serve): document httpResponse.err…` | `error-handling` reads `httpResponse.err`, but the `/serve` reference table omitted it. Added the row (`err?: unknown`). |
| 3 | `docs(close): add a Cancellation at a glance…` | The cancellation APIs were scattered across `/close`, `/transport`, `/channel`, `/file-download`. Added one table mapping each to graceful-vs-immediate + scope. |
| 4 | `docs(withContext): give withContext() its own reference page…` | `withContext()` was buried in `/transport` and absent from the nav. Promoted to a dedicated API page under **Context**; repointed `/transport` + `/httpHeaders` at it. |
| 5 | `docs(transport,channel): disambiguate client vs server config.channel` | `config.channel.transports` (client) and `config.channel` timeouts/buffers (server) share a name on different imports. Cross-noted both pages. |
| 6 | `docs(rxjs): clean up shared-Subject examples…` | *Live cursors* leaked a per-client subscription (now released in `onClose()`); added the single-server caveat + `/scaling` link the page was missing. |
| 7 | `docs(redis): use npm install…` | New README was the lone `pnpm add` among `npm install` docs. |
| 8 | `docs(file-download): lead with an explicit File-vs-download() decision` | Turned the intro callout into a crisp two-branch decision before the three dense tables. |
| 9 | `docs(stream,real-time): reinforce the 'live values' umbrella term` | Child pages had drifted from the `/live` "live values" brand; re-anchored both intros. |
| 10 | `docs(nav): rename API 'Real-Time' category…` | Two nav entries read "Real-Time"; renamed the API category to "Channels & Broadcast" and labeled the empty `/live` table header. |

## Notes / judgment calls
- **#1 vs #4 (Beta banner):** removed it from `serve()` (stable) but kept it on the new `withContext()` page, since `withContext`'s distinguishing options (stream/channel transport overrides) ship with the beta surface. The rule applied: *gate the banner on API stability, not page folder.*
- **#4:** placed `withContext()` under the **Context** nav group alongside `getContext()` / `provideTelefuncContext()` (client per-call context), and trimmed `/transport`'s "Per-call overrides" to a transport-focused snippet that links to the new page (DRY).
- **#5:** kept the server-side `config.channel = { … }` object literal (readability) and resolved the "implies a wipe" concern with an explicit note that client and server `config.channel` are independent objects.

## Verification
- Static link/anchor check across all 53 doc pages (docpress slug rules replicated): **all internal links resolve**, including the new `/withContext` page and the `#lifecycle`, `#stream-transport`, `#channel-transport`, `#multi-server`, `#configuration`, `#streaming-with-download` anchors.
- `vike build` was **not** run in-environment (monorepo deps not installed). Worth a build before merge.

https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH

---
_Generated by [Claude Code](https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH)_