### PR TITLE
Add streaming, real-time channels, and broadcast support

### DIFF
--- a/docs/components/NeedsLongRunningServer.mdx
+++ b/docs/components/NeedsLongRunningServer.mdx
@@ -1,3 +1,3 @@
 import { Link } from '@brillout/docpress'
 
-> **Needs a long-running server.** A channel holds a connection open, so channels and broadcasts don't fit typical serverless (Vercel, Lambda), which cuts the connection short. See <Link href="/scaling" /> for running multiple instances, or <Link href="/cloudflare" /> for Cloudflare's Durable Objects.
+> **Needs a long-running server.** A channel holds a connection open for its entire lifetime, so channels and broadcasts don't work on most serverless platforms (e.g. Vercel, AWS Lambda), which terminate a connection after a short time limit. See <Link href="/scaling" /> for running multiple instances, or <Link href="/cloudflare" /> for Cloudflare's Durable Objects.

--- a/docs/components/StreamingBeta.mdx
+++ b/docs/components/StreamingBeta.mdx
@@ -1,1 +1,1 @@
-> **Beta** — the streaming & real-time API is in beta and may still change before it's stabilized.
+> **Beta** — the streaming & real-time API is in beta and may change in a future release.

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -13,7 +13,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 
-> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background, see <Link href="/transport" />.
+> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and upgrades to WebSocket in the background, with no interruption to your code (see <Link href="/transport" />).
 
 <NeedsLongRunningServer />
 
@@ -226,7 +226,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 `seq` is monotonic per `key`, useful for ordering and gap detection. `publish()` resolves to `info` once the message is accepted.
 
-> In-memory broadcast works out of the box for single-server deployments. For multi-server, set `config.broadcast.transport` — see <Link text="Multi-server" href="#multi-server" />. On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
+> In-memory broadcast works without setup for single-server deployments. For multi-server, set `config.broadcast.transport` — see <Link text="Multi-server" href="#multi-server" />. On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
 
 
 ## new BroadcastChannel()
@@ -295,7 +295,7 @@ chat.publish({ user: 'Alice', text: 'Hello!', })
 | `close()` | Close gracefully. |
 | `abort(value?)` | Terminate immediately. |
 
-> The instance has its `key` baked in, so `publish(data)` / `subscribe(cb)` take no key. The static <Link text={<code>Broadcast.publish(key, data)</code>} href="#broadcast" /> / `Broadcast.subscribe(key, cb)` take it first — and have no `onOpen` / `onClose` / `close` / `abort`, since there's no instance to manage.
+> The instance is bound to its `key`, so `publish(data)` / `subscribe(cb)` take no key. The static <Link text={<code>Broadcast.publish(key, data)</code>} href="#broadcast" /> / `Broadcast.subscribe(key, cb)` take it first — and have no `onOpen` / `onClose` / `close` / `abort`, since there's no instance to manage.
 
 
 ## `Channel` vs `BroadcastChannel`
@@ -387,7 +387,7 @@ If the connection drops, Telefunc reconnects automatically and resumes existing 
 - Both sides keep a bounded replay buffer; after reconnect, missing frames are replayed and duplicates are ignored.
 - `onOpen()` fires only on initial open, `onClose()` only on permanent close.
 
-> Reconnection is transparent — you don't need to handle it in your application code.
+> Reconnection is automatic — you don't need to handle it in your application code.
 
 
 ## Error handling

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -13,7 +13,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 
-> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and upgrades to WebSocket in the background, with no interruption to your code (see <Link href="/transport" />).
+> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and automatically upgrades to WebSocket in the background (see <Link href="/transport" />).
 
 <NeedsLongRunningServer />
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -13,7 +13,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 
-> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and automatically upgrades to WebSocket in the background (see <Link href="/transport" />).
+> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background (see <Link href="/transport" />).
 
 <NeedsLongRunningServer />
 
@@ -226,7 +226,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 `seq` is monotonic per `key`, useful for ordering and gap detection. `publish()` resolves to `info` once the message is accepted.
 
