### PR TITLE
fix: finish telefunc() → serve() rename (leftover error messages + /telefunc URL redirect)

### DIFF
--- a/docs/+redirects.ts
+++ b/docs/+redirects.ts
@@ -12,4 +12,5 @@ checkType<HeadingsURL>(0 as any as RedirectsURL)
 const redirects = {
   '/remix': '/react-router',
   '/httpHeaders': '/headers',
+  '/telefunc': '/serve',
 } as const satisfies Config['redirects']

--- a/packages/telefunc/node/server/context/async.ts
+++ b/packages/telefunc/node/server/context/async.ts
@@ -22,7 +22,7 @@ function provideTelefuncContext_async(context: Telefunc.Context): void {
   globalObject.asyncStore = globalObject.asyncStore ?? new AsyncLocalStorage()
   assertUsage(
     typeof globalObject.asyncStore.enterWith === 'function',
-    '[provideTelefuncContext()] This runtime does not support AsyncLocalStorage.enterWith(). Pass context directly to telefunc() instead.',
+    '[provideTelefuncContext()] This runtime does not support AsyncLocalStorage.enterWith(). Pass context directly to serve() instead.',
   )
   globalObject.asyncStore.enterWith({ [PROVIDED_CONTEXT]: context })
 }
@@ -31,7 +31,7 @@ function restoreContext_async<T>(rawContext: Context, fn: () => T): T {
   assert(isObject(rawContext))
   assertWarning(
     !rawContext[PROVIDED_CONTEXT],
-    'When using `provideTelefuncContext()` (i.e. Async Hooks), then providing the `context` object to the server middleware `telefunc()` has no effect.',
+    'When using `provideTelefuncContext()` (i.e. Async Hooks), then providing the `context` object to the server middleware `serve()` has no effect.',
     { onlyOnce: true },
   )
   globalObject.asyncStore = globalObject.asyncStore ?? new AsyncLocalStorage()


### PR DESCRIPTION
## What

The public request handler `telefunc()` was renamed to `serve()` (kept as a `@deprecated` alias). I swept the **entire repo** (code, docs, examples, tests, config, JSDoc, error-message strings, every file type) for spots where the rename was forgotten, and verified independently with a second pass. Two genuine leftovers:

### 1. Leftover handler name in user-facing messages
`packages/telefunc/node/server/context/async.ts` — two Async-Hooks context messages still called the handler `telefunc()`:
- `enterWith()`-unsupported error: *"Pass context directly to `telefunc()` instead"* → `serve()`
- redundant-context warning: *"…the server middleware `telefunc()` has no effect"* → `serve()`

### 2. Missing doc redirect for the renamed page
The handler's doc page was renamed `docs/pages/telefunc/` → `docs/pages/serve/` (URL `/telefunc` → `/serve`) as part of this rename, but **no redirect was added** — so external links/bookmarks to `telefunc.com/telefunc` 404. Added `'/telefunc': '/serve'` to `docs/+redirects.ts`, matching the existing convention (`/remix` → `/react-router`, `/httpHeaders` → `/headers`). The redirect target type-checks against `HeadingsURL`.

## Everything else verified clean
- **Docs** (`/serve`, `/server`, `/getContext`, `/provideTelefuncContext`, `/RPC`, `/vike`, `headings.ts`): already migrated to `serve()` / `telefunc.serve()`, including the upgrade note. "Telefunc middleware" prose labels sit beside correct `serve()` snippets.
- **Examples & test playgrounds** (9 server/middleware files): all call `serve()` / `tf.serve()`; local wrapper names like `installTelefunc`/`handleTelefunc` just wrap `serve()`.
- **Other packages** (`rxjs`, `redis`, `tanstack-query`): no handler references.
- No stray `import { telefunc } from 'telefunc'` handler imports remain (all `import { telefunc }` are the `telefunc/vite` plugin).
- Deprecation warning correctly links to `https://telefunc.com/serve`.

## Intentionally left unchanged
- the `telefunc()` **deprecated alias** + its warning (`node/server/telefunc.ts`) — back-compat
- the **Vite plugin** `telefunc()` (`telefunc/vite`), `new Telefunc()`, `withTelefunc()` — different APIs
- private `function telefunc()` factories in `serve/{node,bun,deno,cloudflare}.ts` — internal builders behind `new Telefunc()`
- `CHANGELOG.md` history

No tests asserted the old message strings.

## Out of scope (heads-up, not in this PR)
The same streaming refactor (commit `488fa7f`) also deleted `docs/pages/{createChannel,telefuncWebSocket,telefuncWebSocketCloudflare}/` without redirects. Those belong to the WebSocket/streaming consolidation rather than the `telefunc()` → `serve()` rename, and their redirect targets are ambiguous (likely `/stream`, `/stream/cloudflare`, a channels page). Happy to add those redirects in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)