### PR TITLE
docs(server): document `context` for Bun, Deno & Cloudflare tabs

### DIFF
--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -61,21 +61,16 @@ telefunc.installWebSocket(server)
 
 > **Performance tip**: prefer `{ req, res }` over `{ request }` when you have access to the raw Node.js objects (Express, raw `http`, Connect-style middleware). The `req`/`res` path reads the request body directly from the Node `Readable` and writes the response straight to the Node `Writable`, skipping the Web Streams conversion layer. Node's Web Streams implementation is slower than its internal streams; see [nodejs/performance#134](https://github.com/nodejs/performance/issues/134).
 
-### With context
+Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
 
 ```ts
-app.all('/_telefunc', async (c) => {
-  const response = await telefunc.serve({
-    request: c.req.raw,
-    context: {
-      user: await getUser(c.req),
-    },
-  })
-  return response ?? c.notFound()
+const response = await telefunc.serve({
+  request: c.req.raw,
+  context: {
+    user: await getUser(c.req),
+  },
 })
 ```
-
-> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 :::
 
 :::Choice{#Bun}
@@ -100,7 +95,7 @@ Bun.serve({
 })
 ```
 
-### With context
+Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
 
 ```ts
 const response = await telefunc.serve({
@@ -111,8 +106,6 @@ const response = await telefunc.serve({
   },
 })
 ```
-
-> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 :::
 
 :::Choice{#Deno}
@@ -132,7 +125,7 @@ Deno.serve({ port: 3000 }, async (request, info) => {
 })
 ```
 
-### With context
+Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
 
 ```ts
 const response = await telefunc.serve({
@@ -143,8 +136,6 @@ const response = await telefunc.serve({
   },
 })
 ```
-
-> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 :::
 
 :::Choice{#Cloudflare}
@@ -186,9 +177,7 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 }
 ```
 
-### With context
-
-On Cloudflare, telefunctions run inside the Durable Object — pass `context` as a function to `new Telefunc()` (not to `serve()`):
+Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>. On Cloudflare, telefunctions run inside the Durable Object, so `context` is a function passed to `new Telefunc()` (not to `serve()`):
 
 ```ts
 const telefunc = new Telefunc({
@@ -197,8 +186,6 @@ const telefunc = new Telefunc({
   }),
 })
 ```
-
-> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 
 > See <Link text="Cloudflare Workers" href="/stream/cloudflare" /> for scaling, distributed broadcast, delivery guarantees, and Durable Object configuration.
 :::

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -24,7 +24,13 @@ const app = new Hono()
 const telefunc = new Telefunc()
 
 app.all('/_telefunc', async (c) => {
-  const response = await telefunc.serve({ request: c.req.raw })
+  const response = await telefunc.serve({
+    request: c.req.raw,
+    // Expose data to your telefunctions, accessed via getContext()
+    context: {
+      user: await getUser(c.req),
+    },
+  })
   return response ?? c.notFound()
 })
 
@@ -61,16 +67,6 @@ telefunc.installWebSocket(server)
 
 > **Performance tip**: prefer `{ req, res }` over `{ request }` when you have access to the raw Node.js objects (Express, raw `http`, Connect-style middleware). The `req`/`res` path reads the request body directly from the Node `Readable` and writes the response straight to the Node `Writable`, skipping the Web Streams conversion layer. Node's Web Streams implementation is slower than its internal streams; see [nodejs/performance#134](https://github.com/nodejs/performance/issues/134).
 
-Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
-
-```ts
-const response = await telefunc.serve({
-  request: c.req.raw,
-  context: {
-    user: await getUser(c.req),
-  },
-})
-```
 :::
 
 :::Choice{#Bun}
@@ -87,22 +83,17 @@ Bun.serve({
   // Pass telefunc.websocket to enable WebSocket channels
   websocket: telefunc.websocket,
   async fetch(request, server) {
-    const response = await telefunc.serve({ request, server })
+    const response = await telefunc.serve({
+      request,
+      server,
+      // Expose data to your telefunctions, accessed via getContext()
+      context: {
+        user: await getUser(request),
+      },
+    })
     if (response) return response
 
     return new Response('Not found', { status: 404 })
-  },
-})
-```
-
-Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
-
-```ts
-const response = await telefunc.serve({
-  request,
-  server,
-  context: {
-    user: await getUser(request),
   },
 })
 ```
@@ -118,22 +109,17 @@ import { Telefunc } from 'telefunc/deno'
 const telefunc = new Telefunc()
 
 Deno.serve({ port: 3000 }, async (request, info) => {
-  const response = await telefunc.serve({ request, info })
+  const response = await telefunc.serve({
+    request,
+    info,
+    // Expose data to your telefunctions, accessed via getContext()
+    context: {
+      user: await getUser(request),
+    },
+  })
   if (response) return response
 
   return new Response('Not found', { status: 404 })
-})
-```
-
-Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>:
-
-```ts
-const response = await telefunc.serve({
-  request,
-  info,
-  context: {
-    user: await getUser(request),
-  },
 })
 ```
 :::
@@ -145,7 +131,13 @@ const response = await telefunc.serve({
 
 import { Telefunc } from 'telefunc/cloudflare'
 
-const telefunc = new Telefunc()
+const telefunc = new Telefunc({
+  // Expose data to your telefunctions, accessed via getContext().
+  // On Cloudflare it's a function (telefunctions run in the Durable Object).
+  context: async (request, env: Env) => ({
+    user: await getUser(request, env),
+  }),
+})
 
 export const TelefuncDurableObject = telefunc.TelefuncDurableObject
 
@@ -175,16 +167,6 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
     { "tag": "v1", "new_classes": ["TelefuncDurableObject"] }
   ]
 }
-```
-
-Pass `context` to expose data to your telefunctions, accessed via <Link href="/getContext">`getContext()`</Link>. On Cloudflare, telefunctions run inside the Durable Object, so `context` is a function passed to `new Telefunc()` (not to `serve()`):
-
-```ts
-const telefunc = new Telefunc({
-  context: async (request, env: Env) => ({
-    user: await getUser(request, env),
-  }),
-})
 ```
 
 > See <Link text="Cloudflare Workers" href="/stream/cloudflare" /> for scaling, distributed broadcast, delivery guarantees, and Durable Object configuration.

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -99,6 +99,20 @@ Bun.serve({
   },
 })
 ```
+
+### With context
+
+```ts
+const response = await telefunc.serve({
+  request,
+  server,
+  context: {
+    user: await getUser(request),
+  },
+})
+```
+
+> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 :::
 
 :::Choice{#Deno}
@@ -117,6 +131,20 @@ Deno.serve({ port: 3000 }, async (request, info) => {
   return new Response('Not found', { status: 404 })
 })
 ```
+
+### With context
+
+```ts
+const response = await telefunc.serve({
+  request,
+  info,
+  context: {
+    user: await getUser(request),
+  },
+})
+```
+
+> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 :::
 
 :::Choice{#Cloudflare}
@@ -157,6 +185,20 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
   ]
 }
 ```
+
+### With context
+
+On Cloudflare, telefunctions run inside the Durable Object — pass `context` as a function to `new Telefunc()` (not to `serve()`):
+
+```ts
+const telefunc = new Telefunc({
+  context: async (request, env: Env) => ({
+    user: await getUser(request, env),
+  }),
+})
+```
+
+> Access `context` inside telefunctions via <Link href="/getContext">`getContext()`</Link>.
 
 > See <Link text="Cloudflare Workers" href="/stream/cloudflare" /> for scaling, distributed broadcast, delivery guarantees, and Durable Object configuration.
 :::


### PR DESCRIPTION
## What

The `/server` docs page (`docs/pages/server/+Page.mdx`) only documented how to provide `context` (accessed via `getContext()`) in the **Node** tab. The **Bun**, **Deno**, and **Cloudflare** tabs had no `context` documentation at all.

This adds a "With context" subsection to each of those tabs, mirroring the existing Node one.

## Why it matters / accuracy

The mechanism genuinely differs per runtime, so the examples are tailored rather than copy-pasted:

- **Bun** / **Deno** — `context` is a plain object passed per-request to `serve({ ..., context })`, matching Node. Verified against `packages/telefunc/serve/bun.ts` and `serve/deno.ts` (`ServeInput.context?: TelefuncNamespace.Context`).
- **Cloudflare** — different on purpose: telefunctions execute **inside the Durable Object**, not where `serve()` is called in the Worker. So `context` is a **function** passed to the `new Telefunc({ context })` constructor, invoked as `(request, env) => Context` inside the DO. Verified against `packages/telefunc/serve/cloudflare.ts` (`CloudflareOptions.context` + its use in `TelefuncDurableObject.fetch`).

The `/getContext` page already points readers to `/server` to learn how to provide context, so this fills the gap for the non-Node runtimes.

## Changes

- `docs/pages/server/+Page.mdx` — add "With context" subsections to the Bun, Deno, and Cloudflare runtime tabs (+42 lines, docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DyApPbSTByJfDHBMHcQom

---
_Generated by [Claude Code](https://claude.ai/code/session_018DyApPbSTByJfDHBMHcQom)_