### PR TITLE
refactor: set hook-level `order: 'pre'` on pluginTransformTelefuncFiles

### DIFF
--- a/packages/telefunc/node/vite/plugins/pluginTransformTelefuncFiles.ts
+++ b/packages/telefunc/node/vite/plugins/pluginTransformTelefuncFiles.ts
@@ -13,8 +13,9 @@ function pluginTransformTelefuncFiles(): Plugin[] {
   return [
     {
       name: 'telefunc:pluginTransformTelefuncFiles',
-      enforce: 'pre', // TODO/now: also use `order: 'pre'`
+      enforce: 'pre',
       configResolved: {
+        order: 'pre',
         handler(config) {
           root = toPosixPath(config.root)
           assert(root)
@@ -22,11 +23,13 @@ function pluginTransformTelefuncFiles(): Plugin[] {
         },
       },
       configureServer: {
+        order: 'pre',
         handler() {
           isDev = true
         },
       },
       transform: {
+        order: 'pre',
         filter: {
           id: '**/*.telefunc.*',
         },


### PR DESCRIPTION
## What

Implements the `// TODO/now: also use \`order: 'pre'\`` note in `pluginTransformTelefuncFiles.ts` by adding hook-level `order: 'pre'` to the plugin's object hooks (`configResolved`, `configureServer`, `transform`), while keeping the existing plugin-level `enforce: 'pre'`.

## Why

`enforce` and a hook's `order` are **complementary** ordering mechanisms:

- **`enforce: 'pre'`** orders this *plugin* relative to other plugins.
- **`order: 'pre'`** orders an individual *hook* relative to the same hook in other plugins.

Rollup stable-sorts each hook's implementing plugins by the hook's `order` (`pre` → `null` → `post`) *across the whole plugin list*. So a **normal** plugin that declares `order: 'pre'` on its `transform` hook could run **before** Telefunc's `transform` — even though Telefunc's plugin is `enforce: 'pre'` — because the `order: 'pre'` tier wins the stable sort regardless of the plugin's enforce bucket.

Setting `order: 'pre'` on Telefunc's hooks keeps them in that top tier, guaranteeing Telefunc files are transformed on their original source before other plugins process them. It also future-proofs ordering for the Rolldown-based pipeline, where per-hook `order` is the canonical mechanism.

## Notes

- Type-safe: all three hooks are typed as `ObjectHook<T> = T | { handler: T; order?: 'pre' | 'post' | null }`, so `order` is valid (the hooks already used the `{ handler }` object form).
- `pnpm run build` (`tsc --build`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUz9BiqacvgH29kr3iDHqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUz9BiqacvgH29kr3iDHqm)_