### PR TITLE
docs(onClose): correct the "close manually?" note — GC won't reclaim a stream you're still consuming

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -23,7 +23,7 @@ export async function onInit(onTick: (n: number) => void) {
 ```
 
 <Warning>
-**Performance: always release resources** — anything a ltelefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the telefunction call and leaks unless you release it.
+**Performance: always release resources** — anything a telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the telefunction call and leaks unless you release it.
 </Warning>
 
 You can also use an abort `signal` ([`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)) and more methods, see:
@@ -105,14 +105,37 @@ export async function onLoad() {
 
 You can manually close the telefunction call/<Link href="/stream">stream</Link> via `close()` (graceful) or `abort()` (immediate), and more.
 
-> **Do I need to close manually? Almost never:**
-> - A <Link href="/stream">stream values</Link> that finishes on its own — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — automatically closes
-> - A garbage collected `channel` also automatically closes.
-> This means `onClose()` will automatically be triggered when all stream values aren't used anymore.
->
->  TODO/ai provide React client-side example with useEffect() that (it somewhat surprising) dosn't need close() because React element => no reference => GC => onClose() is triggered automatically.
->
-> You usually close manually only to release resources **promptly**.
+> **Do I need to close manually?** Often not:
+> - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
+> - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
+
+A **long-lived stream you keep consuming** is the exception: an active `for await` loop (or an open channel) keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
+
+```tsx
+// Clock.tsx
+// Environment: client
+
+import { useEffect, useState } from 'react'
+import { onClock } from './Clock.telefunc'
+
+function Clock() {
+  const [n, setN] = useState(0)
+
+  useEffect(() => {
+    const clock = onClock() // long-lived AsyncGenerator
+    ;(async () => {
+      for await (const tick of clock) setN(tick)
+    })()
+    // The running loop keeps the stream alive, so unmounting won't stop it on
+    // its own — end it to release the server's resources (fires onClose()):
+    return () => void clock.return()
+  }, [])
+
+  return <p>{n}</p>
+}
+```
+
+Closing manually also releases resources **promptly**, instead of waiting for GC.
 
 There's one catch-all API, `close()`, plus several per-type APIs.
 


### PR DESCRIPTION
## Context

Reviewing the `/onClose` note from 822b48b ("Do I need to close manually? Almost never") and its `TODO/ai` for a React `useEffect()` example. **The premise is inaccurate**, so I corrected it rather than implement the TODO as written.

## The accuracy problem

The note (and the TODO) claim a React component's stream needs no manual close because unmount → no reference → GC → `onClose()`. That **does not hold for a long-lived stream you're actively consuming**:

- The client AsyncGenerator is **pull-based** — `next()` drives it (`async-generator-interface.ts`); there's no background pump.
- `wrapProxy.ts` keeps the wrapper **deliberately reachable while you consume it** (`keepWrapperAlive`), precisely so GC *won't* close it mid-consumption.
- So a detached `for await` loop in `useEffect` keeps running after unmount, pinning the value. GC never fires, the server's `setInterval` runs forever — a **leak**, not auto-cleanup.

GC-based cleanup (`gcRegistry.ts`: `FinalizationRegistry` + ~5s `WeakRef` scan) only reclaims values you've **stopped consuming and dropped**. A value that **finishes on its own** also closes automatically. But a stream you keep reading must be ended explicitly.

## Changes

- Reworded the note to what actually holds: finishes-on-its-own / stop-referencing-entirely → auto-closes; a stream you keep consuming → end it yourself; manual close also = release **promptly**.
- Replaced the `TODO/ai` with a **correct** React `useEffect()` example that stops the stream on unmount (`clock.return()`), with a comment explaining why unmount alone doesn't.
- Fixed a typo: "a **l**telefunction opens" → "a telefunction opens".

## Verification

- `node docs/check-docs.mjs` → ✓ `51 pages, 85 internal anchor links — all resolve.`
- Behavior traced through `wire-protocol/gcRegistry.ts`, `wire-protocol/wrapProxy.ts`, and `client/remoteTelefunctionCall/async-generator-interface.ts`.

## Note

If you'd genuinely prefer to show a "no manual close needed" React example, the only accurate version is a stream that **completes on its own** (the loop ends → auto-close) — happy to swap to that framing instead. For a long-lived stream there's no leak-free way to skip the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6)_