### PR TITLE
test(channel): fix flaky upstream-reconnect baseline

### DIFF
--- a/test/playground-stream/pages/channel/e2e-test.ts
+++ b/test/playground-stream/pages/channel/e2e-test.ts
@@ -349,13 +349,21 @@ function testChannel(isDev: boolean, inDocker = false) {
         channelId = state.upstreamReconnectChannelId
       })
 
-      // Send 2 messages while still online to establish a baseline
-      await page.click('#channel-test-upstream-send')
-      await page.click('#channel-test-upstream-send')
-      await autoRetry(async () => {
-        const ss = await getCleanupState()
-        expect(ss[`upstream_${channelId}_receivedCount`]).toBe('2')
-      })
+      // Establish a baseline of 2 received messages while still online — sending them one at a
+      // time, each confirmed received before the next, rather than back-to-back. During the
+      // initial SSE connect handshake two client→server sends can be split across separate HTTP
+      // requests (the initial-batch SSE POST vs. the streamRequest POST) that the server may
+      // process out of order; it dedups by seq (dropping any seq <= the last one seen), so the
+      // late frame is dropped and the baseline flakes at "1 of 2". Keeping at most one frame in
+      // flight leaves nothing to reorder. The reconnect phase below still fires buffered sends
+      // back-to-back — that rapid-fire exactly-once delivery is the behaviour under test.
+      for (let seq = 1; seq <= 2; seq++) {
+        await page.click('#channel-test-upstream-send')
+        await autoRetry(async () => {
+          const ss = await getCleanupState()
+          expect(ss[`upstream_${channelId}_receivedCount`]).toBe(String(seq))
+        })
+      }
 
       // Go offline
       if (inDocker) stopProxy()


### PR DESCRIPTION
## Problem

The docker SSE e2e test **"channel: reconnect — client messages sent while offline are delivered exactly once after reconnect"** flaked in CI ([run 27830777827](https://github.com/telefunc/telefunc/actions/runs/27830777827/job/82366749688)):

```
AssertionError: expected '1' to equal '2'
  at pages/channel/e2e-test.ts:357
```

It failed at the **online baseline** — only 1 of 2 client→server messages was received — *before* any offline/reconnect simulation.

## Root cause

The server dedups incoming client→server frames by sequence number:

```ts
// packages/telefunc/wire-protocol/server/channel.ts
if (data.seq) {
  if (data.seq <= this._lastClientSeq) return   // drops anything <= last seen
  this._lastClientSeq = data.seq
}
```

This drops any **out-of-order** frame, not just true duplicates. If `seq=2` is dispatched before `seq=1`, then `seq=1` is permanently dropped → `received 1 of 2`.

On an established wire this never happens — frames are TCP-ordered, dispatch is serialized per connection (`chainRecv`), and the SSE `ready` gate guarantees initial-batch frames dispatch before any streamRequest/batch-POST frames. **But during the initial SSE connect handshake**, two back-to-back sends can be split across *separate* HTTP requests (the initial-batch SSE POST vs. the streamRequest POST), which the server may process out of order. The baseline fired both sends immediately after `openChannel()` resolved — landing right in that window.

The offline→reconnect phase is **not** vulnerable: offline sends are all buffered before reconnect and replayed as a single ordered batch on one wire.

## Fix (test-only)

Send the two baseline messages one at a time, each confirmed received before the next, so at most one client→server frame is ever in flight during the fragile connecting window — nothing can reorder:

```ts
for (let seq = 1; seq <= 2; seq++) {
  await page.click('#channel-test-upstream-send')
  await autoRetry(async () => {
    const ss = await getCleanupState()
    expect(ss[`upstream_${channelId}_receivedCount`]).toBe(String(seq))
  })
}
```

The reconnect phase still fires buffered sends back-to-back and asserts exactly-once delivery, so the behaviour under test is unchanged.

## Note for maintainer

This stabilizes CI without masking the offline→reconnect guarantee. It does, however, sidestep a *separate* latent question: whether telefunc intends to guarantee ordered exactly-once delivery for sends fired **during** the initial SSE connect handshake (i.e. across the initial-batch POST and the streamRequest POST). The carry-over ordering comment in `client/connection.ts:stageInitialBatch` suggests it does — so there may be a narrow connecting-window reorder worth hardening in the library separately. I couldn't reproduce it deterministically (it needs the docker cluster) or pinpoint it confidently, so I kept the change to the test rather than making a speculative change to the wire protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKp4dRjayfmhcgmngpSjoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKp4dRjayfmhcgmngpSjoL)_