### PR TITLE
docs: cross-cluster correctness & consistency audit (real-time)

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -22,7 +22,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 ## new Channel()
 
-`new Channel()` creates a private, two-way message pipe between the server and the one client that called the telefunction. The server keeps the `Channel` object and hands the client its end by returning `chat.client`. The channel outlives the telefunction call: both ends can `send()` and `listen()` until one side closes it.
+`new Channel()` creates a private, two-way message pipe between the server and the one client that called the telefunction. The server keeps the `Channel` object and hands the client its end by returning its `.client`. The channel outlives the telefunction call: both ends can `send()` and `listen()` until one side closes it.
 
 The simplest case — the server pushes live updates to the one client that opened the channel:
 
@@ -66,7 +66,7 @@ The rest of this section adds types, two-way messaging, acks, and binary; see <L
 | `close()` | Close gracefully. |
 | `abort(value?)` | Terminate immediately. |
 
-Server: return `chat.client` from the telefunction. The client gets the same API with message directions flipped.
+Server: return the channel's `.client` from the telefunction. The client gets the same API with message directions flipped.
 
 
 ### TypeScript
@@ -200,7 +200,7 @@ chat.send({ type: 'ping' }) // sent immediately, no await needed
 
 ## Broadcast
 
-`Broadcast` is a keyed pub/sub **bus**: `publish()` to a `key` reaches every `subscribe()` on that same `key`, anywhere — on the server, or on any client. Publishers and subscribers are decoupled; all they share is the string `key`. It's the fan-out layer that `BroadcastChannel` (below) is built on.
+`Broadcast` is a keyed pub/sub **bus**: a `publish()` to a `key` reaches every subscriber of that `key` — on the server (via `Broadcast.subscribe()`) or on a client (via a `BroadcastChannel`). Publishers and subscribers are decoupled; all they share is the string `key`. It's the fan-out layer that `BroadcastChannel` (below) is built on.
 
 The static methods run purely on the server — no client, no handle, no lifecycle — and take the `key` as their first argument:
 

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -23,7 +23,7 @@ It works in **both directions**:
 | Upload a file | `File` argument | <Link href="/file-upload" /> |
 | Let the server call you back | function passing | <Link href="/real-time" /> |
 | Hold a two-way conversation with one client | `new Channel()` | <Link text="Channel" href="/channel" /> |
-| Broadcast to many — rooms, presence, live feeds | `new BroadcastChannel()` | <Link text="Broadcast" href="/channel#new-broadcastchannel" /> |
+| Broadcast to many — rooms, presence, live feeds | `new BroadcastChannel()` | <Link text="BroadcastChannel" href="/channel#new-broadcastchannel" /> |
 | Auto-refetching queries | `@telefunc/tanstack-query` | <Link href="/tanstack-query" /> |
 | Reactive streams with operators | `@telefunc/rxjs` | <Link href="/rxjs" /> |
 

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -22,7 +22,7 @@ Without sticky sessions a reconnect that lands on a different instance sees no m
 
 ## Broadcast across instances
 
-A broadcast is different: publishers and subscribers are intentionally decoupled — they only share a string key. Each instance keeps its own subscriber list locally, and the broadcast transport is what makes a publish on instance A reach a subscriber on instance B.
+A <Link text="broadcast" href="/channel#broadcast" /> is different: publishers and subscribers are intentionally decoupled — they only share a string key. Each instance keeps its own subscriber list locally, and the broadcast transport is what makes a publish on instance A reach a subscriber on instance B.
 
 In a single-instance setup the default in-memory transport is enough. In a multi-instance setup, configure a transport that fans out across the cluster:
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -10,7 +10,7 @@ Telefunc has two transport settings:
 | Setting | Controls |
 |---|---|
 | `config.stream.transport` | How <Link href="/stream">streamed values</Link> (`AsyncGenerator`, `ReadableStream`, `Promise`) are delivered |
-| `config.channel.transports` | How <Link text={<code>new Channel()</code>} href="/channel" /> connections work |
+| `config.channel.transports` | How <Link text={<code>new Channel()</code>} href="/channel" /> and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" /> connections work |
 
 Plain telefunction calls are always `text/plain` JSON — these settings only affect streaming and channels.
 
@@ -56,7 +56,7 @@ Controls how streamed values are delivered over HTTP.
 
 ## Channel transport
 
-Controls how <Link text={<code>new Channel()</code>} href="/channel" /> connections work, and which backend `config.stream.transport = 'channel'` uses.
+Controls how <Link text={<code>new Channel()</code>} href="/channel" /> and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" /> connections work, and which backend `config.stream.transport = 'channel'` uses.
 
 | Transport | Description |
 |---|---|


### PR DESCRIPTION
A full correctness & consistency audit of the real-time/streaming docs cluster against the post-rename model (`Channel` · `Broadcast` bus · `BroadcastChannel` composition). Method: a comprehensive review of every cluster page (live, real-time, channel, stream, close, transport, scaling, cloudflare, redis, shield, tanstack-query, file-upload, file-download, nav), cross-checked against the source — every `<Link>`/anchor verified to resolve, config defaults verified against `serverConfig.ts`, API names verified against the package exports.

## Genuine issues found & fixed

1. **`/channel` — `chat.client` used before it exists.** The `## new Channel()` section's only example uses `clock` (`return { channel: clock.client }`), but the intro and the methods note both said `chat.client` (`chat` isn't introduced until the TypeScript section far below). Generalized both to the channel's `.client`.
2. **`/channel` `## Broadcast` — precision slip (mine, from #328).** The bus intro said a publish "reaches every `subscribe()` … on any client" — but the static `Broadcast.*` bus is **server-only**; a client subscribes via a `BroadcastChannel`, not `Broadcast.subscribe()`. Made the two paths explicit: *on the server (via `Broadcast.subscribe()`) or on a client (via a `BroadcastChannel`)*.
3. **`/live` — mislabelled link.** The broadcast row's "Docs" link read `Broadcast` but targets the `new BroadcastChannel()` construct section; relabelled `BroadcastChannel` (matching its sibling `Channel` row).
4. **`/transport` — incomplete.** `config.channel.transports` governs `new BroadcastChannel()` too (it's a channel), not only `new Channel()` — reflected in both the settings table and the Channel-transport section.
5. **`/scaling` — missing cross-ref.** "Broadcast across instances" now links the bus to its reference (`/channel#broadcast`).

## Verified clean (no changes needed)

`stream`, `close`, `redis`, `shield`, `tanstack-query`, `file-upload`, `file-download`, `cloudflare`, and the nav — links/anchors resolve, terminology is consistent, config values match source. (Specifically checked: the `cloudflare` partial `config.channel = {…}` assignment is *not* a contradiction — the resolver fills unspecified fields from defaults.)

## Verification

- `vike build` (docs) — clean; all links + anchors resolve.

https://claude.ai/code/session_01JYQMc6CsRHkhJi9jhzAenZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYQMc6CsRHkhJi9jhzAenZ)_