### PR TITLE
docs(nav): de-leak the docs structure (separate deployment, dedup labels, group the feature)

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -276,8 +276,13 @@ const headings = [
     url: '/close',
   },
   {
+    level: 2,
+    title: '`transport`',
+    url: '/transport',
+  },
+  {
     level: 4,
-    title: 'Error Handling',
+    title: 'Hooks',
   },
   {
     level: 2,
@@ -310,11 +315,6 @@ const headings = [
   },
   {
     level: 2,
-    title: '`transport`',
-    url: '/transport',
-  },
-  {
-    level: 2,
     title: '`fetch`',
     url: '/fetch',
   },
@@ -330,7 +330,7 @@ const headings = [
   },
   {
     level: 2,
-    title: '`shield`',
+    title: '`config.shield`',
     url: '/shield-config',
   },
   {

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -140,20 +140,6 @@ const headings = [
   },
   {
     level: 4,
-    title: 'Files',
-  },
-  {
-    level: 2,
-    title: 'File upload',
-    url: '/file-upload',
-  },
-  {
-    level: 2,
-    title: 'File download',
-    url: '/file-download',
-  },
-  {
-    level: 4,
     title: 'Live',
   },
   {
@@ -169,18 +155,22 @@ const headings = [
   },
   {
     level: 2,
-    title: 'Real-Time',
+    title: 'Real-time',
     url: '/real-time',
   },
   {
-    level: 2,
-    title: 'Scaling',
-    url: '/scaling',
+    level: 4,
+    title: 'Files',
   },
   {
     level: 2,
-    title: 'Cloudflare',
-    url: '/cloudflare',
+    title: 'File upload',
+    url: '/file-upload',
+  },
+  {
+    level: 2,
+    title: 'File download',
+    url: '/file-download',
   },
   {
     level: 4,
@@ -200,6 +190,20 @@ const headings = [
     level: 2,
     title: '`@telefunc/rxjs`',
     url: '/rxjs',
+  },
+  {
+    level: 4,
+    title: 'Deploying',
+  },
+  {
+    level: 2,
+    title: 'Scaling',
+    url: '/scaling',
+  },
+  {
+    level: 2,
+    title: 'Cloudflare',
+    url: '/cloudflare',
   },
   {
     level: 1,


### PR DESCRIPTION
Fixes the **information architecture** confusion (distinct from the earlier concept/term work — those are settled). Per the Guide-vs-Reference division of labor — **guides introduce + cover the common path (~50%); reference is the complete contract (100%)** — this keeps the two separate and instead de-leaks the existing structure. **Nav-only: no page URLs change, so no broken links and no redirects.**

## What was confusing (and what this fixes)
The live feature's pages were scattered, deployment was mixed into feature how-tos, and two labels were duplicated:

**Guides** — pull deployment out, lead with the Overview:
```
before                          after
Files                           Live        Overview · Stream · Real-time
Live  Overview · Stream ·       Files       File upload · File download
      Real-Time · Scaling ·     Integrations  tanstack-query · redis · rxjs
      Cloudflare                Deploying   Scaling · Cloudflare   ← own group
Integrations
```

**API reference** — remove the duplicate labels, group `transport` with the channel reference:
- `Error Handling` category → **`Hooks`** (it collided with the Guides *Error handling* page)
- Config `shield` → **`config.shield`** (it collided with Protection `shield()`)
- `transport` moved out of generic **Config** into **Channels & Broadcast** (it's the channel/stream transport)

## Deliberately NOT done
- **No merging reference into guides** — you were right that it would bloat the guides past their "introduce + 50%" job. Guide↔reference stays separated.
- Kept the maintainers' recent `Live` group name (not renamed).
- No page rewrites, no URL changes, no concept/term changes.

## Follow-up (not in this PR)
Your 50/100 model is also a *content* test: `/stream` has drifted fairly comprehensive (every type + client→server + mixed + cancel + errors) — some of that "100% tail" may belong trimmed-and-linked rather than inline. Worth a separate content pass; flagging, not doing it here.

## Verification
- `headings.ts` internally consistent: one `transport`, distinct shield labels, no duplicate URLs, balanced structure.
- Static link/anchor check across all 53 pages — **all internal links resolve**.
- `vike build` not run (monorepo deps not installed) — worth a build before merge.

https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH

---
_Generated by [Claude Code](https://claude.ai/code/session_014eXwgJQw67EeFCr6sYwPeH)_