### PR TITLE
docs(stream): drop incidental edits to pre-existing examples

### DIFF
--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -69,8 +69,6 @@ In this situation, you can:
 You can propagate error information to the frontend like this:
 
 ```ts
-// Environment: server
-
 import { validate } from 'some-library'
 
 function onFormSubmit(data) {
@@ -87,8 +85,6 @@ function onFormSubmit(data) {
 You can also use `throw Abort(someValue)`:
 
 ```ts
-// Environment: server
-
 import { validate } from 'some-library'
 import { Abort } from 'telefunc'
 

--- a/docs/pages/event-based/+Page.mdx
+++ b/docs/pages/event-based/+Page.mdx
@@ -164,7 +164,6 @@ We recommend the following instead:
 
 ```ts
 // database/actions/task.ts
-// Environment: server
 
 import { Task } from '../models/Task'
 import { getContext } from 'telefunc'
@@ -180,7 +179,6 @@ export async function updateTask(id: number, mods: Partial<typeof Task>) {
 
 ```ts
 // components/TodoList.telefunc.ts
-// Environment: server
 
 import { updateTask } from '../database/actions/task'
 

--- a/docs/pages/next/+Page.mdx
+++ b/docs/pages/next/+Page.mdx
@@ -5,7 +5,7 @@ Using Telefunc with [Next.js](https://nextjs.org).
 
 ## 1. Install
 
-```bash
+```shell
 npm install telefunc
 ```
 
@@ -64,7 +64,6 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
 
 ```tsx
 // app/layout.tsx
-// Environment: server
 
 import { ClientProviders } from './client-providers'
 

--- a/docs/pages/onBug/+Page.mdx
+++ b/docs/pages/onBug/+Page.mdx
@@ -5,8 +5,6 @@ import { Link } from '@brillout/docpress'
 To track bugs, use `onBug()`:
 
 ```ts
-// Environment: server
-
 import { onBug } from 'telefunc'
 
 onBug((err) => {

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -32,7 +32,6 @@ In other words: telefunction argument types are automatically validated at runti
 
 ```ts ts-only
 // hello.telefunc.ts
-// Environment: server
 
 // No need to define a shield() when using TypeScript: Telefunc automatically generates
 // it. For example here, Telefunc automatically aborts the telefunction call if the


### PR DESCRIPTION
## What

The streaming docs work added a few **minor, incidental edits to code blocks the streaming feature doesn't actually introduce** — most visibly `// Environment: server` comments sprinkled onto otherwise-untouched pre-existing examples. This PR reverts only those incidental edits, so the diff stays focused on the content the streaming work genuinely changes.

## Reverted

| Page | Reverted |
|---|---|
| `error-handling` | `// Environment: server` on the two unchanged `validate` / `Abort` examples |
| `event-based` | `// Environment: server` on the two unchanged examples (page now matches `main`) |
| `next` | `// Environment: server` on the unchanged `app/layout.tsx` block + ` ```shell `→` ```bash ` flip on the install command |
| `onBug` | `// Environment: server` on the unchanged `onBug()` example (page already carries a page-level `**Environment**: server`) |
| `shield` | `// Environment: server` on the unchanged `hello.telefunc.ts` example |

## Deliberately left intact

- `// Environment: server` comments inside **genuinely new or rewritten streaming sections** — `server/` (multi-runtime `new Telefunc()`), `file-upload/` (binary-streaming rewrite), and the `error-handling` `serve()` migration block.
- The new **Conventions** section in `CONTRIBUTING.md` that documents the `// Environment` convention (additive new content).
- Substantive `telefunc()`→`serve()` / `config.headers` API-migration edits and new streaming callouts on `RPC`, `vite-plugin`, `httpHeaders`, `permissions`, `shield`.
- The `onBug` see-also link removal (`/error-handling#error-tracking`) — that anchor doesn't exist in `error-handling` on `main` either, so it's a legit dangling-link cleanup. Restoring it would fail the docs gate.

## Verification

`node docs/check-docs.mjs` → `✓ docs quality gate: 52 pages, 82 internal anchor links — all resolve.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn5GS2W6A9vAKdZvjevpCM)_