### PR TITLE
docs(stream): implement proper Cleanup section

### DIFF
--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -407,9 +407,37 @@ await onTeamFeed('acme', (text) => showMessage(text))
 
 ## Cleanup
 
-✅ **Cleanup** — when the client disconnects or stops reading, <Link href="/close">`onClose()`</Link> fires so you can release resources.  
+Every streaming value eventually ends — the client finishes reading it, calls <Link text={<code>close()</code>} href="/close" />, navigates away, or the connection drops for good. However it ends, the server's `onClose()` hook fires so you can release whatever the telefunction opened. Get it from <Link text="getContext()" href="/getContext" />:
 
-TODO/now implement proper section
+```ts
+// AiChat.telefunc.ts
+// Environment: server
+
+import { getContext } from 'telefunc'
+
+export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
+  const { onClose } = getContext()
+
+  // Stop the upstream AI request when the client disconnects or stops reading
+  const controller = new AbortController()
+  onClose(() => controller.abort())
+
+  const stream = await ai.streamText({ prompt, signal: controller.signal })
+  for await (const message of stream) {
+    yield message
+  }
+}
+```
+
+> **Pitfall** — anything a long-lived telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down.
+
+<Link text="Channels" href="#channel" /> and broadcasts expose `onClose()` (and `onOpen()`) directly on the instance — e.g. `dashboard.onClose(() => clearInterval(interval))` in the <Link text="Channel example" href="#channel" /> above; see <Link href="/channel#lifecycle" />.
+
+From the client, end a stream early with <Link text={<code>close()</code>} href="/close" /> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel. Drop every reference without closing and Telefunc still cleans up automatically, via garbage collection, a few seconds later.
+
+See also:
+- <Link href="/close" />
+- <Link href="/channel#lifecycle" />
 
 
 ## Error handling


### PR DESCRIPTION
## What

Resolves the `TODO/now implement proper section` placeholder in the **Cleanup** section of the streaming docs (`docs/pages/stream/+Page.mdx`).

## Changes

The placeholder is replaced with a proper section that covers, in the streaming context:

- **Server-side `onClose()`** via `getContext()` — fires however the stream ends (client finishes reading, calls `close()`, navigates away, or the connection drops), with a concrete `AsyncGenerator` example that aborts the upstream AI request on close.
- **The leak pitfall** — anything a long-lived telefunction opens (`setInterval`, subscriptions, DB cursors, upstream streams) leaks unless released in `onClose()`.
- **Channel/broadcast lifecycle hooks** — instances carry their own `onClose()` / `onOpen()`, linking to `/channel#lifecycle`.
- **Client-side closing** — `close()` plus the standard JS ways to stop reading, and the garbage-collection fallback.

It follows the structure and voice of the neighbouring **Authorization** and **Error handling** sections (prose + example + `>` pitfall callout + *See also*). All cross-links point to verified targets (`/close`, `/getContext`, `/channel#lifecycle`, and the in-page `#channel` anchor), and every MDX/JSX construct used already appears elsewhere in the same file.

## Base branch

Targets `nitedani/streaming` (where the streaming docs and the TODO live), matching the convention used by other incremental streaming PRs (e.g. #360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY4UsrywQ2diTXYeuJSSqE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY4UsrywQ2diTXYeuJSSqE)_