### PR TITLE
docs(stream): hyphenate AsyncGenerator/ReadableStream anchor slugs

### DIFF
--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -15,7 +15,7 @@ Passing a `File` / `Blob` argument is one of several ways to move binary data wi
 | Method | Backpressure | Best for |
 |---|---|---|
 | `File` / `Blob` argument | TCP-level | Finite uploads — files, images, CSV imports |
-| <Link text={<code>ReadableStream</code>} href="/stream#readablestream" /> argument | Yes | Long-lived streams — video feed, sensor data, continuous audio |
+| <Link text={<code>ReadableStream</code>} href="/stream#readable-stream" /> argument | Yes | Long-lived streams — video feed, sensor data, continuous audio |
 | <Link text={<code>new Channel().sendBinary()</code>} href="/channel#binary-data" /> | <Link text="Opt-in" href="/channel#backpressure" /> — `await` each send | Low-latency frames — skip the `await` for fire-and-forget |
 | <Link text={<code>new BroadcastChannel().publishBinary()</code>} href="/channel#new-broadcastchannel" /> | Publish-side only | Broadcast binary — video to multiple subscribers |
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -7,7 +7,7 @@ Telefunc supports many primitives for streaming and real-time use cases — with
 
 #### Primitives
 
-<Link href="#asyncgenerator" text={<><code>AsyncGenerator</code> (<code>function*</code>)</>} />:
+<Link href="#async-generator" text={<><code>AsyncGenerator</code> (<code>function*</code>)</>} />:
 ```ts
 // AiChat.telefunc.ts
 // Environment: server
@@ -49,7 +49,7 @@ export async function onLoadDashboard() {
 }
 ```
 
-<Link href="#readablestream" text={<code>ReadableStream</code>} />:
+<Link href="#readable-stream" text={<code>ReadableStream</code>} />:
 ```ts
 // Compress.telefunc.ts
 // Environment: server
@@ -80,8 +80,7 @@ export function onCompress(data: ReadableStream<Uint8Array>): ReadableStream<Uin
 ✅ **Errors** — expected failures stay distinct from bugs, even mid-stream: if a generator or stream throws, the client receives an error while values already delivered remain available. See <Link href="/error-handling#streaming" text="Error handling — streaming" />.  
 
 
-{/* TODO/now URL slug: #async-generator */}
-## Primitive: `AsyncGenerator` (`function*`) {#asyncgenerator}
+## Primitive: `AsyncGenerator` (`function*`) {#async-generator}
 
 An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator): the usual choice for structured values that arrive one piece at a time — AI tokens, notifications, progress updates.
 
@@ -223,8 +222,7 @@ const report = await res.report
 > ```
 
 
-{/* TODO/now URL slug: #readable-stream */}
-## Primitive: `ReadableStream` {#readablestream}
+## Primitive: `ReadableStream` {#readable-stream}
 
 Stream raw bytes with a web-standard [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) — in either direction.
 


### PR DESCRIPTION
## What

Resolves the two `TODO/now` markers in `docs/pages/stream/+Page.mdx` by renaming the section anchors to the hyphenated convention:

- `#asyncgenerator` → `#async-generator`
- `#readablestream` → `#readable-stream`

This makes them consistent with the other primitive-section slugs on the same page (`#function-passing`, `#concurrent-promise`, `#channel`).

## Changes

- `docs/pages/stream/+Page.mdx`
  - Updated both heading anchors (`{#async-generator}`, `{#readable-stream}`).
  - Updated the two in-page `<Link>` references in the "Primitives" overview.
  - Removed the two `{/* TODO/now ... */}` markers.
- `docs/pages/file-upload/+Page.mdx`
  - Updated the cross-page link `/stream#readablestream` → `/stream#readable-stream`.

## Verification

`node docs/check-docs.mjs` passes — the docs quality gate confirms every internal anchor link still resolves:

```
✓ docs quality gate: 52 pages, 73 internal anchor links — all resolve.
```

No `TODO/now` markers and no stale `#asyncgenerator` / `#readablestream` references remain. Since only in-page anchors changed (the `/stream` page URL is unchanged), no redirect entry is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpyfjV2eAPcgEctPDaCkXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpyfjV2eAPcgEctPDaCkXk)_