-> In-memory broadcast works without setup for single-server deployments. For multi-server, set `config.broadcast.transport` — see <Link text="Multi-server" href="#multi-server" />. On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
+> In-memory broadcast works out-of-the-box for single-server deployments. For multi-server, set `config.broadcast.transport` — see <Link text="Multi-server" href="#multi-server" />. On Cloudflare Workers, Telefunc uses Durable Objects automatically — see <Link href="/cloudflare" />.
 
 
 ## new BroadcastChannel()

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -10,7 +10,7 @@ import { StreamingBeta } from '../../components'
 
 ## At a glance
 
-There's one umbrella API, `close()`, plus the per-type APIs. They all signal the server to stop producing and release resources — the difference is **graceful** (flush buffered data, then close) vs **immediate** (cancel in-flight work):
+There's one catch-all API, `close()`, plus the per-type APIs. They all signal the server to stop producing and release resources — the difference is **graceful** (flush buffered data, then close) vs **immediate** (cancel in-flight work):
 
 | API | Side | Graceful / immediate | Closes |
 |---|---|---|---|

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -74,7 +74,7 @@ const tf = new Telefunc({
 Telefunc uses [Durable Objects](https://developers.cloudflare.com/durable-objects/) for channel state and broadcast fan-out. Channel state is in-memory JavaScript (closures, callbacks, local variables), so it must live on the same Durable Object as the WebSocket connection.
 
 [KV](https://developers.cloudflare.com/kv/) stores two things:
-- **Session tokens** — pins a browser to the same Durable Object across requests.
+- **Session tokens** — pin a browser to the same Durable Object across requests.
 - **Broadcast presence** — tracks which Durable Objects have active subscribers for each key.
 
 ### Regions
@@ -94,7 +94,7 @@ Each region runs its own Durable Objects so that channel state stays close to us
 
 ### Session affinity
 
-Every telefunction call and channel message from a browser must reach the **same Durable Object** — otherwise the channel state wouldn't be there.
+Every telefunction call and channel message from a browser must reach the **same Durable Object** — otherwise its channel state would not be available.
 
 On the first request, Telefunc picks a Durable Object in the nearest region, stores a session token in KV (TTL: 24 hours), and returns it to the client via the `x-telefunc-session` header. Subsequent requests send this token back so Telefunc routes to the same Durable Object.
 

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -169,9 +169,9 @@ If the user's browser can't connect to your server:
 
 The expected-vs-bug distinction above applies to <Link href="/stream">streamed</Link> and <Link href="/real-time">real-time</Link> values too.
 
-A generator or stream that **throws partway through** sends the client a typed error for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
+A generator or stream that **throws mid-response** surfaces a typed error on the client for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
 
-**Channels and broadcasts** signal failure through four error types — `NetworkError` (`isChannel: true`, connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
+**Channels and broadcasts** signal failure through four types of errors — `NetworkError` (`isChannel: true`, connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
 
 
 ## See also

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -169,9 +169,9 @@ If the user's browser can't connect to your server:
 
 The expected-vs-bug distinction above applies to <Link href="/stream">streamed</Link> and <Link href="/real-time">real-time</Link> values too.
 
-A generator or stream that **throws mid-response** surfaces a typed error on the client for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
+A generator or stream that **throws partway through** sends the client a typed error for that value, while values already delivered stay usable. `throw Abort()` is relayed as an expected error; any other throw is treated as a bug (hidden in production, like a normal telefunction).
 
-**Channels and broadcasts** signal failure through a small set of errors — `NetworkError` (`isChannel: true`, connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
+**Channels and broadcasts** signal failure through four error types — `NetworkError` (`isChannel: true`, connection lost beyond the reconnect window), `ChannelClosedError` (`send()` after `close()` / `abort()`), `ChannelOverflowError` (buffered sends exceeded the limit), and `Abort` (the server called `abort(value)`). See <Link href="/channel#error-handling" /> for the table and recovery.
 
 
 ## See also

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -7,7 +7,7 @@ Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Bl
 
 > **Which API?**
 > - **Bytes already in memory** → return a native `File` / `Blob` (as above).
-> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />, which never buffers the full payload (on either the server or the client).
+> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />, which adds progress, cancel, and save-to-disk — and, when the source is a stream, never buffers the full payload on the server.
 >
 > The tables below break down the memory trade-offs.
 
@@ -163,7 +163,7 @@ const opfsFile = await dl.saveToOpfs()
 imgEl.src = URL.createObjectURL(opfsFile)
 ```
 
-> Web APIs that require a real Blob brand (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first — those APIs check the internal Blob slot, which only real `File` / `Blob` instances have.
+> Web APIs that require a genuine `File` / `Blob` (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first — they check for an internal marker that only real `File` / `Blob` instances have.
 
 
 ### `saveToDisk({ mode })`

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -163,7 +163,7 @@ const opfsFile = await dl.saveToOpfs()
 imgEl.src = URL.createObjectURL(opfsFile)
 ```
 
-> Web APIs that require a genuine `File` / `Blob` (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first — they check for an internal marker that only real `File` / `Blob` instances have.
+> Web APIs that require a real `File` / `Blob` (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first — they check for an internal marker that only real `File` / `Blob` instances have.
 
 
 ### `saveToDisk({ mode })`

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-Pass `File` or `Blob` arguments to a telefunction like any other value. Single file, multiple files, `File[]` arrays, mixed with other arguments — it just works.
+Pass `File` or `Blob` arguments to a telefunction like any other value. A single file, multiple files, `File[]` arrays, or files mixed with other arguments — all are supported.
 
 > When a call contains files, Telefunc automatically switches from JSON to a binary format that streams file bytes without buffering.
 
@@ -148,7 +148,7 @@ await file2.text()
 await file1.text()
 ```
 
-> All files share a single forward-only HTTP stream. Reading `file2` before `file1` would require buffering `file1` in memory.
+> All files of a single call share one forward-only HTTP stream. Reading `file2` before `file1` would require buffering `file1` in memory.
 
 You can start reads concurrently — they stream in the correct order automatically:
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -213,7 +213,7 @@ export async function someTelefunction() {
 
 ## `onClose()`
 
-The context object returned by `getContext()` also includes `onClose()`, a callback that fires exactly once when the call ends — whether the client received everything, disconnected, or hit an error. Use it to release resources.
+The context object returned by `getContext()` also includes `onClose()`, a callback that fires exactly once when the call ends — whether the client received everything, the client disconnected, or an error occurred. Use it to release resources.
 
 ```ts
 const context = getContext()

--- a/docs/pages/index/features/Features.tsx
+++ b/docs/pages/index/features/Features.tsx
@@ -69,7 +69,7 @@ function Features() {
         </h2>
         <>
           <p>
-            Telefunctions can <b>stream values</b> — AI tokens, progress, file up/downloads — and power <b>real-time</b>{' '}
+            Telefunctions can <b>stream values</b> — AI tokens, progress, file uploads &amp; downloads — and power <b>real-time</b>{' '}
             features with channels &amp; broadcasts, by returning or passing them like any other value.
           </p>
         </>

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -9,7 +9,7 @@ It works in **both directions**:
 - **Server → client** — return an `AsyncGenerator`, `ReadableStream`, `File`, nested `Promise`, `Channel`, or `BroadcastChannel`.
 - **Client → server** — pass a `ReadableStream`, `File`, or callback as an argument.
 
-> Plain telefunction calls are unaffected — this kicks in only when you return or pass one of these, with zero config.
+> Plain telefunction calls are unaffected. The special handling described here applies only when you return or pass one of the types listed above, and it requires no configuration.
 
 
 ## A first example
@@ -60,12 +60,12 @@ That's the whole idea: the value crosses the network like any return value, but 
 > One-way or two-way? Reach for an `AsyncGenerator` or `ReadableStream` when data flows one way; use a <Link text="channel" href="/channel" /> only when the client also needs to send.
 
 
-## Handled for you
+## Handled automatically
 
 Whatever you return or pass:
 
 - **Validation** — every value the client sends to the server is shield-validated against your TypeScript types. See <Link href="/shield" />.
-- **Cleanup** — when the client stops reading or disconnects, your telefunction is notified so it can release resources. See <Link href="/close" />.
+- **Cleanup** — when the client stops reading or disconnects, `onClose()` fires so your telefunction can release resources. See <Link href="/close" />.
 - **Transport & reconnection** — streams and channels negotiate a working transport (HTTP, SSE, WebSocket) and recover from dropped connections automatically. Tune it only if you need to — see <Link href="/transport" />.
 - **Serialization** — structured values use Telefunc's serializer, so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip (not just JSON); raw bytes travel as `Uint8Array` / `File` / `Blob`.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -188,7 +188,7 @@ export async function onJoinRoom(roomId: string) {
 
 ## Reconnection
 
-If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. Your application code doesn't need to handle any of this.
+If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. It's fully automatic: you don't need to handle any of this.
 
 See <Link href="/channel#reconnection" text="Channel reconnection" /> for details.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -3,9 +3,9 @@ import { StreamingBeta, NeedsLongRunningServer } from '../../components'
 
 <StreamingBeta />
 
-Telefunc supports real-time use cases — chat, file upload progress, live updates, and more. They build on values that stream or stay connected across the client/server boundary — see the <Link text="Live overview" href="/live" />.
+Telefunc supports real-time use cases — chat, file-upload progress, live updates, and more. They're all built on Telefunc values that stream or stay connected across the client/server boundary — see the <Link text="Live overview" href="/live" />.
 
-> Before reaching for Telefunc's real-time primitives directly, consider a high-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in an ergonomic API.
+> Before reaching for Telefunc's real-time primitives directly, consider a higher-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in a simpler API.
 
 
 ## Which primitive should I use?
@@ -97,7 +97,7 @@ See <Link href="/channel" /> for the full API.
 
 ## Broadcast
 
-Broadcasting is keyed pub/sub — everything sharing a `key` forms a group. There are two pieces: the server-side <Link text={<code>Broadcast</code>} href="/channel#broadcast" /> bus (`publish` / `subscribe` by key), and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, which bridges a client into a key's group. Return a `BroadcastChannel` to broadcast to clients:
+Broadcasting is keyed pub/sub — everyone sharing a `key` is in the same group. There are two pieces: the server-side <Link text={<code>Broadcast</code>} href="/channel#broadcast" /> bus (`publish` / `subscribe` by key), and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, which bridges a client into a key's group. Return a `BroadcastChannel` to broadcast to clients:
 
 ### Notifications
 
@@ -162,7 +162,7 @@ export async function onJoinTeam(teamId: string) {
 }
 ```
 
-`getContext()` and `throw Abort()` only work **synchronously, before the telefunction returns** (see <Link href="/getContext#access" />). A channel outlives that window — its `listen()` callback runs later, after the telefunction has returned — so **capture what you need in a closure** and check it on each message:
+`getContext()` and `throw Abort()` only work **synchronously, before the telefunction returns** (see <Link href="/getContext#access" />). A channel outlives that window — its `listen()` callback runs later, after the telefunction has returned — so **capture what you need in a closure** and re-check authorization on each message:
 
 ```ts
 // Room.telefunc.ts
@@ -188,7 +188,7 @@ export async function onJoinRoom(roomId: string) {
 
 ## Reconnection
 
-If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. It's transparent to your application code.
+If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. Your application code doesn't need to handle any of this.
 
 See <Link href="/channel#reconnection" text="Channel reconnection" /> for details.
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -5,7 +5,7 @@ import { StreamingBeta } from '../../components'
 
 For reactive streams with full operator support, you can use [RxJS](https://rxjs.dev).
 
-The `@telefunc/rxjs` integration lets you pass RxJS `Observable` and `Subject` transparently between client and server — both directions, all operators.
+The `@telefunc/rxjs` integration lets you pass RxJS `Observable` and `Subject` directly between client and server — both directions, all operators.
 
 > Values you stream to the server are **shield-validated at runtime** against your TypeScript types — see <Link href="#shields" />.
 
@@ -79,7 +79,7 @@ edits.subscribe(edit => applyEdit(edit))
 edits.next({ userId: 'alice', text: 'Hello' })
 ```
 
-> **Single server.** A module-level `Subject` lives in one server process. These multicast examples (the editor above, and *Live cursors* below) work as-is on a single instance. Across multiple instances, each process has its own `Subject` — so route shared state through a broadcast transport instead, see <Link href="/scaling" />.
+> **Single server.** A module-level `Subject` lives in one server process. These multicast examples (the editor above, and *Live cursors* below) work as-is on a single instance. Across multiple instances, each server process has its own `Subject` — so route shared state through a broadcast transport instead, see <Link href="/scaling" />.
 
 
 

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -13,7 +13,7 @@ That's the whole picture. The rest of this page explains why and shows the commo
 
 ## Sticky sessions
 
-A Telefunc `Channel` is a stateful connection. Its server-side state — the `Channel` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one Node process. When the client reconnects (a brief network drop, a page reload, an SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
+A Telefunc `Channel` is a stateful connection. Its server-side state — the `Channel` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one Node process. When the client reconnects (network issues, a page reload, an SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
 
 This is the same constraint Socket.IO documents under [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/). The same load-balancer feature solves it for Telefunc: a sticky session, usually backed by a cookie or by the client IP.
 

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -13,7 +13,7 @@ That's the whole picture. The rest of this page explains why and shows the commo
 
 ## Sticky sessions
 
-A Telefunc `Channel` is a stateful connection. Its server-side state — the `Channel` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one Node process. When the client reconnects (network blip, page reload, SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
+A Telefunc `Channel` is a stateful connection. Its server-side state — the `Channel` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one Node process. When the client reconnects (a brief network drop, a page reload, an SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
 
 This is the same constraint Socket.IO documents under [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/). The same load-balancer feature solves it for Telefunc: a sticky session, usually backed by a cookie or by the client IP.
 
@@ -37,7 +37,7 @@ const redis = new IORedis(process.env.REDIS_URL)
 installRedis(redis)
 ```
 
-See <Link href="/redis" /> for details. Redis is the only adapter shipped today, but the `BroadcastTransport` interface is small — about four methods — so a custom transport on top of NATS, Kafka, RabbitMQ, or any other message broker is straightforward.
+See <Link href="/redis" /> for details. Redis is the only adapter shipped today, but the `BroadcastTransport` interface is small (about four methods), so you can write a custom transport on top of NATS, Kafka, RabbitMQ, or any other message broker.
 
 
 ## Load balancer setup
@@ -87,7 +87,7 @@ See <Link href="/cloudflare#scaling" text="Cloudflare scaling" />.
 
 ## Sanity check
 
-After deploying behind a sticky load balancer, open the browser network tab, refresh once, and confirm every request to `/_telefunc` carries the same sticky cookie. If two consecutive requests carry different sticky values, the load balancer isn't configured.
+After deploying behind a sticky load balancer, open the browser network tab, refresh once, and confirm every request to `/_telefunc` carries the same sticky cookie. If two consecutive requests carry different sticky values, the load balancer isn't configured for sticky sessions.
 
 
 ## See also

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Low-level function that processes telefunction requests and returns an HTTP response. It's stateless (a pure function with no side effects).
+Low-level function that processes telefunction requests and returns an HTTP response. It's stateless — it holds no state between requests.
 
 > For <Link href="/stream">streaming</Link> and <Link href="/real-time">real-time</Link> setups, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Low-level function that processes telefunction requests and returns an HTTP response. It's stateless — it holds no state between requests.
+Low-level function that processes telefunction requests and returns an HTTP response. It's a pure function: stateless and has no side effects.
 
 > For <Link href="/stream">streaming</Link> and <Link href="/real-time">real-time</Link> setups, use the runtime-specific `new Telefunc()` from `telefunc/node`, `telefunc/bun`, `telefunc/deno`, or `telefunc/cloudflare` instead. See <Link href="/server" />.
 

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -154,7 +154,7 @@ List of `shield()` types:
 
 ## Beyond top-level arguments
 
-Telefunc's automatic `shield()` generation isn't limited to a telefunction's direct arguments. It also emits **sub-shields** for values nested inside your types wherever the RPC boundary extends — callbacks and channels below, and <Link href="/rxjs#shields" text="RxJS streams" /> via `@telefunc/rxjs`. Sub-shields come from the same TypeScript types, so the runtime check always matches the declared type.
+Telefunc's automatic `shield()` generation isn't limited to a telefunction's direct arguments. It also emits **sub-shields** for values nested inside your types wherever the RPC boundary extends — callbacks and channels below, and <Link href="/rxjs#shields" text="RxJS streams" /> via `@telefunc/rxjs`. Sub-shields are generated from your TypeScript types, so the runtime check always matches the declared type.
 
 The invariant: **only values arriving at the server are validated.** Values flowing the other way are trusted (the server is the trust boundary).
 
@@ -183,7 +183,7 @@ export async function getUser(id: string) {
 }
 ```
 
-> `void` return types compile to a shield that accepts only `undefined`. A callback typed `() => Promise<void>` that returns a truthy value is rejected — otherwise `if (await cb()) …` would branch on client-returned garbage.
+> `void` return types compile to a shield that accepts only `undefined`. A callback typed `() => Promise<void>` that returns a truthy value is rejected — otherwise `if (await cb()) …` would branch on an arbitrary value supplied by the client.
 
 
 ### Channels

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,7 +7,7 @@ Stream values that arrive over time — AI tokens, progress, raw bytes, or lazil
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
-> Streaming works out of the box with zero config — including <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting transport only if you need to).
+> Streaming needs no configuration — including its <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting transport only if you need to).
 
 
 ## Which one should I use?

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,7 +7,7 @@ Stream values that arrive over time — AI tokens, progress, raw bytes, or lazil
 - **Server → client**: Return `AsyncGenerator`, `ReadableStream`, `File` / `Blob` / `download()`, or nested `Promise` from a telefunction.
 - **Client → server**: Pass a `ReadableStream` as a telefunction argument.
 
-> Streaming needs no configuration — including its <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting transport only if you need to).
+> Streaming works out-of-the-box — including its <Link text="transport" href="/transport" /> (binary HTTP by default; switch to SSE or a reconnecting transport only if you need to).
 
 
 ## Which one should I use?

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -31,7 +31,7 @@ function App() {
 }
 ```
 
-`withTelefunc()` returns the same `QueryClient` instance. All options and APIs keep working as-is.
+`withTelefunc()` returns the same `QueryClient` instance. All options and APIs keep working unchanged.
 
 > The integration lives in `QueryClient` (the peer dependency is `@tanstack/query-core` v5+), so any TanStack Query adapter works: React, Vue, Svelte, Solid. The examples above use React.
 
@@ -48,9 +48,9 @@ queryKey: ['global:todos', `user:${userId}`]     // global — all clients with 
 queryKey: ['global:documents', docId]            // global
 ```
 
-> A key is global when its *first* element is a string starting with `global:`, e.g. `['todos', 'global:x']` is a local key.
+> A key is global when its *first* element is a string starting with `global:` — e.g. `['global:todos']` is global, while `['todos', 'global:x']` is local (its first element isn't).
 
-> Global keys ride on Telefunc calls, so two rules apply:
+> Global keys are carried by Telefunc calls, so two rules apply:
 >
 > - **`queryFn` must call a telefunction.** The invalidation subscription piggybacks on that call. With a non-telefunc `queryFn` (e.g. plain `fetch()`), a global key silently behaves like a local one. The same goes for mutations: global keys in `meta.invalidates` are published server-side after the telefunction succeeds, so `mutationFn` must be a telefunction call too.
 > - **Return the telefunction call directly.** The integration reads the invalidation subscription from whatever `queryFn` returns, so transform with `select` instead:
@@ -124,7 +124,7 @@ invalidate(['global:articles'])
 invalidate(['global:documents', docId])
 ```
 
-Prefix matching — invalidating `['global:documents']` hits `['global:documents', docId]` too. Same behavior as TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys).
+Prefix matching — invalidating `['global:documents']` matches `['global:documents', docId]` too. Same behavior as TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys).
 
 
 ## How it works

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -83,7 +83,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 - **Start with `'sse'`** — it works everywhere with no extra setup.
 - **Use `'ws'`** for chatty real-time traffic where you want full-duplex.
 
-> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background — no interruption to your application code.
+> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background; open channels keep working without interruption.
 
 
 ## Recommended setup

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -52,7 +52,7 @@ Controls how streamed values are delivered over HTTP.
 ### When to use what
 
 - **Start with `'binary-inline'`** — it's the fastest and works in most setups.
-- **Switch to `'sse-inline'`** if a proxy or CDN buffers binary HTTP responses but passes SSE events through without buffering.
+- **Switch to `'sse-inline'`** if a proxy or CDN buffers binary HTTP responses, but passes SSE events through without buffering.
 - **Use `'channel'`** when you want streamed values to reconnect automatically after a dropped connection, like Telefunc channels do.
 
 
@@ -65,7 +65,7 @@ Controls how <Link text={<code>new Channel()</code>} href="/channel" /> and <Lin
 | `'sse'` | HTTP requests + SSE stream. Works without extra server setup. |
 | `'ws'` | Multiplexed WebSocket. Requires <Link text="WebSocket server setup" href="/server" />. |
 
-The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE without any setup and adds WebSocket when you install an adapter (see <Link href="/server" />).
+The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE out-of-the-box and adds WebSocket when you install an adapter (see <Link href="/server" />).
 
 All channels share a single multiplexed connection per server URL, so opening many channels doesn't open many connections.
 
@@ -80,10 +80,10 @@ All channels share a single multiplexed connection per server URL, so opening ma
 
 ### When to use what
 
-- **Start with `'sse'`** — it works everywhere with no extra setup.
+- **Start with `'sse'`** — it works everywhere out-of-the-box.
 - **Use `'ws'`** for chatty real-time traffic where you want full-duplex.
 
-> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background; open channels keep working without interruption.
+> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and seamlessly upgrades to WebSocket in the background (open channels keep working without interruption).
 
 
 ## Recommended setup

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -52,7 +52,7 @@ Controls how streamed values are delivered over HTTP.
 ### When to use what
 
 - **Start with `'binary-inline'`** — it's the fastest and works in most setups.
-- **Switch to `'sse-inline'`** if a proxy or CDN buffers binary HTTP responses but passes SSE events through.
+- **Switch to `'sse-inline'`** if a proxy or CDN buffers binary HTTP responses but passes SSE events through without buffering.
 - **Use `'channel'`** when you want streamed values to reconnect automatically after a dropped connection, like Telefunc channels do.
 
 
@@ -65,7 +65,7 @@ Controls how <Link text={<code>new Channel()</code>} href="/channel" /> and <Lin
 | `'sse'` | HTTP requests + SSE stream. Works without extra server setup. |
 | `'ws'` | Multiplexed WebSocket. Requires <Link text="WebSocket server setup" href="/server" />. |
 
-The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE out of the box and adds WebSocket when you install an adapter (see <Link href="/server" />).
+The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE without any setup and adds WebSocket when you install an adapter (see <Link href="/server" />).
 
 All channels share a single multiplexed connection per server URL, so opening many channels doesn't open many connections.
 
@@ -80,10 +80,10 @@ All channels share a single multiplexed connection per server URL, so opening ma
 
 ### When to use what
 
-- **Start with `'sse'`** — it works everywhere out of the box.
+- **Start with `'sse'`** — it works everywhere with no extra setup.
 - **Use `'ws'`** for chatty real-time traffic where you want full-duplex.
 
-> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and seamlessly upgrades to WebSocket in the background — no interruption to your application code.
+> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background — no interruption to your application code.
 
 
 ## Recommended setup

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -40,7 +40,7 @@ for await (const token of gen) {
 | `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streamed values. |
 | `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
 | `channel.connectionKey` | `string` | Calls with the same key share one connection; different keys use separate connections. |
-| `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
+| `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes the connection immediately when the last channel closes. |
 
 
 ## See also

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -40,7 +40,7 @@ for await (const token of gen) {
 | `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streamed values. |
 | `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
 | `channel.connectionKey` | `string` | Calls with the same key share one connection; different keys use separate connections. |
-| `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes the connection immediately when the last channel closes. |
+| `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
 
 
 ## See also


### PR DESCRIPTION
This PR introduces comprehensive streaming and real-time communication features to Telefunc, including bidirectional channels, pub/sub broadcasts, file downloads, and RxJS integration.

## Summary
Adds support for real-time, streaming, and advanced data transfer patterns alongside the existing RPC functionality. Includes new wire protocol implementations, server/client connection management, and integration with multiple runtime environments (Node.js, Cloudflare, Bun, Deno).

## Key Changes

### Core Streaming & Real-Time Features
- **Channels**: Bidirectional communication pipes between server and individual clients (`ClientChannel`, `ServerChannel`)
- **Broadcasts**: Pub/sub messaging system with keyed subscriptions (`Broadcast`, `ServerBroadcast`)
- **Streaming**: Support for async generators, readable streams, and progressive data delivery
- **File Downloads**: `FileDownload` and `BlobDownload` classes for efficient file transfer with progress tracking

### Wire Protocol Implementation
- New client-side connection management (`ClientConnection`, `MuxConnection`) with WebSocket and SSE support
- Server-side channel and broadcast implementations with flow control and replay buffers
- Frame encoding/decoding, session management, and reconnection logic
- Flow control with BDP (Bottleneck Bandwidth and RTT) estimation
- Replay buffers for message recovery on reconnect

### Server Integration
- Multi-runtime support: Node.js, Cloudflare Workers, Bun, Deno via `serve()` function
- Context management refactored from `getContext/` to `context/` directory
- Server configuration for channels and broadcasts
- Shield generation enhancements for type validation

### Client Features
- `withContext()` for client-side context management
- `useGenerator()` React hook for consuming async generators
- `close()` and `abort()` utilities for connection lifecycle
- Session token management for persistent connections

### Ecosystem Integrations
- **RxJS**: Full Observable/Subject serialization support (`@telefunc/rxjs`)
- **TanStack Query**: Integration for live queries via channels/broadcasts (`@telefunc/tanstack-query`)
- **Redis**: Broadcast fan-out for distributed systems (`@telefunc/redis`)

### Documentation
- New pages: `/stream`, `/channel`, `/real-time`, `/file-download`, `/close`, `/serve`, `/scaling`, `/transport`, `/live`, `/withContext`, `/provideTelefuncContext`, `/rxjs`, `/tanstack-query`, `/redis`, `/cloudflare`
- Updated existing pages with streaming/real-time examples
- Added `StreamingBeta` and `NeedsLongRunningServer` documentation components

### Testing & Infrastructure
- Comprehensive test suites for flow control, BDP estimation, channel close semantics
- E2E test playground for streaming scenarios
- Cloudflare Workers test integration with channel/chat examples
- CI workflow for static docs quality checks

## Notable Implementation Details
- Efficient binary frame protocol with length-prefixed encoding
- Automatic reconnection with exponential backoff
- Heartbeat/ping-pong for connection liveness detection
- Graceful channel closure with configurable drain timeouts
- Support for both text (JSON) and binary data streams
- Backward compatible with existing RPC functionality

https://claude.ai/code/session_01Jg48acDTQc1moVdKyn2CkZ