### PR TITLE
docs: rename `tf` to `telefunc` in `new Telefunc()` examples

### DIFF
--- a/docs/pages/Telefunc/+Page.mdx
+++ b/docs/pages/Telefunc/+Page.mdx
@@ -12,28 +12,28 @@ import { StreamingBeta } from '../../components'
 
 import { Telefunc } from 'telefunc/node'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 ```
 ```ts choice=Bun
 // Environment: server
 
 import { Telefunc } from 'telefunc/bun'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 ```
 ```ts choice=Deno
 // Environment: server
 
 import { Telefunc } from 'telefunc/deno'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 ```
 ```ts choice=Cloudflare
 // Environment: server
 
 import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 ```
 
 > For per-runtime setup see <Link href="/server" />, and <Link href="/stream/cloudflare" /> for Cloudflare specifics. For a low-level request handler without channels, use <Link href="/serve" />.
@@ -55,10 +55,10 @@ Provide the <Link text="getContext()" href="/getContext" /> data per request —
 
 ```ts
 // Node / Bun / Deno
-await tf.serve({ request, context: { user } })
+await telefunc.serve({ request, context: { user } })
 
 // Cloudflare
-const tf = new Telefunc({ context: (request, env) => ({ user }) })
+const telefunc = new Telefunc({ context: (request, env) => ({ user }) })
 ```
 
 See <Link href="/getContext#provide" />.

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -28,7 +28,7 @@ It's most commonly used for implementing permissions, see <Link href="/permissio
 
 ## Provide
 
-Before you can use `getContext()`, you must provide the `context` object when calling `tf.serve()`, see <Link href="/server" />.
+Before you can use `getContext()`, you must provide the `context` object when calling `telefunc.serve()`, see <Link href="/server" />.
 
 For example:
 
@@ -49,10 +49,10 @@ import { Hono } from 'hono'
 import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
-  const response = await tf.serve({
+  const response = await telefunc.serve({
     request: c.req.raw,
     // Provide the context object here:
     context: {
@@ -93,7 +93,7 @@ import express from 'express'
 import { Telefunc } from 'telefunc/node'
 
 const app = express()
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 // Telefunc middleware
 app.all('/_telefunc', async (req, res, next) => {
@@ -106,7 +106,7 @@ app.all('/_telefunc', async (req, res, next) => {
   const user2 = await authProviderApi.getUser(req.headers)
 
   // Provide the context object here:
-  const handled = await tf.serve({
+  const handled = await telefunc.serve({
     req,
     res,
     context: { user }

--- a/docs/pages/next/+Page.mdx
+++ b/docs/pages/next/+Page.mdx
@@ -34,10 +34,10 @@ import { config } from 'telefunc'
 
 config.telefuncUrl = '/api/telefunc'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 async function handler(request: Request) {
-  const response = await tf.serve({ request })
+  const response = await telefunc.serve({ request })
   return response ?? new Response('Not found', { status: 404 })
 }
 export { handler as GET, handler as POST }

--- a/docs/pages/provideTelefuncContext/+Page.mdx
+++ b/docs/pages/provideTelefuncContext/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-`provideTelefuncContext()` makes the `context` object available to telefunctions via <Link href="/getContext" text="getContext()" /> — useful when a telefunction runs **outside `tf.serve()`**, such as server-side rendering or unit tests.
+`provideTelefuncContext()` makes the `context` object available to telefunctions via <Link href="/getContext" text="getContext()" /> — useful when a telefunction runs **outside `telefunc.serve()`**, such as server-side rendering or unit tests.
 
 ```ts
 // Environment: server

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -21,17 +21,17 @@ import { serve } from '@hono/node-server'
 import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
-  const response = await tf.serve({ request: c.req.raw })
+  const response = await telefunc.serve({ request: c.req.raw })
   return response ?? c.notFound()
 })
 
 const server = serve({ fetch: app.fetch, port: 3000 })
 
 // Enable WebSocket support for channels
