### PR TITLE
docs(onClose): resolve close() TL;DR + channel GC example TODOs

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -105,7 +105,7 @@ export async function onLoad() {
 
 You can (and sometimes should) manually close the telefunction call/<Link href="/stream">stream</Link> via `close()` (graceful) or `abort()` (immediate), and more.
 
-> **Do I need to close manually?** Mostly no — values close when they finish or when you drop them. The catch: a running `for await` loop pins the stream from GC, so `break` / `gen.return()` it. <Link href="#when-to-close" text="Details" />
+> **Do I need to close manually?** It comes down to reachability. A value that **finishes** (a generator run to completion, a stream read to the end) or that you **drop entirely** closes itself. One you **keep reachable** won't be GC'd, so end it yourself: `break` / `gen.return()` a live `for await` loop, and `channel.close()` a `channel` you `listen()` on. <Link href="#when-to-close" text="Details" />
 
 There's one catch-all API, `close()`, plus several per-type APIs.
 
@@ -124,11 +124,11 @@ There's one catch-all API, `close()`, plus several per-type APIs.
 
 ### When to close
 
-You usually don't need to close manually, as streams often close automatically:
+Whether you need to close by hand comes down to reachability. Some values close on their own:
 - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
 - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
 
-Two things stay open until you end them yourself. A long-lived `channel` — close it on unmount:
+Two things stay open until you end them yourself. A `channel` you `listen()` on — the listener keeps it reachable, so GC won't close it; close it on unmount:
 
 ```tsx
 // Chat.tsx

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -105,7 +105,7 @@ export async function onLoad() {
 
 You can (and sometimes should) manually close the telefunction call/<Link href="/stream">stream</Link> via `close()` (graceful) or `abort()` (immediate), and more.
 
-> **Do I need to close manually?** Usually not — a stream that finishes, or that you stop referencing, closes itself; close manually mainly to release resources **promptly**, or to end a long-lived stream you keep consuming (<Link href="#when-to-close" text="when to close" />).
+> **Do I need to close manually?** Mostly no — values close when they finish or when you drop them. The catch: a running `for await` loop pins the stream from GC, so `break` / `gen.return()` it. <Link href="#when-to-close" text="Details" />
 
 There's one catch-all API, `close()`, plus several per-type APIs.
 
@@ -128,7 +128,7 @@ You usually don't need to close manually, as streams often close automatically:
 - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
 - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
 
-A `channel` is the interesting case — it's callback-based, so nothing keeps it alive on its own; drop it and GC closes it, no cleanup function required:
+Two things stay open until you end them yourself. A long-lived `channel` you hold a reference to — close it on unmount:
 
 ```tsx
 // Chat.tsx
@@ -143,18 +143,17 @@ function Chat() {
 
   useEffect(() => {
     onChat().then(({ channel }) => {
-      channelRef.current = channel // keep a reference, else GC closes it while still mounted
+      channelRef.current = channel
       channel.listen((msg) => setMessages((prev) => [...prev, msg]))
     })
-    // ✅ No close() — on unmount the ref drops and GC closes the channel a few
-    //    seconds later (fires onClose()). Close it in a cleanup to release promptly.
+    return () => channelRef.current?.close() // close on unmount
   }, [])
 
   return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
 }
 ```
 
-The exception is a stream you consume with a **`for await` loop**: unlike the channel above, the running loop keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
+And a stream you're still consuming in a **`for await` loop** — the running loop keeps it reachable, so end it (e.g. when a React component unmounts):
 
 ```tsx
 // Clock.tsx

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -141,16 +141,11 @@ function Chat() {
   const [messages, setMessages] = useState<string[]>([])
 
   useEffect(() => {
-    let channel
-    let unmounted = false
-    ;(async () => {
-      channel = (await onChat()).channel
-      if (unmounted) channel.close() // unmounted before the handshake resolved
-      else channel.listen((msg) => setMessages((prev) => [...prev, msg]))
-    })()
+    const open = onChat() // Promise<{ channel }>
+    open.then(({ channel }) =>
+      channel.listen((msg) => setMessages((prev) => [...prev, msg])))
     return () => {
-      unmounted = true
-      channel?.close() // close on unmount
+      open.then(({ channel }) => channel.close()) // close on unmount
     }
   }, [])
 
@@ -158,7 +153,7 @@ function Chat() {
 }
 ```
 
-> **No `ref` needed** — the effect's own closure already reaches the channel (a `ref` is only for access *outside* the effect, e.g. a "send" button calling `channel.send()`). The **`unmounted` flag** handles the async gap: if you unmount mid-handshake (React StrictMode does this on every mount), `onChat()` resolves *after* cleanup ran, opening a channel that never gets closed — and since it's still listening, GC won't reclaim it either, so it leaks (client *and* server) until you close it.
+> **Why close via `open.then()` instead of a saved variable?** `onChat()` resolves asynchronously, so on unmount the channel may not exist yet. Re-using the promise closes it *whenever* the handshake resolves — including an unmount mid-handshake, which React StrictMode triggers on every mount. Skip it and that late channel opens still-listening; since GC won't reclaim a listening channel, it leaks (client *and* server). No `ref` needed either — the promise already carries the channel to both the listener and the cleanup.
 
 And a stream you're still consuming in a **`for await` loop** — the running loop keeps it reachable, so end it (e.g. when a React component unmounts):
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -142,19 +142,23 @@ function Chat() {
 
   useEffect(() => {
     let channel
+    let unmounted = false
     ;(async () => {
-      const result = await onChat()
-      channel = result.channel
-      channel.listen((msg) => setMessages((prev) => [...prev, msg]))
+      channel = (await onChat()).channel
+      if (unmounted) channel.close() // unmounted before the handshake resolved
+      else channel.listen((msg) => setMessages((prev) => [...prev, msg]))
     })()
-    return () => channel?.close() // close on unmount
+    return () => {
+      unmounted = true
+      channel?.close() // close on unmount
+    }
   }, [])
 
   return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
 }
 ```
 
-> A `ref` is only needed when something *outside* the effect touches the channel — e.g. a "send" button handler calling `channel.send()`. For listen-and-close, the effect's own closure is enough.
+> **No `ref` needed** — the effect's own closure already reaches the channel (a `ref` is only for access *outside* the effect, e.g. a "send" button calling `channel.send()`). The **`unmounted` flag** guards the async gap: `onChat()` resolves later, so without it, unmounting *during* the handshake — which React StrictMode does on every mount — would open a channel after cleanup ran and never close it.
 
 And a stream you're still consuming in a **`for await` loop** — the running loop keeps it reachable, so end it (e.g. when a React component unmounts):
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -105,7 +105,7 @@ export async function onLoad() {
 
 You can (and sometimes should) manually close the telefunction call/<Link href="/stream">stream</Link> via `close()` (graceful) or `abort()` (immediate), and more.
 
-> **Do I need to close manually?** It comes down to reachability. A value that **finishes** (a generator run to completion, a stream read to the end) or that you **drop entirely** closes itself. One you **keep reachable** won't be GC'd, so end it yourself: `break` / `gen.return()` a live `for await` loop, and `channel.close()` a `channel` you `listen()` on. <Link href="#when-to-close" text="Details" />
+> **Do I need to close manually?** A stream **ends on its own** — a generator returns, a `ReadableStream` is read to the end, or the server closes a `channel` — otherwise **you close it**: `break` / `gen.return()` a live `for await` loop, `channel.close()` a `channel` you `listen()` on. (Abandon one without closing and GC reclaims it eventually — a leak backstop, not something to rely on.) <Link href="#when-to-close" text="Details" />
 
 There's one catch-all API, `close()`, plus several per-type APIs.
 
@@ -124,16 +124,18 @@ There's one catch-all API, `close()`, plus several per-type APIs.
 
 ### When to close
 
-Whether you need to close by hand comes down to **reachability**. A value that **finishes** (runs to completion) or that you **drop entirely** closes itself — the latter via garbage collection a few seconds later (firing the server's `onClose()`), so close it yourself to release promptly. A value you **keep reachable** can't be garbage-collected, so you must end it:
+The rule is simple: **a stream ends on its own, or you must close it.** It ends on its own when it runs out — a generator returns, a `ReadableStream` is read to the end — or when the server closes it. Anything else — something still producing that you stop consuming, or a `channel` you `listen()` on — you close by hand:
 
-| Value | Closes itself when… | You **must** close it when… | How |
+| Value | Ends on its own when… | You **must** close it when… | How |
 |---|---|---|---|
-| `AsyncGenerator` | run to completion, or dropped (GC) | you stop a running `for await` early (incl. endless streams) | `break` (auto-calls `return()`), `gen.return()`, `await using`, or `close(gen)` |
-| `ReadableStream` | read to the end, or dropped (GC) | you stop reading a still-open stream early | `reader.cancel()`, `break` a `for await`, or `close(stream)` |
-| `Channel` / `BroadcastChannel` | the server ends it, or you drop it with **no** listener (GC) | you `listen()` on one that stays open — the listener keeps it reachable, so GC never reclaims it | `channel.close()` (graceful) or `channel.abort()` (immediate) |
-| `File` / `Blob` / streamed `Promise` / download | awaited or consumed, or dropped (GC) | rarely — only a partial **download** you keep but don't finish | `close(value)`, or download `.cancel()` |
+| `AsyncGenerator` | it returns — the `for await` runs to completion | it's endless, or you stop iterating early | `break` (auto-calls `return()`), `gen.return()`, `await using`, or `close(gen)` |
+| `ReadableStream` | it's read to the end | you stop reading before the end | `reader.cancel()`, `break` a `for await`, or `close(stream)` |
+| `Channel` / `BroadcastChannel` | the server ends it | it stays open and you `listen()` on it | `channel.close()` (graceful) or `channel.abort()` (immediate) |
+| `File` / `Blob` / streamed `Promise` / download | it resolves — you `await` it | ≈ never (just `await` it; or cancel a download) | `close(value)` / download `.cancel()` |
 
 To cancel a call and **every** stream/channel it opened at once — immediately, without waiting for a graceful close — use `abort(call)` or `withContext(fn, { signal })`; `close(value)` closes everything nested in a return value. (See the close-API table above.)
+
+> **Where does GC come in?** Only as a backstop. If you *abandon* a stream — lose the reference on an error path, forget to close one — telefunc reclaims it when the garbage collector collects the value (firing `onClose()`), so a forgotten stream won't leak *forever*. But it's not a close mechanism you can use: the moment you consume or hold a stream it's reachable, and GC can't touch what's reachable. It's also best-effort and seconds-delayed — so always close explicitly to free the server promptly.
 
 The two cases you'll hit most. **A `channel` you `listen()` on** — close it on unmount:
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -124,11 +124,18 @@ There's one catch-all API, `close()`, plus several per-type APIs.
 
 ### When to close
 
-Whether you need to close by hand comes down to reachability. Some values close on their own:
-- A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
-- A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
+Whether you need to close by hand comes down to **reachability**. A value that **finishes** (runs to completion) or that you **drop entirely** closes itself — the latter via garbage collection a few seconds later (firing the server's `onClose()`), so close it yourself to release promptly. A value you **keep reachable** can't be garbage-collected, so you must end it:
 
-Two things stay open until you end them yourself. A `channel` you `listen()` on — the listener keeps it reachable, so GC won't close it; close it on unmount:
+| Value | Closes itself when… | You **must** close it when… | How |
+|---|---|---|---|
+| `AsyncGenerator` | run to completion, or dropped (GC) | you stop a running `for await` early (incl. endless streams) | `break` (auto-calls `return()`), `gen.return()`, `await using`, or `close(gen)` |
+| `ReadableStream` | read to the end, or dropped (GC) | you stop reading a still-open stream early | `reader.cancel()`, `break` a `for await`, or `close(stream)` |
+| `Channel` / `BroadcastChannel` | the server ends it, or you drop it with **no** listener (GC) | you `listen()` on one that stays open — the listener keeps it reachable, so GC never reclaims it | `channel.close()` (graceful) or `channel.abort()` (immediate) |
+| `File` / `Blob` / streamed `Promise` / download | awaited or consumed, or dropped (GC) | rarely — only a partial **download** you keep but don't finish | `close(value)`, or download `.cancel()` |
+
+To cancel a call and **every** stream/channel it opened at once — immediately, without waiting for a graceful close — use `abort(call)` or `withContext(fn, { signal })`; `close(value)` closes everything nested in a return value. (See the close-API table above.)
+
+The two cases you'll hit most. **A `channel` you `listen()` on** — close it on unmount:
 
 ```tsx
 // Chat.tsx

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -128,30 +128,32 @@ You usually don't need to close manually, as streams often close automatically:
 - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
 - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
 
-Two things stay open until you end them yourself. A long-lived `channel` you hold a reference to — close it on unmount:
+Two things stay open until you end them yourself. A long-lived `channel` — close it on unmount:
 
 ```tsx
 // Chat.tsx
 // Environment: client
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { onChat } from './Chat.telefunc'
 
 function Chat() {
-  const channelRef = useRef()
   const [messages, setMessages] = useState<string[]>([])
 
   useEffect(() => {
-    onChat().then(({ channel }) => {
-      channelRef.current = channel
+    let channel
+    onChat().then((result) => {
+      channel = result.channel
       channel.listen((msg) => setMessages((prev) => [...prev, msg]))
     })
-    return () => channelRef.current?.close() // close on unmount
+    return () => channel?.close() // close on unmount
   }, [])
 
   return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
 }
 ```
+
+> A `ref` is only needed when something *outside* the effect touches the channel — e.g. a "send" button handler calling `channel.send()`. For listen-and-close, the effect's own closure is enough.
 
 And a stream you're still consuming in a **`for await` loop** — the running loop keeps it reachable, so end it (e.g. when a React component unmounts):
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -142,10 +142,11 @@ function Chat() {
 
   useEffect(() => {
     let channel
-    onChat().then((result) => {
+    ;(async () => {
+      const result = await onChat()
       channel = result.channel
       channel.listen((msg) => setMessages((prev) => [...prev, msg]))
-    })
+    })()
     return () => channel?.close() // close on unmount
   }, [])
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -158,7 +158,7 @@ function Chat() {
 }
 ```
 
-> **No `ref` needed** — the effect's own closure already reaches the channel (a `ref` is only for access *outside* the effect, e.g. a "send" button calling `channel.send()`). The **`unmounted` flag** guards the async gap: `onChat()` resolves later, so without it, unmounting *during* the handshake — which React StrictMode does on every mount — would open a channel after cleanup ran and never close it.
+> **No `ref` needed** — the effect's own closure already reaches the channel (a `ref` is only for access *outside* the effect, e.g. a "send" button calling `channel.send()`). The **`unmounted` flag** handles the async gap: if you unmount mid-handshake (React StrictMode does this on every mount), `onChat()` resolves *after* cleanup ran, opening a channel that never gets closed — and since it's still listening, GC won't reclaim it either, so it leaks (client *and* server) until you close it.
 
 And a stream you're still consuming in a **`for await` loop** — the running loop keeps it reachable, so end it (e.g. when a React component unmounts):
 

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -105,7 +105,7 @@ export async function onLoad() {
 
 You can (and sometimes should) manually close the telefunction call/<Link href="/stream">stream</Link> via `close()` (graceful) or `abort()` (immediate), and more.
 
-> **Do I need to close manually?** TODO/ai single sentence TLDR, with link to setion below
+> **Do I need to close manually?** Usually not — a stream that finishes, or that you stop referencing, closes itself; close manually mainly to release resources **promptly**, or to end a long-lived stream you keep consuming (<Link href="#when-to-close" text="when to close" />).
 
 There's one catch-all API, `close()`, plus several per-type APIs.
 
@@ -128,31 +128,33 @@ You usually don't need to close manually, as streams often close automatically:
 - A value that **finishes on its own** — an `AsyncGenerator` iterated to completion, a `ReadableStream` read to the end — closes automatically.
 - A value you **stop referencing entirely** is garbage-collected a few seconds later, which closes it too (firing the server's `onClose()`).
 
-TODO/ai: remove following (which is kinda obvious I think), with a `channel` that automatically GC's?
+A `channel` is the interesting case — it's callback-based, so nothing keeps it alive on its own; drop it and GC closes it, no cleanup function required:
 
 ```tsx
-// Greeting.tsx
+// Chat.tsx
 // Environment: client
 
-import { useEffect, useState } from 'react'
-import { onGreeting } from './Greeting.telefunc'
+import { useEffect, useRef, useState } from 'react'
+import { onChat } from './Chat.telefunc'
 
-function Greeting() {
-  const [text, setText] = useState('')
+function Chat() {
+  const channelRef = useRef()
+  const [messages, setMessages] = useState<string[]>([])
 
   useEffect(() => {
-    ;(async () => {
-      for await (const word of onGreeting()) setText((t) => t + word)
-    })()
-    // ✅ No cleanup needed — onGreeting() yields a few words then returns, so the
-    //    generator completes on its own, which closes the stream (fires onClose()).
+    onChat().then(({ channel }) => {
+      channelRef.current = channel // keep a reference, else GC closes it while still mounted
+      channel.listen((msg) => setMessages((prev) => [...prev, msg]))
+    })
+    // ✅ No close() — on unmount the ref drops and GC closes the channel a few
+    //    seconds later (fires onClose()). Close it in a cleanup to release promptly.
   }, [])
 
-  return <p>{text}</p>
+  return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
 }
 ```
 
-The exception is a **long-lived stream you keep consuming**: an active `for await` loop keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
+The exception is a stream you consume with a **`for await` loop**: unlike the channel above, the running loop keeps the value reachable, so GC never reclaims it on its own — you have to end it. For example, stop it when a React component unmounts:
 
 ```tsx
 // Clock.tsx
@@ -177,8 +179,6 @@ function Clock() {
   return <p>{n}</p>
 }
 ```
-
-> **A `channel` is different.** It's callback-based (`channel.listen(cb)`), so no consuming loop pins it: dropping the channel on unmount lets GC close it within a few seconds. You don't strictly *need* a cleanup — but call `channel.close()` in one anyway to release **promptly**, otherwise `listen()` keeps firing (and the server keeps the channel open) until GC catches up. You *must* close explicitly only if the channel stays reachable past the component — e.g. stored in a `ref` or a module variable.
 
 Closing manually also releases resources **promptly**, instead of waiting for GC.
 


### PR DESCRIPTION
## What

Resolves the two `TODO/ai` markers in a07f8a7 on the `/onClose` page:

1. **TL;DR** — filled in the "Do I need to close manually?" blockquote with a one-sentence answer + a link to the `#when-to-close` section.

2. **"channel that automatically GC's"** — replaced the (admittedly obvious) self-completing-stream `Greeting` example with a **channel** example that demonstrates GC auto-close on unmount. Also dropped the now-redundant channel callout (the example covers it) and sharpened the for-await-loop-vs-channel contrast.

## ⚠️ The footgun this example has to encode

A channel auto-GCs because nothing pins it — but that **cuts both ways**, and the example has to account for it:

- The client gets a GC-registered **wrapper**; `ClientChannel` registers *itself* with the connection (`channel.ts:120`), so the connection holds the **internal** channel, not the wrapper (`connection.ts:283`).
- `channel.listen(cb)` registers `cb` on the internal channel — it does **not** keep the wrapper alive. `wrapProxy`'s `keepWrapperAlive` only pins the wrapper while you retain a *derived* object (the `listen()` unsubscribe), or the channel itself.
- So a fire-and-forget `channel.listen(cb)` with **no retained reference would be GC-closed while still mounted** — the stream dies mid-use.

That's why the example holds the channel in a `useRef` (keeps it alive while mounted) and lets GC close it when the ref drops on unmount. The inline comment flags it: `// keep a reference, else GC closes it while still mounted`.

## A heads-up / open question

This is an accurate "no cleanup function" example, but relying on GC has real downsides the docs now imply but don't dwell on: it's **not prompt** (a few-second window where the server keeps the channel open and `listen()` can fire after unmount), and the required `useRef` dance is subtle. The genuinely *recommended* pattern is still to `channel.close()` in a cleanup.

So: happy to keep this as-is (it's what the TODO asked for), but if you'd rather not showcase GC-reliance as the headline pattern, I can either (a) restore the footgun-free self-completing-stream example, or (b) flip this to the close-in-cleanup pattern with GC mentioned as the backstop. Your call.

## Verification

- `node docs/check-docs.mjs` → ✓ `51 pages, 86 internal anchor links — all resolve.`
- Behavior traced through `wire-protocol/client/channel.ts`, `connection.ts`, `response/parse.ts`, `wrapProxy.ts`, `gcRegistry.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6)_