### PR TITLE
docs(stream): reorder Cloudflare hibernation preconditions (review follow-up)

### DIFF
--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -213,7 +213,7 @@ Channel state is in-memory JavaScript. If the Durable Object hibernates, that st
 
 </Warning>
 
-Once all channels close, no clients are connected, and the reconnect and idle windows have expired, the Durable Object can hibernate.
+The Durable Object can hibernate once all channels close, no clients remain connected, and both the reconnect and idle windows have expired.
 
 ```ts
 import { config } from 'telefunc'


### PR DESCRIPTION
Companion to the docs sentence-review PR (branch `claude/kind-allen-siys4q`). It is intentionally kept separate.

During the sentence-by-sentence review, this was the **one** sentence whose best rewrite still could not reach a confident ≥ 8/10 on clarity, so it was held back from the main PR for an author decision.

### The sentence
`docs/pages/stream/cloudflare/+Page.mdx`

- **Before:** "Once all channels close, no clients are connected, and the reconnect and idle windows have expired, the Durable Object can hibernate."
- **After:** "The Durable Object can hibernate once all channels close, no clients remain connected, and both the reconnect and idle windows have expired."

### Why it needs a human call
The rewrite improves flow (main clause first) and disambiguates the conjunction ("**both** the reconnect and idle windows"). What it can't fix on its own is an apparent **content-level redundancy**: "all channels close" and "no clients remain connected" read as the same condition. They can only be safely collapsed if they are genuinely the same — but a client could plausibly be connected with no open channel, in which case both conditions are intentional and distinct.

If the two conditions are independent, this rewrite is the recommended wording. If "no clients are connected" is redundant, the sentence can be shortened further. Either way it's an author judgement, hence the separate PR.

The full analysis (10 rated alternatives) is in the review at `docs-review/C-cloudflare-scale-transport.md`, entry **[51]**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdwJFMFGSJmcsqWGEXi2Fr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdwJFMFGSJmcsqWGEXi2Fr)_