### PR TITLE
Improve documentation clarity and precision across pages

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -200,7 +200,7 @@ chat.send({ type: 'ping' }) // sent immediately, no await needed
 
 ## Broadcast
 
-`Broadcast` is a keyed pub/sub **bus**: a `publish()` to a `key` reaches every subscriber of that `key` — on the server (via `Broadcast.subscribe()`) or on a client (via a `BroadcastChannel`). Publishers and subscribers are decoupled; all they share is the string `key`. It's the fan-out layer that `BroadcastChannel` (below) is built on.
+`Broadcast` is a keyed pub/sub **bus**: a `publish()` to a `key` reaches every subscriber of that `key` — server-side subscribers (via `Broadcast.subscribe()`) and clients bridged into the key (via a `BroadcastChannel`). Publishers and subscribers are decoupled; all they share is the string `key`. It's the fan-out layer that `BroadcastChannel` (below) is built on.
 
 The static methods run purely on the server — no client, no handle, no lifecycle — and take the `key` as their first argument:
 
@@ -231,7 +231,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 ## new BroadcastChannel()
 
-`new BroadcastChannel({ key })` is the composition: a `Channel` to the one client that received it, bridged onto a `Broadcast` key. Return it from a telefunction and that client can `publish()` / `subscribe()` on the key — every message reaches every member of the group: the other subscribers, the server, and the publishing instance itself. No `.client` needed: broadcast is symmetric (one message type, no directional flip), so the same instance works on both ends — unlike channels.
+`new BroadcastChannel({ key })` is the composition: a `Channel` to the one client that received it, bridged onto a `Broadcast` key. Return it from a telefunction and that client can `publish()` / `subscribe()` on the key — every message reaches every member of the group, including the publisher itself. No `.client` needed: broadcast is symmetric (one message type, no directional flip), so the same instance works on both ends — unlike channels.
 
 <Warning>
 
@@ -312,7 +312,7 @@ Only the two ends of a channel can use it, while anything that knows a `key` can
 
 ### Technically
 
-You can think of `new BroadcastChannel()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received the broadcast object, and bridges that client into the keyed broadcast group that the static methods publish to and subscribe from directly.
+You can think of `new BroadcastChannel()` as `new Channel()` plus the static `Broadcast.publish()` / `Broadcast.subscribe()`: the server holds a private channel to the one client that received it, and bridges that client into the keyed broadcast group — the same group those static methods publish to and subscribe from.
 
 ### Comparison
 

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-`close()` and `onClose()` manage the lifecycle of live values — anything returned from or passed to a telefunction that holds an open connection.
+`close()` and `onClose()` manage the lifecycle of the streams and connections a telefunction returns or accepts — so the server can stop producing and release resources.
 
 > Applies to both <Link href="/stream">streaming</Link> (`AsyncGenerator`, `ReadableStream`, files) and <Link href="/real-time">real-time</Link> (`Channel`, `BroadcastChannel`) values — they all close the same way.
 
@@ -28,7 +28,7 @@ The rest of this page covers `close()`, `abort()`, and `onClose()` in detail; ch
 
 ## `close()` (client)
 
-`close()` from `telefunc/client` gracefully closes any value returned by a telefunction. In one call, it closes every live value nested anywhere in the return value.
+`close()` from `telefunc/client` gracefully closes any value returned by a telefunction. In one call, it closes every stream, channel, and file nested anywhere in the return value.
 
 ```ts
 // Environment: client

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -3,14 +3,14 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-`close()` and `onClose()` manage the lifecycle of telefunction values — anything returned from or passed to a telefunction that holds an open connection.
+`close()` and `onClose()` manage the lifecycle of live values — anything returned from or passed to a telefunction that holds an open connection.
 
 > Applies to both <Link href="/stream">streaming</Link> (`AsyncGenerator`, `ReadableStream`, files) and <Link href="/real-time">real-time</Link> (`Channel`, `BroadcastChannel`) values — they all close the same way.
 
 
 ## At a glance
 
-There's one umbrella API, `close()`, plus the per-type APIs. They all signal the server to stop producing and release resources — the difference is **graceful** (flush buffered data, then close) vs **immediate** (cancel in flight):
+There's one umbrella API, `close()`, plus the per-type APIs. They all signal the server to stop producing and release resources — the difference is **graceful** (flush buffered data, then close) vs **immediate** (cancel in-flight work):
 
 | API | Side | Graceful / immediate | Closes |
 |---|---|---|---|
