### PR TITLE
docs(rxjs): correct the shared-Subject multicast semantics

### DIFF
--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -54,7 +54,7 @@ price$.pipe(
 
 ## Collaborative editor
 
-A shared `Subject` returned to multiple clients multicasts: when any client calls `next()`, all other clients' subscribers receive the value.
+A shared `Subject` returned to multiple clients multicasts across them: when one client emits with `next()`, every other client's subscribers receive the value through the server. The emitting client's own subscribers receive it locally too — the server doesn't echo a client's `next()` back to that same client.
 
 ```ts
 // Editor.telefunc.ts


### PR DESCRIPTION
## Summary

Corrects one sentence on the `/rxjs` page ("Collaborative editor") that misstated how a shared server-side `Subject` multicasts.

**Before:**
> A shared `Subject` returned to multiple clients multicasts: when any client calls `next()`, all other clients' subscribers receive the value.

**After:**
> A shared `Subject` returned to multiple clients multicasts across them: when one client emits with `next()`, every other client's subscribers receive the value through the server. The emitting client's own subscribers receive it locally too — the server doesn't echo a client's `next()` back to that same client.

## Why

"all other clients' subscribers" implies the emitting client is excluded, but that's not what the implementation does. Verified against the source and the e2e tests:

- **`wireSubject`'s re-entrancy guard** (`packages/rxjs/src/shared.ts`) stops the server from echoing a client's own `next()` back over the same channel:
  ```ts
  next(v) { if (channel.isClosed || isProcessingRemote) return; channel.send({ t: MSG.NEXT, v }) }
  ```
  The `onSubjectEcho` test (`test/playground-streaming/pages/rxjs/RxJS.telefunc.ts`) documents this: a synchronous server-side echo is dropped and must be deferred with `setTimeout` to escape the re-entrant window.
- **But** `wireSubject` patches only `_subscribe`, not `next()` — so the emitting client's own local subscribers fire synchronously via plain `Subject` semantics.

Net: every connected client's subscribers see the value — other clients through the server, the emitter locally. This also clarifies the contrast with `BroadcastChannel` (which delivers to the publisher *via* a server round-trip).

## Notes

- Rebased on the latest `nitedani/streaming`; the three clarity fixes from the (now-closed) #338 were already incorporated via #339/#340, so this PR contains only the new rxjs correctness fix — one line changed.
- Docs quality gate passes (`pnpm --filter docs run docs:lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114fSzc9okhk8zrwko8SEo7

---
_Generated by [Claude Code](https://claude.ai/code/session_0114fSzc9okhk8zrwko8SEo7)_