### PR TITLE
docs: complementary polish on the live-feature docs (openers, a11y, seam link)

### DIFF
--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -224,3 +224,4 @@ The streaming download can only be consumed once — calling `.stream()`, `.byte
 - <Link href="/file-upload" />
 - <Link href="/stream" />
 - <Link href="/transport" />
+- <Link href="/close" />

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-Streaming is one kind of <Link href="/live">live value</Link>. Telefunc streams in both directions:
+Stream values that arrive over time — AI tokens, progress, raw bytes, or lazily-resolved parts of a response — by returning or accepting them like any other value. It works in both directions:
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -47,6 +47,8 @@ Controls how streamed values are delivered over HTTP.
 | `'channel'` (SSE) | 🟡 | ✅ | ✅ | None |
 | `'channel'` (WS) | ✅ | 🟡 | ✅ | <Link text="Server setup" href="/server" /> |
 
+*Key: ✅ good · 🟡 partial / caveats · ❌ none*
+
 ### When to use what
 
 - **Start with `'binary-inline'`** — it's the fastest and works in most setups.
@@ -73,6 +75,8 @@ All channels share a single multiplexed connection per server URL, so opening ma
 |---|---|---|---|---|
 | `'sse'` | 🟡 | ✅ | ✅ | None |
 | `'ws'` | ✅ | ✅ | 🟡 | <Link text="Server setup" href="/server" /> |
+
+*Key: ✅ good · 🟡 partial / caveats · ❌ none*
 
 ### When to use what
 


### PR DESCRIPTION
A deliberately **thin, additive** layer on top of the recent live-feature work.

## Why it's small
This started as a larger plan to re-spine the streaming/real-time docs around a "direction / who-keeps-sending" axis and retire the fuzzy terms. But #327–#330 (merged after that plan) already solved most of the fuzziness from a different, equally-valid angle — the crisp **"two primitives + one composition"** spine (`Channel` / `Broadcast` bus / `BroadcastChannel`) — and deliberately kept `/real-time` and "live values". Overriding that would delete good, recent work. So this PR **complements** rather than overrides: only the changes that are unambiguously additive and don't fight the new model.

## Changes (one commit each)
1. **`docs(stream)`** — replace the leftover `Streaming is one kind of live value` breadcrumb (from my earlier `0872680`) with a **task-first opener** that leads with what streaming does and that it's used "like any other value." `/live` is still linked from See also.
2. **`docs(transport)`** — **accessibility**: the ✅/🟡/❌ comparison tables encoded meaning only in the glyph (a screen reader announces 🟡 as "yellow circle"). Added a one-line text **key** under each table.
3. **`docs(file-download)`** — link the **cleanup seam** (`/close`): the page documents `dl.cancel()` but didn't point to the canonical cancellation/cleanup page.

## Explicitly NOT done (respecting the new model)
- No `/real-time` dissolution, no "direction" spine imposed, no purge of "streaming / real-time / live values" — those would override #327–#330.

## Verification
- Static link/anchor check across all 53 doc pages (docpress slug rules replicated): **all internal links resolve**.
- `vike build` not run in-environment (monorepo deps not installed) — worth a build before merge.

https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH

---
_Generated by [Claude Code](https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH)_