### PR TITLE
docs: remove the /server page

### DIFF
--- a/docs/+docpress.tsx
+++ b/docs/+docpress.tsx
@@ -34,7 +34,7 @@ const config: Config = {
 
   umamiId: 'd03d0873-19dc-42c4-a250-cf8500171a9e',
 
-  // Globally-synced runtime toggle (used by /server and /Telefunc).
+  // Globally-synced runtime toggle (used by /Telefunc).
   choices: {
     runtime: {
       choices: [

--- a/docs/+redirects.ts
+++ b/docs/+redirects.ts
@@ -13,4 +13,5 @@ const redirects = {
   '/remix': '/react-router',
   '/httpHeaders': '/headers',
   '/telefunc': '/serve',
+  '/server': '/Telefunc',
 } as const satisfies Config['redirects']

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -100,15 +100,6 @@ const headings = [
   },
   {
     level: 4,
-    title: 'Server integration',
-  },
-  {
-    level: 2,
-    title: 'Server (Hono, Express, ...)',
-    url: '/server',
-  },
-  {
-    level: 4,
     title: 'Bundler integration',
   },
   {

--- a/docs/pages/Telefunc/+Page.mdx
+++ b/docs/pages/Telefunc/+Page.mdx
@@ -217,6 +217,5 @@ Add the Durable Object and KV bindings to your `wrangler.jsonc`:
 
 ## See also
 
-- <Link href="/server" />
 - <Link href="/stream/cloudflare" />
 - <Link href="/serve" />

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -13,7 +13,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 
-> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/server" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background (see <Link href="/transport" />).
+> By default, channels and broadcasts use **SSE** and work without extra server setup. When WebSocket is enabled (see <Link href="/Telefunc" />), the client starts on SSE and seamlessly upgrades to WebSocket in the background (see <Link href="/transport" />).
 
 <NeedsLongRunningServer />
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -28,7 +28,7 @@ It's most commonly used for implementing permissions, see <Link href="/permissio
 
 ## Provide
 
-Before you can use `getContext()`, you must provide the `context` object when calling `telefunc.serve()` — see <Link href="/server" />.
+Before you can use `getContext()`, you must provide the `context` object when calling `telefunc.serve()` — see <Link href="/Telefunc" />.
 
 For example:
 
@@ -239,4 +239,4 @@ const response = await fetch(url, { signal: context.signal })
 ## See also
 
 - <Link href="/permissions" />
-- <Link href="/server" />
+- <Link href="/Telefunc" />

--- a/docs/pages/provideTelefuncContext/+Page.mdx
+++ b/docs/pages/provideTelefuncContext/+Page.mdx
@@ -21,4 +21,4 @@ Call it before the telefunction runs (e.g. in your test setup or your SSR reques
 ## See also
 
 - <Link href="/getContext" />
-- <Link href="/server" />
+- <Link href="/Telefunc" />

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -4,8 +4,7 @@ import { Link } from '@brillout/docpress'
 
 Low-level function that turns a telefunction HTTP request into an HTTP response. It's a pure function: stateless and side-effect-free. It runs in every runtime without adapter.
 
-> **Most apps should use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instead** — it's the standard server integration, see:
-> - <Link href="/server" />
+> **Most apps should use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instead** — it's the standard server integration.
 >
 > Because `new Telefunc()` has full-fledged support for <Link href="/stream">Telefunc Stream</Link>, whereas `serve()` doesn't support the following:
 > - <Link text="WebSocket" href="/transport#channel-transport" />
@@ -84,5 +83,4 @@ const httpResponse = await serve({
 ## See also
 
 - <Link href="/Telefunc" />
-- <Link href="/server" />
 - <Link href="/getContext" />

--- a/docs/pages/server/+Page.mdx
+++ b/docs/pages/server/+Page.mdx
@@ -1,8 +1,0 @@
-import { Link, Tabs } from '@brillout/docpress'
-
-
-## See also
-
-- <Link href="/Telefunc" />
-- <Link href="/getContext" />
-- <Link href="/serve" />

--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -230,6 +230,6 @@ config.channel = {
 ## See also
 
 - <Link href="/stream/scale" />
-- <Link href="/server" />
+- <Link href="/Telefunc" />
 - <Link href="/channel" />
 - <Link href="/stream" />

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -45,7 +45,7 @@ Controls how streamed values are delivered over HTTP.
 | `'binary-inline'` | ✅ | 🟡 | ❌ | None |
 | `'sse-inline'` | 🟡 | ✅ | ❌ | None |
 | `'channel'` (SSE) | 🟡 | ✅ | ✅ | None |
-| `'channel'` (WS) | ✅ | 🟡 | ✅ | <Link text="Server setup" href="/server" /> |
+| `'channel'` (WS) | ✅ | 🟡 | ✅ | <Link text="Server setup" href="/Telefunc" /> |
 
 *Key: ✅ good · 🟡 partial / caveats · ❌ none*
 
@@ -63,9 +63,9 @@ Controls how <Link text={<code>new Channel()</code>} href="/channel" /> and <Lin
 | Transport | Description |
 |---|---|
 | `'sse'` | HTTP requests + SSE stream. Works without extra server setup. |
-| `'ws'` | Multiplexed WebSocket. Requires <Link text="WebSocket server setup" href="/server" />. |
+| `'ws'` | Multiplexed WebSocket. Requires <Link text="WebSocket server setup" href="/Telefunc" />. |
 
-The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE out-of-the-box and adds WebSocket when you install an adapter (see <Link href="/server" />).
+The client default is `['sse', 'ws']` — start on SSE, then upgrade to WebSocket once the server offers it. The server offers SSE out-of-the-box and adds WebSocket when you install an adapter (see <Link href="/Telefunc" />).
 
 All channels share a single multiplexed connection per server URL, so opening many channels doesn't open many connections.
 
@@ -74,7 +74,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 | | Throughput | Recovery | Proxy/CDN | Setup |
 |---|---|---|---|---|
 | `'sse'` | 🟡 | ✅ | ✅ | None |
-| `'ws'` | ✅ | ✅ | 🟡 | <Link text="Server setup" href="/server" /> |
+| `'ws'` | ✅ | ✅ | 🟡 | <Link text="Server setup" href="/Telefunc" /> |
 
 *Key: ✅ good · 🟡 partial / caveats · ❌ none*
 
@@ -83,7 +83,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 - **Start with `'sse'`** — it works everywhere out-of-the-box.
 - **Use `'ws'`** for high-frequency, real-time traffic that benefits from a full-duplex connection.
 
-> When WebSocket is enabled (see <Link href="/server" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background (open channels keep working without interruption).
+> When WebSocket is enabled (see <Link href="/Telefunc" />), the server supports both SSE and WS. The client starts on SSE and upgrades to WebSocket in the background (open channels keep working without interruption).
 
 
 ## Recommended setup
@@ -94,7 +94,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 | Proxy buffers binary | `config.stream.transport = 'sse-inline'` |
 | Streams with reconnection | `config.stream.transport = 'channel'` |
 | Channels without WS | `config.channel.transports = ['sse']` |
-| Full-duplex channels | `config.channel.transports = ['sse', 'ws']` + <Link text="Server setup" href="/server" /> |
+| Full-duplex channels | `config.channel.transports = ['sse', 'ws']` + <Link text="Server setup" href="/Telefunc" /> |
 
 
 ## Per-call overrides


### PR DESCRIPTION
## What

Removes the `/server` page. Its server-setup content (the Node/Bun/Deno/Cloudflare setup tabs) was already moved onto **`/Telefunc`** (`new Telefunc()`), leaving `/server` as a redundant stub.

## Changes

- **Delete** `docs/pages/server/+Page.mdx`.
- **Nav** (`docs/headings.ts`): remove the now-empty *Server integration* sub-section from *Get Started* (its only entry was `/server`). Server setup remains discoverable under *API → `new Telefunc()`*.
- **Links**: repoint every `<Link href="/server">` to `/Telefunc` (the content successor) across `transport`, `channel`, `getContext`, `provideTelefuncContext`, `serve`, `stream/cloudflare`, and `Telefunc`. Duplicate "See also" entries (where `/Telefunc` was already listed) are collapsed rather than duplicated.
- **Redirect** (`docs/+redirects.ts`): add `/server` → `/Telefunc` so existing links and bookmarks keep working, matching the repo's existing redirect convention.
- **Cleanup**: update the stale `/server` mention in the `+docpress.tsx` comment.

## Verification

- `node docs/check-docs.mjs` passes — 51 pages, all 80 internal anchor links resolve.
- No remaining `href="/server"` doc-links (the only leftover `/server` strings are unrelated: `$lib/server`, package import paths like `@telefunc/rxjs/server`, the new redirect, and a `// /server/index.ts` code-comment example).

> Note: this targets `nitedani/streaming` (the branch this work is based on), so the diff is scoped to just the `/server` removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQs9Hqbk7MGVE9DrvkvdUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQs9Hqbk7MGVE9DrvkvdUJ)_