### PR TITLE
docs: make the `serve()` vs `new Telefunc()` recommendation precise &amp; consistent

### DIFF
--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -2,11 +2,11 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-Low-level function that turns a telefunction HTTP request into an HTTP response. It's a pure function: stateless and side-effect-free. It runs in every runtime without adapter.
+Low-level function that turns a telefunction HTTP request into an HTTP response. It's a pure function: stateless and side-effect-free, and runs in any runtime without an adapter.
 
-> **Most apps should use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instead** — it's the standard server integration (see <Link href="/server" />) and the only one with <Link text="WebSocket" href="/transport#channel-transport" /> support.
+> **Most apps should use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instead** — it's the standard server integration (see <Link href="/server" />). Reach for `serve()` when you want direct, low-level control over the HTTP response, or a runtime without a dedicated adapter.
 >
-> Reach for `serve()` when you want direct, low-level control over the HTTP response, or a runtime without a dedicated adapter. It handles <Link href="/stream">streaming</Link> calls, but not <Link text="WebSocket" href="/transport#channel-transport" />.
+> `serve()` handles RPC, <Link href="/stream">streaming</Link>, and <Link text="channels" href="/channel" /> over SSE. It can't do <Link text="WebSocket" href="/transport#channel-transport" />, and on Cloudflare it can't do channels at all — those need `new Telefunc()`'s <Link text="Durable Objects" href="/stream/cloudflare" />.
 
 > Not to be confused with the `telefunc.serve()` *method* on a <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instance — the standalone `serve()` here returns a low-level `HttpResponse` object, whereas the method returns a standard web `Response`.
 

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -2,6 +2,8 @@ import { Link, Tabs } from '@brillout/docpress'
 
 Telefunc can integrate with any server — Hono, Express, Fastify, and more.
 
+Use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> (shown below) — the standard integration, with full support for <Link href="/stream">streaming and real-time</Link>. For a low-level, pure-function alternative (no WebSocket), see <Link href="/serve" />.
+
 
 ## Setup
 
@@ -173,8 +175,6 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 | Cloudflare | `Response \| undefined` | `undefined` if not a Telefunc request |
 
 > `telefunc.serve()` returns `undefined` (or `false`) for non-Telefunc requests, allowing you to chain it with other handlers.
-
-> There's also a low-level <Link text={<code>serve()</code>} href="/serve" /> function, for when you want direct control over the HTTP response or a runtime without a dedicated adapter.
 
 
 


### PR DESCRIPTION
## Problem

After #373, the *examples* were consistent (`new Telefunc()` everywhere), but the **recommendation itself** still wasn't:

- The reason to pick `serve()` was stated three different ways — "low-level HTTP control / runtime without an adapter" (`/serve`, `/server`), "no WebSocket" (`/Telefunc`), and "you don't use channels" (`/stream/cloudflare`).
- `/server` — the page users land on for server integration — never actually stated the recommendation.
- `/serve` said `serve()` "handles streaming, but not WebSocket", which is **incomplete**: it omits that `serve()` *does* handle SSE channels, and that the real extra carve-out is channels on Cloudflare.

## The actual capability boundary (traced through the source)

`new Telefunc().serve({ request })` delegates to the same core `serve()` (`serve/node.ts`); SSE channels are handled inside `runTelefunc` on a process-global mux (`parseHttpRequest.ts` → `sse.ts`/`mux.ts`). So:

| | `serve()` | needs `new Telefunc()` |
|---|---|---|
| RPC, streaming (`AsyncGenerator`/`ReadableStream`/`Promise`) | ✅ any runtime | |
| **SSE** channels / broadcast | ✅ single long-running Node/Bun/Deno | |
| **WebSocket** channels | ❌ (needs `installWebSocket()`) | ✅ |
| Channels on **Cloudflare** | ❌ (needs Durable Objects) | ✅ (`serve/cloudflare.ts` routes through a DO) |

So the only things that require `new Telefunc()` are **WebSocket** and **channels on Cloudflare**.

## Change

- **`/serve`** — single source of truth for the boundary: *"handles RPC, streaming, and channels over SSE. It can't do WebSocket, and on Cloudflare it can't do channels at all — those need `new Telefunc()`'s Durable Objects."*
- **`/server`** — state the recommendation at the top (it was missing); drop the now-redundant low-level-`serve()` footnote.
- **`/Telefunc`** footer and **`/stream/cloudflare`** already matched this framing — left untouched.

Kept it succinct: the pointer pages give a one-line recommendation with a `(no WebSocket)` hint and link to `/serve` for the full boundary.

> **Note:** the "`serve()` handles SSE channels" capability is **code-traced, not test-verified** (the channel playground only exercises `new Telefunc()`). Happy to add a harness that drives an SSE channel through bare `serve()` if you want it backed by a test.

Verified with `node docs/check-docs.mjs` — all 81 internal anchor links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek5Nk2g1KrSYvv8zBimMEx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek5Nk2g1KrSYvv8zBimMEx)_