### PR TITLE
docs: hesitant clarity/naturalness edits (streaming/real-time pages)

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -9,7 +9,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 - **`new Channel()`** — a private two-way pipe between the server and *one* client.
 - **`Broadcast`** — a keyed pub/sub **bus**: `publish()` / `subscribe()` by string `key`, server-side.
-- **`new BroadcastChannel()`** — a `Channel` bridged onto a `Broadcast` key. The two combined.
+- **`new BroadcastChannel()`** — a `Channel` bridged onto a `Broadcast` key; the two primitives combined.
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -235,7 +235,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 <Warning>
 
-**Keys are capabilities** — anyone who knows the `key` joins the group. Secure a broadcast one of two ways:
+**Keys are capabilities** — anyone who knows the `key` joins the group. Secure a broadcast in one of two ways:
 - **Guard the key**: derive it from **authorized server-side context** (e.g. the user from <Link text="getContext()" href="/getContext" />), never from raw client input — see <Link href="/real-time#authorization" />.
 - **Guard the payload**: whatever you `publish()` reaches every subscriber, so broadcast only non-sensitive data. That's how <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> stays safe — it broadcasts only a *"refetch"* signal (the query key), and each client loads the actual data through its own authorized telefunction.
 
@@ -399,7 +399,7 @@ If the connection drops, Telefunc reconnects automatically and resumes existing 
 | `Abort` | Either side called `abort(value)`, or a callback threw `Abort` | Closed | Inspect `err.abortValue` |
 | `NetworkError` (`isChannel: true`) | Connection lost beyond `reconnectTimeout` | Closed | Auto-closed — recreate if needed |
 | `ChannelClosedError` | `send()` on a closed channel (thrown synchronously); also rejects pending `ack` sends orphaned by close or close timeout | Closed | Recreate the channel |