@@ -28,7 +28,7 @@ The rest of this page covers `close()`, `abort()`, and `onClose()` in detail; ch
 
 ## `close()` (client)
 
-`close()` from `telefunc/client` gracefully closes any value returned by a telefunction. It walks the return value recursively and closes everything in one call.
+`close()` from `telefunc/client` gracefully closes any value returned by a telefunction. In one call, it closes every live value nested anywhere in the return value.
 
 ```ts
 // Environment: client
@@ -67,7 +67,7 @@ await channel.close()
 
 All of these signal the server to stop producing and release resources.
 
-> `close()` ends a value **gracefully** (buffered data is flushed). To stop a call **immediately** instead, pass the pending call to `abort()` — the underlying request is cancelled and the result rejects with an `Abort` error (mid-stream, the next read rejects):
+> `close()` ends a value **gracefully** (buffered data is flushed). To stop a call **immediately** instead, pass the pending call to `abort()` — the request is cancelled, and the pending call (or the next read, if you're mid-stream) rejects with an `Abort` error:
 > ```ts
 > // Environment: client
 >

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -113,7 +113,7 @@ By default, Telefunc creates one Durable Object per region. Increase capacity wi
 const tf = new Telefunc({ scale: 4 })
 ```
 
-This creates 4 Durable Objects per region. Sessions are distributed across them.
+This creates 4 Durable Objects per region, and Telefunc distributes sessions across them.
 
 ### Per-region scale
 

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -108,7 +108,7 @@ function Upload() {
 }
 ```
 
