### PR TITLE
Improve documentation clarity and grammar across multiple pages

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -235,7 +235,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 <Warning>
 
-**Keys are capabilities** — anyone who forms the same `key` joins the group. Secure a broadcast one of two ways:
+**Keys are capabilities** — anyone who knows the `key` joins the group. Secure a broadcast one of two ways:
 - **Guard the key**: derive it from **authorized server-side context** (e.g. the user from <Link text="getContext()" href="/getContext" />), never from raw client input — see <Link href="/real-time#authorization" />.
 - **Guard the payload**: whatever you `publish()` reaches every subscriber, so broadcast only non-sensitive data. That's how <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> stays safe — it broadcasts only a *"refetch"* signal (the query key), and each client loads the actual data through its own authorized telefunction.
 
@@ -304,7 +304,7 @@ chat.publish({ user: 'Alice', text: 'Hello!', })
 
 Fundamentally, the difference is what a message is addressed to: a channel message is addressed to *someone*, a broadcast message is addressed to *a topic* (the `key`).
 
-A channel is a conversation, like a phone call: two fixed ends (the server and the one client that received the channel), private to them, finishes when either side hangs up.
+A channel is a conversation, like a phone call: two fixed ends (the server and the one client that received the channel), private to them, ending when either side hangs up.
 
 A broadcast is an announcement, like a radio frequency: whoever tunes in to the `key` receives everything published to it, members come and go, and the `key` belongs to no one.
 
@@ -427,7 +427,7 @@ config.channel = {
 }
 ```
 
-> **What to tune**: defaults suit typical chat/dashboard traffic; reach for these only if you hit one:
+> **What to tune**: the defaults suit typical chat/dashboard traffic; tune these only if you run into one of the issues below:
 > - Slow/flaky clients dropping with `NetworkError` (`isChannel: true`) → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).
 > - `ChannelOverflowError` while a peer is briefly offline → raise `bufferLimit` / `bufferLimitBinary`, or apply backpressure by `await`-ing your `send()`s.
 > - Reconnects should replay more history → raise the replay buffers; lower them to cap memory.

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -110,7 +110,7 @@ export async function* onChat(prompt: string) {
 
 If the client drops all references to a returned value without explicitly closing it, the underlying resources are cleaned up automatically via garbage collection. There is a short delay (typically a few seconds) between the value becoming unreachable and the cleanup firing.
 
-Explicit `close()` is instant. GC cleanup is the fallback for when user code forgets.
+Explicit `close()` is instant. GC cleanup is the fallback for when you forget to do so.
 
 
 ## See also

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -7,7 +7,7 @@ Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Bl
 
 > **Which API?**
 > - **Bytes already in memory** → return a native `File` / `Blob` (as above).
-> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />, which adds progress, cancel, and save-to-disk. When the source is a stream, it never buffers the full payload on the server.
+> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />. When the source is a stream, it never buffers the full payload on the server.
 >
 > The tables below break down the memory trade-offs.
 

--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -41,7 +41,7 @@ const redis = new IORedis(process.env.REDIS_URL, { tls: {} })
 installRedis(redis)
 ```
 
-Telefunc `duplicate()`s the client internally for its subscriber connection — your instance is never mutated or disconnected. You can continue to use it alongside Telefunc without interference.
+Internally, Telefunc calls `duplicate()` on the client to open a dedicated subscriber connection — your instance is never mutated or disconnected. You can continue to use it alongside Telefunc without interference.
 
 ## Channels
 

--- a/docs/pages/scaling/+Page.mdx
+++ b/docs/pages/scaling/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta } from '../../components'
 
 <StreamingBeta />
 
-To scale Telefunc horizontally across several server processes (multiple Node instances, multiple containers, multiple machines), two pieces have to be set up.
+To scale Telefunc horizontally across several server processes (multiple Node instances, multiple containers, multiple machines), you need to set up two things.
 
 1. The load balancer in front of your instances must route every request from the same client to the same instance — **sticky sessions**.
 2. Broadcast publishes must fan out across instances — install a **broadcast transport** like <Link href="/redis">`@telefunc/redis`</Link>.

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -154,7 +154,7 @@ List of `shield()` types:
 
 ## Beyond top-level arguments
 
-Telefunc's automatic `shield()` generation isn't limited to a telefunction's direct arguments. It also emits **sub-shields** for values nested inside your types wherever the RPC boundary extends — callbacks and channels below, and <Link href="/rxjs#shields" text="RxJS streams" /> via `@telefunc/rxjs`. Sub-shields are generated from your TypeScript types, so the runtime check always matches the declared type.
+Telefunc's automatic `shield()` generation isn't limited to a telefunction's direct arguments. It also emits **sub-shields** for values nested inside your types wherever the RPC boundary extends: callbacks and channels (below), and <Link href="/rxjs#shields" text="RxJS streams" /> via `@telefunc/rxjs`. Sub-shields are generated from your TypeScript types, so the runtime check always matches the declared type.
 
 The invariant: **only values arriving at the server are validated.** Values flowing the other way are trusted (the server is the trust boundary).
 


### PR DESCRIPTION
## Summary
This PR improves the clarity and grammatical accuracy of documentation across several pages in the Telefunc docs. The changes focus on refining wording, improving sentence structure, and making technical explanations more precise and accessible.

## Key Changes
- **Channel documentation**: Clarified that "anyone who knows the `key` joins the group" (more precise than "forms the same key"), and changed "finishes when" to "ending when" for better grammar
- **Close documentation**: Simplified explanation of garbage collection fallback from "when user code forgets" to "when you forget to do so" for better readability
- **File download documentation**: Removed redundant phrase about `download()` adding features, streamlining the explanation
- **Redis documentation**: Restructured sentence to clarify that Telefunc calls `duplicate()` internally, making the technical detail more explicit
- **Scaling documentation**: Changed "two pieces have to be set up" to "you need to set up two things" for more natural phrasing
- **Shield documentation**: Changed dash to colon in list of RPC boundary extensions for consistent punctuation

## Notable Details
All changes are documentation-only with no impact on functionality. The modifications maintain technical accuracy while improving readability and consistency across the documentation.

https://claude.ai/code/session_01SX6HnutG77DaQSwPoBsHeF