### PR TITLE
docs(real-time): surface the Broadcast bus in the overview

### DIFF
--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -14,7 +14,8 @@ Telefunc supports real-time use cases — chat, file upload progress, live updat
 |---|---|---|
 | **Function passing** | Short-lived callbacks — progress updates, one-off server-to-client pushes | None |
 | **`new Channel()`** | Ongoing point-to-point messaging — commands, acks, request-response | None (SSE), or <Link text="WebSocket server setup" href="/server" /> (WS) |
-| **`new BroadcastChannel()`** | Broadcast messaging — chat rooms, live feeds, notifications | Same as channels |
+| **`Broadcast`** | Server-side fan-out by `key` — pub/sub with no client handle | None |
+| **`new BroadcastChannel()`** | Broadcasting to clients — chat rooms, live feeds, notifications | Same as channels |
 
 > See also: <Link text={<><code>Channel</code> vs <code>BroadcastChannel</code></>} href="/channel#channel-vs-broadcastchannel" />
 
@@ -96,7 +97,7 @@ See <Link href="/channel" /> for the full API.
 
 ## Broadcast
 
-Use <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" /> for broadcast messaging — all instances sharing a key form a broadcast group.
+Broadcasting is keyed pub/sub — everything sharing a `key` forms a group. There are two faces: the server-side <Link text={<code>Broadcast</code>} href="/channel#broadcast" /> bus (`publish` / `subscribe` by key), and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, which bridges a client into a key's group. Return a `BroadcastChannel` to broadcast to clients:
 
 ### Notifications
 


### PR DESCRIPTION
Continuing the spine direction (#328) outward to the overview. The `/channel` page now teaches `Broadcast` (the bus) as a first-class primitive — but `/real-time`, the page many users hit first, still only showed `BroadcastChannel`, so a reader there wouldn't know the server-side `Broadcast` bus exists. Bringing the overview in line.

## What changed (`/real-time`)

- **Decision table** now lists `Broadcast` alongside the others — *server-side fan-out by `key`, no client handle* — completing the primitive set (function passing · `Channel` · `Broadcast` · `BroadcastChannel`).
- **Broadcast section** reframed to name both faces: the server-side `Broadcast` bus (`publish`/`subscribe` by key) and `new BroadcastChannel()` (a client bridged onto a key), linking to `/channel#broadcast`. The client examples (notifications, chat) are unchanged.

## Scope notes

- **`/live` left as-is** — it lists the *returnable* live values, and the `Broadcast` bus correctly isn't one (it's a server-side API, nothing to return). That asymmetry is already right.
- Kept the overview at overview depth — a prose mention + link to `/channel#broadcast` rather than duplicating the bus code example.

## Verification

- `vike build` (docs) — clean; the new `/channel#broadcast` link resolves.

https://claude.ai/code/session_01JYQMc6CsRHkhJi9jhzAenZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYQMc6CsRHkhJi9jhzAenZ)_