### PR TITLE
docs: redirect old /telefunc URL to /serve

### DIFF
--- a/docs/+redirects.ts
+++ b/docs/+redirects.ts
@@ -12,4 +12,5 @@ checkType<HeadingsURL>(0 as any as RedirectsURL)
 const redirects = {
   '/remix': '/react-router',
   '/httpHeaders': '/headers',
+  '/telefunc': '/serve',
 } as const satisfies Config['redirects']


### PR DESCRIPTION
## What

Adds a `/telefunc` → `/serve` redirect to `docs/+redirects.ts`.

## Why

The `telefunc()` request handler was renamed to `serve()`. On this branch the old docs page (`docs/pages/telefunc/+Page.mdx`, which documented `telefunc()`) has **already been removed** — its content now lives at **`/serve`** (`docs/pages/serve/+Page.mdx`), and `new Telefunc()` is documented separately at `/Telefunc`.

`/telefunc` was a long-standing public URL on telefunc.com, so without a redirect those inbound links/bookmarks would 404 once this branch ships. This adds the redirect so they land on the successor page.

```diff
 const redirects = {
   '/remix': '/react-router',
   '/httpHeaders': '/headers',
+  '/telefunc': '/serve',
 } as const satisfies Config['redirects']
```

This mirrors the existing `'/httpHeaders' → '/headers'` redirect added in #363 for the same kind of page-URL rename.

## Notes

- **Type-check passes by construction:** `+redirects.ts` runs `checkType<HeadingsURL>(...)` to ensure every redirect *target* is a real page. `/serve` is a registered heading (`docs/headings.ts:252`), so the new entry satisfies the constraint. (Couldn't run `tsc` locally — deps aren't installed in this environment — but the only new symbol is the already-valid `/serve` target.)
- **Base branch is `nitedani/streaming`**, not `main`: the `serve()` rename and the `/serve` page only exist on the streaming line so far (consistent with #356/#363).
- Nothing to delete — the old page was already removed when `serve/` and `Telefunc/` were introduced; this PR is the redirect-only follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvF8DzZ6419eSSExJVFSp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvF8DzZ6419eSSExJVFSp2)_