-tf.installWebSocket(server)
+telefunc.installWebSocket(server)
 ```
 
 ### With Express
@@ -44,17 +44,17 @@ import express from 'express'
 import { Telefunc } from 'telefunc/node'
 
 const app = express()
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 app.all('/_telefunc', async (req, res, next) => {
-  const handled = await tf.serve({ req, res })
+  const handled = await telefunc.serve({ req, res })
   if (!handled) next()
 })
 
 const server = app.listen(3000)
 
 // Enable WebSocket support for channels
-tf.installWebSocket(server)
+telefunc.installWebSocket(server)
 ```
 
 > The Node.js adapter auto-detects your HTTP server from the request socket. `installWebSocket()` is idempotent — calling it multiple times is safe.
@@ -65,7 +65,7 @@ tf.installWebSocket(server)
 
 ```ts
 app.all('/_telefunc', async (c) => {
-  const response = await tf.serve({
+  const response = await telefunc.serve({
     request: c.req.raw,
     context: {
       user: await getUser(c.req),
@@ -85,14 +85,14 @@ app.all('/_telefunc', async (c) => {
 
 import { Telefunc } from 'telefunc/bun'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 Bun.serve({
   port: 3000,
-  // Pass tf.websocket to enable WebSocket channels
-  websocket: tf.websocket,
+  // Pass telefunc.websocket to enable WebSocket channels
+  websocket: telefunc.websocket,
   async fetch(request, server) {
-    const response = await tf.serve({ request, server })
+    const response = await telefunc.serve({ request, server })
     if (response) return response
 
     return new Response('Not found', { status: 404 })
@@ -108,10 +108,10 @@ Bun.serve({
 
 import { Telefunc } from 'telefunc/deno'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 Deno.serve({ port: 3000 }, async (request, info) => {
-  const response = await tf.serve({ request, info })
+  const response = await telefunc.serve({ request, info })
   if (response) return response
 
   return new Response('Not found', { status: 404 })
@@ -126,13 +126,13 @@ Deno.serve({ port: 3000 }, async (request, info) => {
 
 import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
-export const TelefuncDurableObject = tf.TelefuncDurableObject
+export const TelefuncDurableObject = telefunc.TelefuncDurableObject
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    const response = await tf.serve({ request, env, ctx })
+    const response = await telefunc.serve({ request, env, ctx })
     if (response) return response
 
     return new Response('Not found', { status: 404 })
@@ -164,7 +164,7 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 
 ## Return value
 
-`tf.serve()` returns:
+`telefunc.serve()` returns:
 
 | Runtime | Returns | Meaning |
 |---|---|---|
@@ -174,7 +174,7 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 | Deno | `Response \| undefined` | `undefined` if not a Telefunc request |
 | Cloudflare | `Response \| undefined` | `undefined` if not a Telefunc request |
 
-> `tf.serve()` returns `undefined` (or `false`) for non-Telefunc requests, allowing you to chain it with other handlers.
+> `telefunc.serve()` returns `undefined` (or `false`) for non-Telefunc requests, allowing you to chain it with other handlers.
 
 
 ## Low-level API

--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -16,13 +16,13 @@ Cloudflare-specific setup for <Link href="/stream">real-time</Link> (i.e. <Link 
 
 import { Telefunc } from 'telefunc/cloudflare'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
-export const TelefuncDurableObject = tf.TelefuncDurableObject
+export const TelefuncDurableObject = telefunc.TelefuncDurableObject
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    const response = await tf.serve({ request, env, ctx })
+    const response = await telefunc.serve({ request, env, ctx })
     if (response) return response
 
     return new Response('Not found', { status: 404 })
@@ -61,7 +61,7 @@ export default {
 Pass per-request data to telefunctions via <Link text={<code>getContext()</code>} href="/getContext" />:
 
 ```ts
