### PR TITLE
Use ghcr.io for DragonflyDB image to improve CI reliability

### DIFF
--- a/test/playground-streaming/compose.yaml
+++ b/test/playground-streaming/compose.yaml
@@ -93,7 +93,11 @@ configs:
 
 services:
   redis:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    # DragonflyDB (Redis-compatible). Pulled from GitHub Container Registry instead of
+    # DragonflyDB's self-hosted `docker.dragonflydb.io`, which intermittently answers pulls
+    # with `403 Forbidden` and flakes CI. ghcr.io serves the identical image and is far more
+    # reliable from GitHub Actions runners.
+    image: ghcr.io/dragonflydb/dragonfly:latest
     ulimits:
       memlock: -1
     command:


### PR DESCRIPTION
## Summary
Updated the DragonflyDB (Redis-compatible) container image source in the playground streaming compose configuration from the self-hosted registry to GitHub Container Registry (ghcr.io) to improve CI reliability.

## Changes
- Changed DragonflyDB image source from `docker.dragonflydb.io/dragonflydb/dragonfly:latest` to `ghcr.io/dragonflydb/dragonfly:latest`
- Added explanatory comments documenting the rationale for the change

## Details
The self-hosted DragonflyDB registry (`docker.dragonflydb.io`) intermittently returns `403 Forbidden` errors during image pulls, causing CI flakes. GitHub Container Registry (ghcr.io) serves the identical image and provides significantly better reliability when accessed from GitHub Actions runners.

https://claude.ai/code/session_01UzbjG9mFon2tzsoT3ppG4Z