### PR TITLE
docs(onClose): add a "no cleanup needed" example + clarify channels in useEffect

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -107,11 +107,33 @@ You can (and sometimes should) manually close the telefunction call/<Link href="
 
 ### When to close
 
-**Do I need to close manually? Often not:
+**Do I need to close manually?** Often not:
 - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
 - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
 
-A **long-lived stream you keep consuming** is the exception: an active `for await` loop (or an open channel) keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
+```tsx
+// Greeting.tsx
+// Environment: client
+
+import { useEffect, useState } from 'react'
+import { onGreeting } from './Greeting.telefunc'
+
+function Greeting() {
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    ;(async () => {
+      for await (const word of onGreeting()) setText((t) => t + word)
+    })()
+    // ✅ No cleanup needed — onGreeting() yields a few words then returns, so the
+    //    generator completes on its own, which closes the stream (fires onClose()).
+  }, [])
+
+  return <p>{text}</p>
+}
+```
+
+The exception is a **long-lived stream you keep consuming**: an active `for await` loop keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
 
 ```tsx
 // Clock.tsx
@@ -136,6 +158,8 @@ function Clock() {
   return <p>{n}</p>
 }
 ```
+
+> **A `channel` is different.** It's callback-based (`channel.listen(cb)`), so no consuming loop pins it: dropping the channel on unmount lets GC close it within a few seconds. You don't strictly *need* a cleanup — but call `channel.close()` in one anyway to release **promptly**, otherwise `listen()` keeps firing (and the server keeps the channel open) until GC catches up. You *must* close explicitly only if the channel stays reachable past the component — e.g. stored in a `ref` or a module variable.
 
 Closing manually also releases resources **promptly**, instead of waiting for GC.
 


### PR DESCRIPTION
## What

Follow-up to 7d0268e on the `/onClose` "When to close" section:

1. **Added an example where manual closing isn't needed** — a React `useEffect` consuming a stream that **finishes on its own** (`onGreeting()` yields a few words then returns). The generator completing closes the stream (fires `onClose()`), so no cleanup function is needed. Sits as the ✅ counterpart to the existing ⚠️ `Clock` (long-lived) example.

2. **Answered "channel in `useEffect`: when must `close()` be called?"** — and corrected an inaccuracy. The note said *"an active `for await` loop (or an open channel) keeps the value reachable"*. That's wrong for channels:

   - A channel is **callback-based** (`channel.listen(cb)`) — no consuming loop pins it.
   - The client gets a GC-registered **wrapper**; the connection holds the **internal `ClientChannel`**, not the wrapper (`parse.ts:160-163`, `connection.ts:283-284`).
   - So dropping the channel on unmount lets **GC close it within a few seconds** — unlike a generator's loop, which pins the value and must be stopped.

   New callout spells out the rule: you don't strictly *need* a cleanup for a channel, but call `channel.close()` in one anyway to release **promptly** (otherwise `listen()` keeps firing and the server keeps the channel open until GC catches up); you *must* close explicitly only if you keep the channel reachable past the component (a `ref`, a module variable, …).

3. **Fixed a markdown bug** introduced in 7d0268e: `**Do I need to close manually? Often not:` had an unclosed `**` (now `**Do I need to close manually?** Often not:`).

## The channel ≠ generator distinction (the crux)

| | Pinned while open? | Drop ref on unmount → GC closes it? | `close()` required? |
|---|---|---|---|
| `AsyncGenerator` consumed by `for await` | **Yes** — the running loop holds it | No (loop keeps it alive) | **Yes** — stop the loop |
| `Channel` via `listen(cb)` | No — callback-based | **Yes**, within a few seconds | No (but do it for *promptness*) |

## Verification

- `node docs/check-docs.mjs` → ✓ `51 pages, 85 internal anchor links — all resolve.`
- Behavior traced through `wire-protocol/client/response/parse.ts`, `wire-protocol/client/connection.ts`, `wire-protocol/wrapProxy.ts`, and `wire-protocol/gcRegistry.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6)_