### PR TITLE
docs(stream): show resource cleanup in the leak-prone examples

### DIFF
--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -318,16 +318,24 @@ The transform can be arbitrarily heavy — for example, compressing a bulky vide
 // CompressVideo.telefunc.ts
 // Environment: server
 
+import { getContext } from 'telefunc'
 import { spawn } from 'node:child_process'
 import { Readable, Writable } from 'node:stream'
 
 export function onCompressVideo(video: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const { onClose } = getContext()
+
   // Re-encode to a smaller H.264/MP4, on the fly
   const ffmpeg = spawn('ffmpeg', ['-i', 'pipe:0', '-movflags', 'frag_keyframe+empty_moov', '-f', 'mp4', 'pipe:1'])
+  // Kill the encoder if the client disconnects mid-stream — otherwise the process leaks
+  onClose(() => ffmpeg.kill())
+
   video.pipeTo(Writable.toWeb(ffmpeg.stdin))
   return Readable.toWeb(ffmpeg.stdout) as ReadableStream<Uint8Array>
 }
 ```
+
+> A spawned process outlives the call and would keep burning CPU if the client navigated away mid-encode — so it's released in `onClose()`. See <Link text="Cleanup" href="#cleanup" />.
 
 
 ## Primitive: `Channel` {#channel}
@@ -383,11 +391,13 @@ A streaming telefunction authorizes like any other telefunction (see <Link href=
 import { getContext, Abort } from 'telefunc'
 
 export async function onTeamFeed(teamId: string, onMessage: (text: string) => void) {
-  const { user } = getContext()
+  const { user, onClose } = getContext()
   if (!user || !user.teams.includes(teamId)) throw Abort()
 
   // Authorized — push this team's messages to the client
-  watchTeam(teamId, onMessage)
+  const unwatch = watchTeam(teamId, onMessage)
+  // Stop watching when the client disconnects — otherwise the subscription leaks
+  onClose(unwatch)
 }
 ```
 


### PR DESCRIPTION
## What

Follow-up to #361. That PR added the proper **Cleanup** section to the streaming docs (`docs/pages/stream/+Page.mdx`), including a **Pitfall** callout:

> anything a long-lived telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the call and **leaks** unless you release it in `onClose()`.

But two of the detailed examples on the same page still opened long-lived resources *without* releasing them — so the page documented the pitfall and then demonstrated it. This PR makes those examples practice what the section preaches.

## Changes

**`onCompressVideo`** (`ReadableStream`, both directions) — spawned an `ffmpeg` child process and never killed it. If the client navigated away mid-encode, the process kept running and burning CPU. Now:

```ts
const { onClose } = getContext()
const ffmpeg = spawn('ffmpeg', [...])
onClose(() => ffmpeg.kill())
```

**`onTeamFeed`** (Authorization) — subscribed via `watchTeam(teamId, onMessage)` but never unsubscribed, leaking the subscription on disconnect. Now captures the teardown and wires it up:

```ts
const { user, onClose } = getContext()
...
const unwatch = watchTeam(teamId, onMessage)
onClose(unwatch)
```

Both mirror the existing **Channel** example, which already does `dashboard.onClose(() => clearInterval(interval))`. The `onCompressVideo` snippet also gets a one-line forward-link to the Cleanup section.

## Deliberately left alone

The lean examples don't leak, so adding `onClose()` to them would just be noise: `onCountdown` / `onLoadDashboard` / `onCompress` (gzip) / `onDownload` / `onIngest` / `onUpload`. The detailed `AsyncGenerator` (`onAiPrompt`) is also left simple, since the Cleanup section already shows that exact function *with* an `AbortController`.

## Base branch

Targets `nitedani/streaming` (where the streaming docs live), matching #361 / #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XthKKi3Jcxa1LzrMK4Qit

---
_Generated by [Claude Code](https://claude.ai/code/session_015XthKKi3Jcxa1LzrMK4Qit)_