-The file bytes stream normally while `onProgress()` updates the client in real time.
+The file bytes stream while `onProgress()` updates the client.
 
 
 ## Reading strategies

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -213,7 +213,7 @@ export async function someTelefunction() {
 
 ## `onClose()`
 
-The context object returned by `getContext()` also includes `onClose()`, a callback that fires exactly once, when the request lifecycle ends for any reason. Use it to release resources.
+The context object returned by `getContext()` also includes `onClose()`, a callback that fires exactly once when the call ends — whether the client received everything, disconnected, or hit an error. Use it to release resources.
 
 ```ts
 const context = getContext()
@@ -228,7 +228,7 @@ context.onClose(() => {
 
 ## `signal`
 
-The context object also includes an `AbortSignal` that fires when the request ends. Pass it to APIs that accept one (`fetch`, database clients, etc.) so in-flight work cancels when the client disconnects.
+The context object also includes a `signal` (an `AbortSignal`) that aborts when the call ends. Pass it to APIs that accept one (`fetch`, database clients, etc.) so in-flight work cancels when the client disconnects.
 
 ```ts
 const context = getContext()

--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -69,8 +69,8 @@ function Features() {
         </h2>
         <>
           <p>
-            Telefunctions can <b>stream values</b> — AI tokens, progress, file up/downloads — and power{' '}
-            <b>real-time</b> features with channels &amp; broadcasts, by returning or passing them like any other value.
+            Telefunctions can <b>stream values</b> — AI tokens, progress, file up/downloads — and power <b>real-time</b>{' '}
+            features with channels &amp; broadcasts, by returning or passing them like any other value.
           </p>
         </>
       </div>

--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -69,7 +69,7 @@ function Features() {
         </h2>
         <>
           <p>
-            Telefunctions can <b>stream live values</b> — AI tokens, progress, file up/downloads — and power{' '}
+            Telefunctions can <b>stream values</b> — AI tokens, progress, file up/downloads — and power{' '}
             <b>real-time</b> features with channels &amp; broadcasts, by returning or passing them like any other value.
           </p>
         </>

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -3,16 +3,16 @@ import { StreamingBeta, NeedsLongRunningServer } from '../../components'
 
 <StreamingBeta />
 
-Telefunc lets you move **live values** across the client/server boundary — async sequences, byte streams, files, and persistent connections — by returning them from, or passing them to, a telefunction like any other value.
+Telefunc moves values that **stream or stay connected** across the client/server boundary — async sequences, byte streams, files, and persistent connections — by returning them from, or passing them to, a telefunction like any other value.
 
 It works in **both directions**:
 - **Server → client** — return an `AsyncGenerator`, `ReadableStream`, `File`, nested `Promise`, `Channel`, or `BroadcastChannel`.
 - **Client → server** — pass a `ReadableStream`, `File`, or callback as an argument.
 
-> Plain telefunction calls are unaffected — these capabilities kick in only when a live value is involved, with zero config.
+> Plain telefunction calls are unaffected — this kicks in only when you return or pass one of these, with zero config.
 
 
-## A first live value
+## A first example
 
 Return an `AsyncGenerator` and read it as it arrives — no setup, no config:
 
@@ -39,7 +39,7 @@ for await (const n of onCountdown(3)) {
 }
 ```
 
-That's a live value: it crosses the network like any return value, but arrives over time. The rest of this page points you to the right one for each job.
+That's the whole idea: the value crosses the network like any return value, but arrives over time. The rest of this page helps you pick the right type for each job.
 
 
 ## What are you moving?

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta, NeedsLongRunningServer } from '../../components'
 
 <StreamingBeta />
 
-Telefunc supports real-time use cases — chat, file upload progress, live updates, and more. They're powered by <Link href="/live">live values</Link> that flow across the client/server boundary.
+Telefunc supports real-time use cases — chat, file upload progress, live updates, and more. They build on values that stream or stay connected across the client/server boundary — see the <Link text="Live overview" href="/live" />.
 
 > Before reaching for Telefunc's real-time primitives directly, consider a high-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in an ergonomic API.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -97,7 +97,7 @@ See <Link href="/channel" /> for the full API.
 
 ## Broadcast
 
-Broadcasting is keyed pub/sub — everything sharing a `key` forms a group. There are two faces: the server-side <Link text={<code>Broadcast</code>} href="/channel#broadcast" /> bus (`publish` / `subscribe` by key), and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, which bridges a client into a key's group. Return a `BroadcastChannel` to broadcast to clients:
+Broadcasting is keyed pub/sub — everything sharing a `key` forms a group. There are two pieces: the server-side <Link text={<code>Broadcast</code>} href="/channel#broadcast" /> bus (`publish` / `subscribe` by key), and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, which bridges a client into a key's group. Return a `BroadcastChannel` to broadcast to clients:
 
 ### Notifications
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -23,7 +23,7 @@ The Telefunc bundler plugin (Vite, webpack, Next.js, Babel) detects `@telefunc/r
 
 ## Live stock ticker
 
-Server pushes prices every second. Client applies operators locally — filtering and limiting happen on the client with standard RxJS.
+Server pushes prices every second. The client filters and limits them locally, with standard RxJS operators.
 
 ```ts
 // StockPrice.telefunc.ts
@@ -79,7 +79,7 @@ edits.subscribe(edit => applyEdit(edit))
 edits.next({ userId: 'alice', text: 'Hello' })
 ```
 
-> **Single server.** A module-level `Subject` lives in one server process. These multicast examples (the editor above, and *Live cursors* below) work as-is on a single instance; across multiple instances each process has its own `Subject`, so route shared state through a broadcast transport instead — see <Link href="/scaling" />.
+> **Single server.** A module-level `Subject` lives in one server process. These multicast examples (the editor above, and *Live cursors* below) work as-is on a single instance. Across multiple instances, each process has its own `Subject` — so route shared state through a broadcast transport instead, see <Link href="/scaling" />.
 
 
 
@@ -194,7 +194,7 @@ export class DashboardComponent {
 
 ## Shields
 
-A `Subject<T>` or `Observable<T>` passed as a telefunction argument gets a shield on each `next(v)` value arriving at the server. Terminal signals (`error`, `complete`) are untyped and pass through unshielded.
+When you pass a `Subject<T>` or `Observable<T>` as a telefunction argument, each `next(v)` value is shield-validated against `T` as it arrives at the server. Terminal signals (`error`, `complete`) are untyped and pass through unshielded.
 
 See <Link href="/shield" /> for how telefunction arguments are validated in general.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Low-level function that processes telefunction requests and returns an HTTP response. It's a pure function with no side effects.
+Low-level function that processes telefunction requests and returns an HTTP response. It's stateless: a request goes in, an HTTP response comes out — no connection state to manage.
 
 > For <Link href="/stream">streaming</Link> and <Link href="/real-time">real-time</Link> setups, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,7 +7,7 @@ Stream values that arrive over time — AI tokens, progress, raw bytes, or lazil
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
-> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting channel only if you need to).
+> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting transport only if you need to).
 
 
 ## Which one should I use?

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -53,7 +53,7 @@ queryKey: ['global:documents', docId]            // global
 > Global keys ride on Telefunc calls, so two rules apply:
 >
 > - **`queryFn` must call a telefunction.** The invalidation subscription piggybacks on that call. With a non-telefunc `queryFn` (e.g. plain `fetch()`), a global key silently behaves like a local one. The same goes for mutations: global keys in `meta.invalidates` are published server-side after the telefunction succeeds, so `mutationFn` must be a telefunction call too.
-> - **Return the telefunction call directly.** The integration unwraps the subscription from whatever `queryFn` returns, so transform with `select` instead:
+> - **Return the telefunction call directly.** The integration reads the invalidation subscription from whatever `queryFn` returns, so transform with `select` instead:
 >   ```js
 >   // ✗ Broken: inside queryFn, getTodos() resolves to an internal wrapper
 >   queryFn: async () => (await getTodos()).items

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -53,7 +53,7 @@ Controls how streamed values are delivered over HTTP.
 
 - **Start with `'binary-inline'`** — it's the fastest and works in most setups.
 - **Switch to `'sse-inline'`** if a proxy or CDN buffers binary HTTP responses but passes SSE events through.
-- **Use `'channel'`** when you want streamed values to use the same reconnecting transport as Telefunc channels.
+- **Use `'channel'`** when you want streamed values to reconnect automatically after a dropped connection, like Telefunc channels do.
 
 
 ## Channel transport

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -39,8 +39,8 @@ for await (const token of gen) {
 | `telefuncUrl` | `string` | Override <Link text={<code>config.telefuncUrl</code>} href="/telefuncUrl" /> for this call and its channels. |
 | `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streamed values. |
 | `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
-| `channel.connectionKey` | `string` | Calls sharing a key share one connection; distinct keys stay isolated. |
-| `channel.idleTimeout` | `number` | How long (ms) to keep the transport alive after all channels close. Default `60_000`; `0` disposes immediately. |
+| `channel.connectionKey` | `string` | Calls with the same key share one connection; different keys use separate connections. |
+| `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
 
 
 ## See also


### PR DESCRIPTION
This PR refines documentation wording across multiple pages to improve clarity, precision, and consistency without changing any functionality.

## Summary
Updated documentation to use clearer language, more precise terminology, and better explanations of Telefunc concepts. Changes focus on making technical descriptions more accessible while maintaining accuracy.

## Key changes

- **close/+Page.mdx**: Clarified that `close()` and `onClose()` manage streams and connections, improved explanation of graceful vs immediate closure, and refined descriptions of the `close()` API behavior
- **live/+Page.mdx**: Reworded "live values" to "values that stream or stay connected" for clarity, simplified section heading from "A first live value" to "A first example", and improved explanation of how values cross the network
- **channel/+Page.mdx**: Enhanced descriptions of `Broadcast` and `BroadcastChannel` to be more precise about how they work and what they do, clarified technical explanations
- **rxjs/+Page.mdx**: Improved wording around client-side operators, clarified single-server limitations, and refined shield validation description
- **getContext/+Page.mdx**: Clarified when `onClose()` fires and what `signal` is, improved descriptions of resource cleanup and abort behavior
- **real-time/+Page.mdx**: Updated intro to reference the live values overview more clearly, changed "faces" to "pieces" for better terminology
- **withContext/+Page.mdx**: Improved descriptions of `channel.connectionKey` and `channel.idleTimeout` options for clarity
- **cloudflare/+Page.mdx**: Simplified explanation of session distribution across Durable Objects
- **file-upload/+Page.mdx**: Removed redundant "in real time" phrase
- **index/features/Features.tsx**: Simplified "stream live values" to "stream values"
- **serve/+Page.mdx**: Clarified that `serve()` is stateless with improved description
- **stream/+Page.mdx**: Changed "reconnecting channel" to "reconnecting transport" for accuracy
- **tanstack-query/+Page.mdx**: Improved explanation of how the integration reads invalidation subscriptions

## Notable details
All changes are documentation-only with no impact on code behavior or APIs. The updates maintain technical accuracy while improving readability and reducing ambiguity.

https://claude.ai/code/session_01WuAMQCh3TTmemXHobGjRkE