-| `ChannelOverflowError` | A buffered send was dropped — backlog exceeded `config.channel.bufferLimit` while the peer was disconnected | **Open** | Only the dropped `send()` rejects; `await` sends to apply backpressure |
+| `ChannelOverflowError` | A buffered send was dropped — backlog exceeded `config.channel.bufferLimit` while the peer was disconnected | **Open** | Only the dropped `send()` rejects; `await` your sends to apply backpressure |
 
 
 ## Configuration

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -110,7 +110,7 @@ export async function* onChat(prompt: string) {
 
 If the client drops all references to a returned value without explicitly closing it, the underlying resources are cleaned up automatically via garbage collection. There is a short delay (typically a few seconds) between the value becoming unreachable and the cleanup firing.
 
-Explicit `close()` is instant. GC cleanup is the fallback for when you forget to do so.
+Explicit `close()` triggers cleanup immediately. GC cleanup is the fallback for when you forget to do so.
 
 
 ## See also

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -21,7 +21,7 @@ There's one catch-all API, `close()`, plus the per-type APIs. They all signal th
 | `abort(call)` | client | Immediate | The in-flight call and any channels it opened |
 | <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
 | <Link text={<code>channel.abort(value?)</code>} href="/channel#lifecycle" /> | either side | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
-| `onClose(cb)` | server | — (cleanup hook) | Fires when the value ends, however it ended |
+| `onClose(cb)` | server | — (cleanup hook) | Fires when the value ends, however it ends |
 
 The rest of this page covers `close()`, `abort()`, and `onClose()` in detail; channel-specific closing is on <Link href="/channel#lifecycle" />.
 

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -52,7 +52,7 @@ export default {
 > - **Durable Objects** provide stateful compute: each channel lives on a Durable Object, which holds the connection and its state.
 > - **KV** provides shared storage: it's how stateless workers — wherever a request happens to land — find the Durable Object that holds the state.
 >
-> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` or `BroadcastChannel`, there's no state to keep — skip both bindings and use `serve()` instead, see <Link text="Low-level API" href="/server#low-level-api" />.
+> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` or `BroadcastChannel`, there's no state to keep — skip both bindings and use `serve()` instead (see <Link text="Low-level API" href="/server#low-level-api" />).
 >
 > See <Link href="#architecture" /> for implementation details.
 
@@ -94,7 +94,7 @@ Each region runs its own Durable Objects so that channel state stays close to us
 
 ### Session affinity
 
-Every telefunction call and channel message from a browser must reach the **same Durable Object** — otherwise its channel state would not be available.
+Every telefunction call and channel message from a browser must reach the **same Durable Object** — otherwise that browser's channel state would be unavailable.
 
 On the first request, Telefunc picks a Durable Object in the nearest region, stores a session token in KV (TTL: 24 hours), and returns it to the client via the `x-telefunc-session` header. Subsequent requests send this token back so Telefunc routes to the same Durable Object.
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -163,7 +163,7 @@ const opfsFile = await dl.saveToOpfs()
 imgEl.src = URL.createObjectURL(opfsFile)
 ```
 
-> Web APIs that require a real `File` / `Blob` (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first — they check for an internal marker that only real `File` / `Blob` instances have.
+> Web APIs that require a real `File` / `Blob` (`URL.createObjectURL`, `<img src>`, `fetch({body})`, `FormData.append`) need `await dl.saveToMemory()` / `saveToDisk()` / `saveToOpfs()` first. These APIs check for an internal marker that only real `File` / `Blob` instances have.
 
 
 ### `saveToDisk({ mode })`

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -7,7 +7,7 @@ Return a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or [`Bl
 
 > **Which API?**
 > - **Bytes already in memory** → return a native `File` / `Blob` (as above).
-> - **Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />. When the source is a stream, it never buffers the full payload on the server.
+> - **Large files, bytes streamed from an upstream source, or when you need progress / cancel / save-to-disk** → wrap them with <Link text={<code>download()</code>} href="#streaming-with-download" />. When the source is a stream, the full payload is never buffered on the server.
 >
 > The tables below break down the memory trade-offs.
 
@@ -83,7 +83,7 @@ const dl = await onGetImage(s3Key)
 imgEl.src = URL.createObjectURL(await dl.saveToMemory())
 ```
 
-> `dl.name`, `dl.type`, `dl.size`, `dl.lastModified` are usable as soon as `await onGetImage(...)` settles — bytes stream in the background.
+> `dl.name`, `dl.type`, `dl.size`, `dl.lastModified` are available as soon as `await onGetImage(...)` settles — bytes stream in the background.
 
 
 ## Progress + cancel
@@ -132,7 +132,7 @@ Calling `dl.cancel()` aborts the stream — the pending `saveToMemory` call reje
 
 ## Reading strategies
 
-The streaming download is a standard [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) / [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)-shaped object — `dl.stream()`, `dl.text()`, `dl.arrayBuffer()`, `dl.bytes()`, `dl.slice()` all work and pull from the streaming source as you read:
+The streaming download is a standard [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) / [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)-shaped object — `dl.stream()`, `dl.text()`, `dl.arrayBuffer()`, `dl.bytes()`, and `dl.slice()` all work and pull from the streaming source as you read:
 
 | Method | Returns | Memory | Best for |
 |---|---|---|---|
@@ -178,7 +178,7 @@ imgEl.src = URL.createObjectURL(opfsFile)
 
 ## Multiple / nested downloads
 
-Return any number of `File`, `Blob`, or `download()` values, anywhere in the response — arrays, nested objects, mixed with regular data. Each one independently exposes its own `onProgress` / `cancel` / `saveTo*` methods on the client.
+Return any number of `File`, `Blob`, or `download()` values anywhere in the response — in arrays, in nested objects, or mixed with regular data. Each one independently exposes its own `onProgress` / `cancel` / `saveTo*` methods on the client.
 
 ```ts
 // Document.telefunc.ts

--- a/docs/pages/live/+Page.mdx
+++ b/docs/pages/live/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta, NeedsLongRunningServer } from '../../components'
 
 <StreamingBeta />
 
-Telefunc moves values that **stream or stay connected** across the client/server boundary — async sequences, byte streams, files, and persistent connections — by returning them from, or passing them to, a telefunction like any other value.
+Telefunc moves values that **stream or stay connected** across the client/server boundary — async sequences, byte streams, files, and persistent connections. You return them from a telefunction, or pass them to one, like any other value.
 
 It works in **both directions**:
 - **Server → client** — return an `AsyncGenerator`, `ReadableStream`, `File`, nested `Promise`, `Channel`, or `BroadcastChannel`.
@@ -67,7 +67,7 @@ Whatever you return or pass:
 - **Validation** — every value the client sends to the server is shield-validated against your TypeScript types. See <Link href="/shield" />.
 - **Cleanup** — when the client stops reading or disconnects, `onClose()` fires so your telefunction can release resources. See <Link href="/close" />.
 - **Transport & reconnection** — streams and channels negotiate a working transport (HTTP, SSE, WebSocket) and recover from dropped connections automatically. Tune it only if you need to — see <Link href="/transport" />.
-- **Serialization** — structured values use Telefunc's serializer, so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip (not just JSON); raw bytes travel as `Uint8Array` / `File` / `Blob`.
+- **Serialization** — structured values use Telefunc's serializer — not just JSON — so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip; raw bytes travel as `Uint8Array` / `File` / `Blob`.
 
 
 ## Shipping to production

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -147,7 +147,7 @@ See <Link href="/channel#new-broadcastchannel" /> for the full broadcast API.
 
 ## Authorization
 
-A channel or broadcast is opened by a telefunction, so you protect it like any other telefunction (see <Link href="/permissions" />): authorize **at open time** with <Link text="getContext()" href="/getContext" /> and `throw Abort()`.
+A channel or broadcast is opened by a telefunction, so you protect it just as you would any telefunction (see <Link href="/permissions" />): authorize **at open time** with <Link text="getContext()" href="/getContext" /> and `throw Abort()`.
 
 ```ts
 // Team.telefunc.ts
@@ -188,7 +188,7 @@ export async function onJoinRoom(roomId: string) {
 
 ## Reconnection
 
-If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order. It's fully automatic: you don't need to handle any of this.
+If the connection drops, Telefunc reconnects automatically, resumes existing channels, and replays buffered messages in order — you don't need to handle any of this.
 
 See <Link href="/channel#reconnection" text="Channel reconnection" /> for details.
 

--- a/docs/pages/real-time/+Page.mdx
+++ b/docs/pages/real-time/+Page.mdx
@@ -3,7 +3,7 @@ import { StreamingBeta, NeedsLongRunningServer } from '../../components'
 
 <StreamingBeta />
 
-Telefunc supports real-time use cases — chat, file-upload progress, live updates, and more. They're all built on Telefunc values that stream or stay connected across the client/server boundary — see the <Link text="Live overview" href="/live" />.
+Telefunc supports real-time use cases — chat, file-upload progress, live updates, and more. They all build on the same foundation: Telefunc values that stream or stay connected across the client/server boundary — see the <Link text="Live overview" href="/live" />.
 
 > Before reaching for Telefunc's real-time primitives directly, consider a higher-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> — it wraps the primitives below in a simpler API.
 
@@ -183,7 +183,7 @@ export async function onJoinRoom(roomId: string) {
 }
 ```
 
-> <Link href="/shield" /> validates the **type** of every client→server message; authorization — **who** may open a channel or send a message — is yours, via `getContext()` + `Abort()`.
+> <Link href="/shield" /> validates the **type** of every client→server message; authorization — **who** may open a channel or send a message — is up to you, via `getContext()` + `Abort()`.
 
 
 ## Reconnection

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -36,7 +36,7 @@ Controls how streamed values are delivered over HTTP.
 |---|---|---|
 | `'binary-inline'` (default) | `application/octet-stream` | Raw binary chunked response. Lowest overhead. |
 | `'sse-inline'` | `text/event-stream` | Base64url-encoded SSE. Works through proxies that buffer binary. |
-| `'channel'` | `text/plain` + channel | Starts in HTTP, continues over the configured channel transport. |
+| `'channel'` | `text/plain` + channel | Starts over HTTP, then continues over the configured channel transport. |
 
 ### Comparison
 
@@ -81,7 +81,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 ### When to use what
 
 - **Start with `'sse'`** — it works everywhere out-of-the-box.
-- **Use `'ws'`** for chatty real-time traffic where you want full-duplex.
+- **Use `'ws'`** for chatty real-time traffic where you want a full-duplex connection.
 
 > When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and seamlessly upgrades to WebSocket in the background (open channels keep working without interruption).
 


### PR DESCRIPTION
## What this is

During a sentence-level clarity & naturalness review of the docs introduced by the streaming PR, I split my edits into two buckets:

- **Confident net-wins** → branch `claude/clever-faraday-u2i264` (the 8 edits this PR stacks on top of).
- **Hesitant edits** (this PR) → cases where, after trying multiple wordings, I was **not sure my edit actually beats the original**. They're matters of taste, parallelism, or trivial polish. Each is independent — accept or reject per line. The alternatives I weighed are listed below.

Stacked on top of the confident-edits branch, so the diff here is *only* the 12 hesitant changes.

---

### 1. `live` — opener (line 6)
- **Current:** *"…and persistent connections — by returning them from, or passing them to, a telefunction like any other value."*
- **Proposed:** *"…and persistent connections. You return them from a telefunction, or pass them to one, like any other value."*
- **Alternatives:** (a) keep current; (b) *"…— just by returning them from, or passing them to, a telefunction."*; (c) *"…by returning or passing them through a telefunction like any other value."* (rejected: "return … through" is slightly wrong).
- **Why hesitant:** the original's coordinated-preposition construction is economical and defensible; splitting trades density for an extra sentence.

### 2. `live` — Serialization bullet (line 70)
- **Current:** *"…use Telefunc's serializer, so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip (not just JSON); raw bytes travel as…"*
- **Proposed:** *"…use Telefunc's serializer — not just JSON — so `Date`, `Map`, `Set`, `BigInt`, etc. survive the trip; raw bytes travel as…"*
- **Alternatives:** (a) keep current; (b) *"so types beyond JSON — `Date`, `Map`, `Set`, `BigInt`, and more — survive the trip"*.
- **Why hesitant:** moving the "(not just JSON)" clarifier next to "serializer" arguably reads cleaner, but the original parenthetical is fine.

### 3. `real-time` — intro (line 6)
- **Current:** *"They're all built on Telefunc values that stream or stay connected…"*
- **Proposed:** *"They all build on the same foundation: Telefunc values that stream or stay connected…"*
- **Alternatives:** (a) keep current; (b) *"They're all powered by Telefunc values that stream or stay connected…"*.
- **Why hesitant:** "use cases … built on values" is slightly abstract, but not wrong; the reword is longer.

### 4. `real-time` — authorization note (line 186)
- **Current:** *"…— is yours, via `getContext()` + `Abort()`."*
- **Proposed:** *"…— is up to you, via `getContext()` + `Abort()`."*
- **Alternatives:** (a) keep current; (b) *"is your responsibility"*.
- **Why hesitant:** "is yours" is punchy and likely intentional; "is up to you" is marginally more explicit.

### 5. `channel` — primitives list (line 12)
- **Current:** *"— a `Channel` bridged onto a `Broadcast` key. The two combined."*
- **Proposed:** *"— a `Channel` bridged onto a `Broadcast` key; the two primitives combined."*
- **Alternatives:** (a) keep current.
- **Why hesitant:** the terse fragment "The two combined." is a deliberate stylistic beat consistent with the list above it.

### 6. `close` — onClose table row (line 24)
- **Current:** *"Fires when the value ends, however it ended"*
- **Proposed:** *"Fires when the value ends, however it ends"* (tense agreement)
- **Alternatives:** (a) keep current — past tense is defensible (at fire time the ending is complete); (b) *"…, no matter how"*.
- **Why hesitant:** genuinely defensible either way.

### 7. `transport` — `'channel'` row (line 39)
- **Current:** *"Starts in HTTP, continues over the configured channel transport."*
- **Proposed:** *"Starts over HTTP, then continues over the configured channel transport."*
- **Alternatives:** (a) keep current; (b) *"Begins over HTTP, then continues…"*.
- **Why hesitant:** "over HTTP" is the more standard idiom and parallels "continues over", but the reviewer rated the original cell fine — low value, possible churn.

### 8. `transport` — when to use `'ws'` (line 84)
- **Current:** *"…where you want full-duplex."*
- **Proposed:** *"…where you want a full-duplex connection."*
- **Alternatives:** (a) keep current.
- **Why hesitant:** "full-duplex" is commonly used elliptically; adding "connection" is clearer but wordier.

### 9. `file-download` — "Which API?" bullet (line 10)
- **Current:** *"**Large files, bytes streamed from an upstream source, or you need progress / cancel / save-to-disk** → wrap them with `download()`. When the source is a stream, it never buffers the full payload on the server."*
- **Proposed:** *"…or when you need progress / cancel / save-to-disk** → wrap them with `download()`. When the source is a stream, the full payload is never buffered on the server."*
- **Alternatives:** (a) keep current; (b) make all three branches noun phrases: *"…, or a need for progress / cancel / save-to-disk"* (rejected: "a need for" is awkward).
- **Why hesitant:** two sub-changes (list parallelism + passive to drop the ambiguous "it"); both minor.

### 10. `file-download` — metadata note (line 86)
- **Current:** *"…are usable as soon as `await onGetImage(...)` settles…"*
- **Proposed:** *"…are available as soon as `await onGetImage(...)` settles…"*
- **Alternatives:** (a) keep current.
- **Why hesitant:** "available" reads slightly more naturally for properties, but "usable" is not wrong.

### 11. `file-download` — reading strategies intro (line 135)
- **Current:** *"…`dl.bytes()`, `dl.slice()` all work and pull from the streaming source…"*
- **Proposed:** *"…`dl.bytes()`, and `dl.slice()` all work and pull from the streaming source…"* (Oxford "and" removes a brief garden-path with "all work")
- **Alternatives:** (a) keep current (matches the comma-only list style elsewhere).
- **Why hesitant:** house style elsewhere omits the conjunction in method lists.

### 12. `file-download` — multiple/nested downloads (line 181)
- **Current:** *"Return any number of `File`, `Blob`, or `download()` values, anywhere in the response — arrays, nested objects, mixed with regular data."*
- **Proposed:** *"Return any number of `File`, `Blob`, or `download()` values anywhere in the response — in arrays, in nested objects, or mixed with regular data."*
- **Alternatives:** (a) keep current.
- **Why hesitant:** parallelism fix on the trailing list; the original is readable.

---

The docs quality gate (`node docs/check-docs.mjs`) passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011eFyZPCBeHzZeuWLAb3xfK)_