-const tf = new Telefunc({
+const telefunc = new Telefunc({
   context: async (request, env: Env) => ({
     user: await getUserFromCookie(request, env),
   }),
@@ -110,7 +110,7 @@ On the first request, Telefunc picks a Durable Object in the nearest region, sto
 By default, Telefunc creates one Durable Object per region. Increase capacity with `scale`:
 
 ```ts
-const tf = new Telefunc({ scale: 4 })
+const telefunc = new Telefunc({ scale: 4 })
 ```
 
 This creates 4 Durable Objects per region, and Telefunc distributes sessions across them.
@@ -118,7 +118,7 @@ This creates 4 Durable Objects per region, and Telefunc distributes sessions acr
 ### Per-region scale
 
 ```ts
-const tf = new Telefunc({
+const telefunc = new Telefunc({
   scale: { weur: 5, enam: 3, apac: 2 },
 })
 ```
@@ -192,7 +192,7 @@ A KV record is created on subscribe and deleted on unsubscribe. If a Durable Obj
 ## Configuration
 
 ```ts
-const tf = new Telefunc({
+const telefunc = new Telefunc({
   bindingName: 'TelefuncDurableObject',  // DO binding name (default)
   kvBindingName: 'TelefuncKV',           // KV binding name (default)
   instanceName: 'telefunc',              // Base name for DO instances (default)

--- a/docs/pages/svelte-kit/+Page.mdx
+++ b/docs/pages/svelte-kit/+Page.mdx
@@ -32,10 +32,10 @@ export default defineConfig({
 import { Telefunc } from 'telefunc/node'
 import type { RequestHandler } from './$types'
 
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 const handler: RequestHandler = async (event) => {
-  const response = await tf.serve({ request: event.request })
+  const response = await telefunc.serve({ request: event.request })
   return response ?? new Response('Not found', { status: 404 })
 }
 export { handler as GET, handler as POST }

--- a/docs/pages/vike/+Page.mdx
+++ b/docs/pages/vike/+Page.mdx
@@ -38,15 +38,15 @@ import { serve } from '@hono/node-server'
 import { Telefunc } from 'telefunc/node'
 
 const app = new Hono()
-const tf = new Telefunc()
+const telefunc = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
-  const response = await tf.serve({ request: c.req.raw })
+  const response = await telefunc.serve({ request: c.req.raw })
   return response ?? c.notFound()
 })
 
 const server = serve({ fetch: app.fetch, port: 3000 })
-tf.installWebSocket(server)
+telefunc.installWebSocket(server)
 ```
 
 ## 4. Create a telefunction


### PR DESCRIPTION
## What

Renames the `new Telefunc()` instance variable from `tf` to the more descriptive `telefunc` throughout the docs.

```diff
- const tf = new Telefunc()
+ const telefunc = new Telefunc()
```

## Details

To keep the docs consistent, every reference is renamed — not just the declaration line:

- `const tf = new Telefunc(...)` → `const telefunc = new Telefunc(...)`
- Method/property accesses: `tf.serve()`, `tf.installWebSocket()`, `tf.websocket`, `tf.TelefuncDurableObject` → `telefunc.*`
- Prose backtick references (e.g. `` `tf.serve()` ``) and an inline `// Pass tf.websocket …` comment

Unrelated tokens that merely contain the substring (`'/_telefunc'` URLs, `config.telefuncUrl`, `instanceName: 'telefunc'`) are untouched.

## Files

- `docs/pages/Telefunc/+Page.mdx`
- `docs/pages/server/+Page.mdx`
- `docs/pages/stream/cloudflare/+Page.mdx`
- `docs/pages/getContext/+Page.mdx`
- `docs/pages/next/+Page.mdx`
- `docs/pages/svelte-kit/+Page.mdx`
- `docs/pages/vike/+Page.mdx`
- `docs/pages/provideTelefuncContext/+Page.mdx`

Docs-only change; no source or test files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBtkSbLJGbaPBGYDb7oU8w)_