### PR TITLE
docs: move getContext() onClose()/signal details to /close

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -24,8 +24,9 @@ There's one catch-all API, `close()`, plus several per-type APIs. They all signa
 | <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
 | <Link text={<code>channel.abort(value?)</code>} href="/channel#lifecycle" /> | either side | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
 | `onClose(cb)` | server | Both | Fires when the connection ends, however it ends |
+| `signal` | server | Both | `AbortSignal` that aborts when the connection ends |
 
-The rest of this page covers `close()`, `abort()`, and `onClose()` in detail; channel-specific closing is documented on <Link href="/channel#lifecycle" />.
+The rest of this page covers `close()`, `abort()`, `onClose()`, and `signal` in detail; channel-specific closing is documented on <Link href="/channel#lifecycle" />.
 
 
 ## `close()`
@@ -110,6 +111,26 @@ export async function* onAiPrompt(prompt: string) {
 **Pitfall** — anything a long-lived telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down here.
 
 </Warning>
+
+
+## `signal`
+
+**Environment**: server.
+
+The context object also includes a `signal` (an `AbortSignal`) that aborts when the response ends — same timing as `onClose()`. Pass it to any API that accepts an `AbortSignal` (`fetch()`, database clients, etc.) so in-flight work cancels when the client disconnects:
+
+```ts
+// Environment: server
+
+import { getContext } from 'telefunc'
+
+export async function getData() {
+  const { signal } = getContext()
+  // The request is cancelled if the client disconnects
+  const response = await fetch('https://api.example.com/data', { signal })
+  return response.json()
+}
+```
 
 
 ## Automatic cleanup (GC)

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -5,7 +5,7 @@ import { StreamingBeta } from '../../components'
 
 **Environment**: server & client.
 
-`close()` and `onClose()` manage the lifecycle of streams and connections — so the server can stop producing, and release resources.
+These APIs manage the lifecycle of streams and connections: the client ends a value with `close()` or `abort()`, and the server reacts with `onClose()` and `signal` — so it can stop producing and release resources.
 
 > Applies to all <Link href="/stream">streaming and real-time</Link> values: `AsyncGenerator`, `ReadableStream`, files, `Channel`, and `BroadcastChannel` all close the same way.
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -211,30 +211,11 @@ export async function someTelefunction() {
 
 ## `onClose()`
 
-The context object includes `onClose()`, a callback that fires exactly once when the call/<Link href="/stream">stream</Link> ends — whether the client received everything, the client disconnected, or an error occurred. Use it to release resources.
-
-```ts
-const context = getContext()
-context.onClose(() => {
-  // Clean up server-side resources
-})
-```
-
-<Link href="/stream">the call</Link>
-
-> See also:
-> - <Link href="/stream" />
-> - <Link href="/close" />
-
+The context object includes `onClose()`, a callback that fires when the call/<Link href="/stream">stream</Link> ends — use it to release server-side resources. See <Link href="/close#onclose" />.
 
 ## `signal`
 
-The context object includes a `signal` (an `AbortSignal`) that aborts when the call/<Link href="/stream">stream</Link> ends. Pass it to APIs that accept an `AbortSignal` (`fetch`, database clients, etc.) so in-flight work cancels when the client disconnects.
-
-```ts
-const context = getContext()
-const response = await fetch(url, { signal: context.signal })
-```
+The context object includes a `signal` (an `AbortSignal`) that aborts when the call/<Link href="/stream">stream</Link> ends — pass it to APIs that accept an `AbortSignal` (`fetch`, database clients, etc.) to cancel in-flight work. See <Link href="/close#signal" />.
 
 
 ## See also


### PR DESCRIPTION
Moves the `onClose()` and `signal` details from `/getContext` to `/close`, consolidating the lifecycle docs in one place, and links back.

### `/close`
- Added a `## signal` section — the actual move (the `onClose()` detail already lived here).
- Added a `signal` row to the "At a glance" table, next to `onClose(cb)`.
- Updated the overview sentence to mention `signal`.

### `/getContext`
- Reduced the `## onClose()` and `## signal` sections to one-line pointers that link to `/close#onclose` and `/close#signal` (the "add links" part).
- The `#onclose` and `#signal` anchors are preserved, so existing deep links still land on relevant content.
- Dropped a stray leftover `<Link href="/stream">the call</Link>` and a redundant "See also" blockquote.

### Why
`/close` is the canonical home for stream/connection lifecycle (it already documents `close()`, `abort()`, `onClose()`). `onClose()` and `signal` are properties of the context object, so `/getContext` keeps a brief mention and links out for the detail — avoiding duplication.

`node docs/check-docs.mjs` passes — all 82 internal anchor links resolve, including the two new `/close#…` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013goKZRdfpwaajELETbedEY

---
_Generated by [Claude Code](https://claude.ai/code/session_013goKZRdfpwaajELETbedEY)_