### PR TITLE
docs(onClose): add channel listener methods + when to call close()

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -45,6 +45,8 @@ On the server-side, you can listen when the telefunction call/<Link href="/strea
 |---|---
 | `context.onClose(cb)` | server
 | `context.signal` | server
+| <Link text={<code>channel.onClose(cb)</code>} href="/channel#lifecycle" /> | client & server
+| <Link text={<code>channel.onOpen(cb)</code>} href="/channel#lifecycle" /> | client & server
 
 > The listeners are fired regardless of the closing reason — whether all returned values are consumed, the client manually closed, the client disconnected, or an error occurred.
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -140,6 +140,8 @@ const { value } = await result.stream.next()
 close(result)
 ```
 
+> **Do you need to call `close()`?** Often not. A value that finishes on its own — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — releases its resources automatically; and if you drop every reference to a returned value, garbage collection reclaims it a few seconds later. Call `close()` when you want to release **promptly** instead of waiting for GC — typically when you stop consuming a streamed value early.
+
 ### Other ways to close
 
 For specific value types, you can also use the standard JS APIs directly:


### PR DESCRIPTION
## What

Two small additions to the **`/onClose`** docs page (`docs/pages/onClose/+Page.mdx`):

**1. Add the missing channel listener methods to the Listening table.**
The Listening table only had the call-level `context.onClose(cb)` / `context.signal`. The Closing table already lists the channel *closers* (`channel.close()` / `channel.abort()`), but the channel's own lifecycle *listeners* were absent. Added, mirroring that pattern (linked to `/channel#lifecycle`):

| API | Side |
|---|---|
| `channel.onClose(cb)` | client & server |
| `channel.onOpen(cb)` | client & server |

**2. Note when `close()` is needed vs. when it isn't.**
A blockquote in the `### close()` section clarifying that `close()` is optional — a value that finishes on its own (an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end) releases automatically, and dropping all references lets GC reclaim it a few seconds later; call `close()` to release **promptly** instead of waiting for GC. Wording is kept consistent with the existing GC language on `/stream` and `/rxjs`.

## Verification

- `node docs/check-docs.mjs` → ✓ `51 pages, 85 internal anchor links — all resolve.`
- Both `channel.onClose(cb)` / `channel.onOpen(cb)` confirmed against the `Channel` and `BroadcastChannel` method tables on `/channel`; the `/channel#lifecycle` anchor resolves.

## Notes

- Base is `nitedani/streaming` (where the `/onClose` page lives), so the diff is just these two additions (+4 lines).
- Unrelated: there's a pre-existing typo on the page — "anything a **l**telefunction opens" (line 26) — left untouched since it's in your in-progress rewrite; easy to fold in if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6)_