### PR TITLE
docs(stream): align primitive links with section titles

### DIFF
--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,9 +7,7 @@ Telefunc supports many primitives for streaming and real-time use cases — with
 
 #### Primitives
 
-{/* TODO/now align the primitive links bellow with the title of the section (just strip `Primitive:`) */}
-
-<Link href="#asyncgenerator" text="AsyncGenerator" /> (`function*`):
+<Link href="#asyncgenerator" text={<><code>AsyncGenerator</code> (<code>function*</code>)</>} />:
 ```ts
 // AiChat.telefunc.ts
 // Environment: server
@@ -23,7 +21,7 @@ export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
 }
 ```
 
-<Link href="#function-passing" text="Function passing" /> (callbacks):
+<Link href="#function-passing" text={<><code>function</code> passing (callbacks)</>} />:
 ```ts
 // Notifications.telefunc.ts
 // Environment: server


### PR DESCRIPTION
## What

Resolves the `TODO/now` in `docs/pages/stream/+Page.mdx`:

> align the primitive links below with the title of the section (just strip `Primitive:`)

The `#### Primitives` list links should display exactly like their section headings, minus the `Primitive:` prefix.

## Changes

Two links were out of sync with their headings; the other three already matched:

| Link | Section heading (stripped) | Before |
|---|---|---|
| AsyncGenerator | `` `AsyncGenerator` (`function*`) `` | `AsyncGenerator` (plain) + `(function*)` outside the link |
| function passing | `` `function` passing (callbacks) `` | `Function passing` (plain) + `(callbacks)` |

Both now use `<code>` formatting matching their headings, and the whole title text is part of the link — consistent with the already-aligned `Concurrent Promise`, `ReadableStream`, and `Channel` links.

The `TODO/now` comment has been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQjNSgqJZmtoHDdAbTDtyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQjNSgqJZmtoHDdAbTDtyK)_