### PR TITLE
Rename CI job to "Playground Stream"

### DIFF
--- a/test-e2e.config.mjs
+++ b/test-e2e.config.mjs
@@ -49,7 +49,7 @@ function getCiJobs() {
     // `splitFiles: true` fans out one CI runner per `.test-*.test.ts` so the suite
     // runs in parallel instead of sequentially.
     {
-      name: 'Playground',
+      name: 'Playground Stream',
       setups: setupModern,
       splitFiles: true,
     },

--- a/test/playground-streaming/.test-e2e.json
+++ b/test/playground-streaming/.test-e2e.json
@@ -1,1 +1,1 @@
-{ "ci": { "job": "Playground" } }
+{ "ci": { "job": "Playground Stream" } }


### PR DESCRIPTION
Renames the CI job for the streaming playground from `Playground` to `Playground Stream`.

The job covers `test/playground-streaming/` (SSE/WS streaming e2e tests), so the more descriptive name distinguishes it from the regular `Vite` playground job. With `splitFiles: true`, GitHub now shows entries like:

```
CI / Playground Stream (.test-preview.sse-inline.sse.test.ts) - Ubuntu - Node.js 23 (push)
```

## Changes
- `test-e2e.config.mjs` — job definition `name: 'Playground'` → `name: 'Playground Stream'`
- `test/playground-streaming/.test-e2e.json` — directory→job mapping `"job": "Playground"` → `"job": "Playground Stream"`

Both must stay in sync: `prepare.ts` asserts the local config's `job` matches a job defined in the global config.

Verified by running `bun ./.github/workflows/ci/prepare.ts --debug`, which now emits `Playground Stream (...)` job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWLtninbR3R1xvkrfjcuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWLtninbR3R1xvkrfjcuz)_