### PR TITLE
docs: move stream cleanup into /stream, make /onClose an API page

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -1,61 +1,31 @@
-import { Link, Warning } from '@brillout/docpress'
+import { Link } from '@brillout/docpress'
 import { TelefuncStreamBeta } from '../../components'
+
+<TelefuncStreamBeta />
 
 **Environment**: server & client.
 
-The `onClose()` hook (defined on <Link href="/getContext">`context`</Link>) enables the server to clean up long-lived resources.
-
-```ts
-// Counter.telefunc.ts
-// Environment: server
-
-import { getContext } from 'telefunc'
-
-export async function onInit(onTick: (n: number) => void) {
-  const context = getContext()
-  let n = 0
-  const interval = setInterval(() => onTick(++n), 1000)
-  context.onClose(() => {
-    // ⚠️ Must be released otherwise it runs forever (memory leak)
-    clearInterval(interval)
-  })
-}
-```
-
-<Warning>
-**To avoid memory leaks, make sure to always:**
-- **Release resources**: any resource a telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the telefunction call and leaks unless you release it.
-- **Close long-lived Telefunc streams**: an open-end <Link href="/stream">Telefunc stream</Link> stays open and leaks unless you close it.
-</Warning>
-
-You can use `onClose()`, an abort `signal` ([`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)), and more methods, see:
-- <Link href="#listening" />
-
-You can close Telefunc streams via `close()` and other methods, see:
-- <Link href="#closing" />
+The API for listening to and closing Telefunc <Link href="/stream">streams</Link>. For when and why streams need cleanup, see <Link text="Cleanup" href="/stream#cleanup" />.
 
 
 ## Listening
 
 **Environment**: server.
 
-On the server-side, you can listen when a <Link href="/stream">Telefunc stream</Link> closes for:
-- Releasing resources
-- Cancel in-flight work
+Run a callback when a stream closes — to release resources or cancel in-flight work.
 
-| API | Side
-|---|---
-| `context.onClose(cb)` | server
-| `context.signal` | server
-| <Link text={<code>channel.onClose(cb)</code>} href="/channel#lifecycle" /> | client & server
-| <Link text={<code>channel.onOpen(cb)</code>} href="/channel#lifecycle" /> | client & server
+| API | Side | Fires when |
+|---|---|---|
+| `context.onClose(cb)` | server | the call/stream closes |
+| `context.signal` | server | the call/stream closes — as an `AbortSignal` |
+| <Link text={<code>channel.onClose(cb)</code>} href="/channel#lifecycle" /> | client & server | a `Channel` / `BroadcastChannel` closes |
+| <Link text={<code>channel.onOpen(cb)</code>} href="/channel#lifecycle" /> | client & server | a `Channel` / `BroadcastChannel` opens |
 
-> The listeners are fired regardless of the closing reason — whether all returned values are consumed, the client manually closed, the client disconnected, or an error occurred.
+> The listeners fire regardless of the closing reason — whether the returned values are consumed, the client manually closed, the client disconnected, or an error occurred.
 
+### `context.onClose(cb)` {#onclose}
 
-### `onClose()`
-
-The <Link href="/getContext">`context` object</Link> includes `onClose()`:
+From <Link text="getContext()" href="/getContext" />:
 
 ```ts
 // AiChat.telefunc.ts
@@ -75,13 +45,9 @@ export async function* onAiPrompt(prompt: string) {
 }
 ```
 
-### `signal`
+### `context.signal` {#signal}
 
-The <Link href="/getContext">`context` object</Link> includes a `signal` (`AbortSignal`) that aborts when the telefunction call closes.
-
-> The `signal` fires at the same time as `onClose()`.
-
-Pass it to any API that accepts an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) (`fetch()`, database clients, etc.) to cancel in-flight work:
+An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that aborts when the call closes — it fires at the same time as `onClose()`. Pass it to any `AbortSignal`-aware API (`fetch()`, database clients, etc.) to cancel in-flight work:
 
 ```ts
 // SomeComponent.telefunc.ts
@@ -91,11 +57,8 @@ import { getContext } from 'telefunc'
 
 export async function onLoad() {
   const { signal } = getContext()
-  const response = await fetch(
-    'https://api.example.com/data',
-    // Cancel the request, e.g. when the client disconnects
-    { signal }
-  )
+  // Cancel the request, e.g. when the client disconnects
+  const response = await fetch('https://api.example.com/data', { signal })
   return response.json()
 }
 ```
@@ -103,86 +66,9 @@ export async function onLoad() {
 
 ## Closing
 
-**Environment**: client & server.
+**Environment**: client.
 
-Make sure to close open-end <Link href="/stream">Telefunc streams</Link> — either the stream automatically ends or you must manually close it:
-
-<Warning>
-  Make sure Telefunc streams always come to an end.
-</Warning>
-
-> A stream can close on one of its two ends: either the server or the client ends it.
-
-TODO/ai:
- - Create table
- - Add links to /stream primitive sections
-
-- It naturally ends (a `ReadableStream` ends, a `async function*` finishes, all concurrent promises resolve) => automatic
-- The client disconnected (the user closes his browser tab) => automatic
-- `Channel` => you must manually close it
-- Callbacks => you must manually close it
-
-### When to close
-
-| Value | Closes server-side when… | You close it (client-side) when… | How |
-|---|---|---|---|
-| `AsyncGenerator` | it returns — the `for await` runs to completion | it's endless, or you stop iterating early | `break` (auto-calls `return()`), `gen.return()`, `await using`, or `close(gen)` |
-| `ReadableStream` | it's read to the end | you stop reading before the end | `reader.cancel()`, `break` a `for await`, or `close(stream)` |
-| `Channel` / `BroadcastChannel` | the server ends it | it stays open and you `listen()` on it | `channel.close()` (graceful) or `channel.abort()` (immediate) |
-| `File` / `Blob` / streamed `Promise` / download | it resolves — you `await` it | ≈ never (just `await` it; or cancel a download) | `close(value)` / download `.cancel()` |
-
-In a component, the two cases you'll hit are a **`channel` you `listen()` on** and a **`for await` loop** — close both on unmount:
-
-```tsx
-// Chat.tsx
-// Environment: client
-
-import { useEffect, useState } from 'react'
-import { onChat } from './Chat.telefunc'
-
-function Chat() {
-  const [messages, setMessages] = useState<string[]>([])
-
-  useEffect(() => {
-    const open = onChat() // Promise<{ channel }>
-    open.then(({ channel }) =>
-      channel.listen((msg) => setMessages((prev) => [...prev, msg])))
-    return () => {
-      open.then(({ channel }) => channel.close()) // close on unmount
-    }
-  }, [])
-
-  return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
-}
-```
-
-> Reusing the `open` promise for both the listener and the cleanup closes the channel even if the handshake hasn't resolved by unmount — no `ref` or flag needed.
-
-```tsx
-// Clock.tsx
-// Environment: client
-
-import { useEffect, useState } from 'react'
-import { onClock } from './Clock.telefunc'
-
-function Clock() {
-  const [n, setN] = useState(0)
-
-  useEffect(() => {
-    const clock = onClock() // long-lived AsyncGenerator
-    ;(async () => {
-      for await (const tick of clock) setN(tick)
-    })()
-    return () => void clock.return() // a running loop won't stop on its own
-  }, [])
-
-  return <p>{n}</p>
-}
-```
-
-### How to close
-
-There's one catch-all API, `close()`, plus several per-type APIs.
+End a stream. `close()` is the catch-all; the rest are per-type.
 
 | API | Side | Graceful / immediate | Closes |
 |---|---|---|---|
@@ -195,12 +81,13 @@ There's one catch-all API, `close()`, plus several per-type APIs.
 | <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
 
 **Graceful**: flush buffered data, then close.  
-**Immediate**: cancel in-flight work.  
+**Immediate**: cancel in-flight work.
 
+The per-type APIs — `gen.return()` / `break`, `reader.cancel()`, `channel.close()` / `channel.abort()` — are shown in context in each <Link text="primitive's section" href="/stream#cleanup" />.
 
-### `close()`
+### `close(value)`
 
-`close()` from `telefunc/client` gracefully closes any value returned by a telefunction. In one call, it closes every stream, channel, and file nested anywhere in the return value.
+`close()` from `telefunc/client` gracefully closes any value returned by a telefunction — in one call, every stream, channel, and file nested anywhere in the return value:
 
 ```ts
 // Environment: client
@@ -210,26 +97,31 @@ import { onLoadDashboard } from './Dashboard.telefunc'
 
 const result = await onLoadDashboard()
 
-// Read what you need...
-const { value } = await result.stream.next()
-
-// Then close everything at once
-close(result)
+const { value } = await result.stream.next() // read what you need...
+close(result)                                // ...then close everything at once
 ```
 
-> To stop a call **immediately** instead of gracefully, pass the pending call to `abort()` — the request is cancelled, and the pending call rejects with an `Abort` error (or, if you're mid-stream, that error surfaces on the next read instead):
-> ```ts
-> // Environment: client
->
-> import { abort } from 'telefunc/client'
->
-> const call = onLoadDashboard()
-> abort(call) // cancels the in-flight call
-> ```
+### `abort(call)`
+
+`abort()` from `telefunc/client` ends a call **immediately** instead of gracefully — the request is cancelled, and the pending call rejects with an `Abort` error (or, if you're mid-stream, that error surfaces on the next read instead):
+
+```ts
+// Environment: client
+
+import { abort } from 'telefunc/client'
+import { onLoadDashboard } from './Dashboard.telefunc'
+
+const call = onLoadDashboard()
+abort(call) // cancels the in-flight call
+```
+
+To abort via an `AbortSignal` instead, use <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" />.
 
 
 ## See also
 
+- <Link text="Cleanup — the guide" href="/stream#cleanup" />
 - <Link href="/stream" />
-- <Link href="/channel" />
+- <Link href="/channel#lifecycle" />
+- <Link href="/withContext" />
 - <Link href="/getContext" />

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -423,7 +423,7 @@ This is the low-level primitive; most apps reach for a higher-level integration 
 
 ### Cleanup {#channel-cleanup}
 
-A channel stays open until you close it. From the client, `channel.close()` (graceful) or `channel.abort()` (immediate). For example, on unmount:
+A channel doesn't end on its own. Close it from the client with `channel.close()` (graceful) or `channel.abort()` (immediate). For example, on unmount:
 
 ```tsx
 // Chat.tsx
@@ -453,7 +453,7 @@ function Chat() {
 
 ## Cleanup {#cleanup}
 
-A stream stays open until it ends. Either the **server** ends it — the value finishes, or the client disconnects — or **you** close it from the client. If neither happens, the stream leaks.
+An open stream holds resources on the server. It closes automatically when the value finishes or the client disconnects. Otherwise, you must close it from the client — or it leaks.
 
 | Primitive | Ends on its own when | Close it yourself with |
 |---|---|---|

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -137,6 +137,32 @@ for await (const n of onCountdown(3)) {
 }
 ```
 
+**Cleanup** — a generator ends on its own when it returns (the `for await` runs to completion). For an endless one, `break` out of the loop (which calls `return()` for you) or `gen.return()` it — for example, on React unmount:
+
+```tsx
+// Clock.tsx
+// Environment: client
+
+import { useEffect, useState } from 'react'
+import { onClock } from './Clock.telefunc'
+
+function Clock() {
+  const [n, setN] = useState(0)
+
+  useEffect(() => {
+    const clock = onClock() // long-lived AsyncGenerator
+    ;(async () => {
+      for await (const tick of clock) setN(tick)
+    })()
+    return () => void clock.return() // a running loop won't stop on its own
+  }, [])
+
+  return <p>{n}</p>
+}
+```
+
+On the server, release resources in `onClose()` — see <Link href="#cleanup" />.
+
 
 ## Primitive: `function` passing (callbacks) {#function-passing}
 
@@ -167,6 +193,8 @@ await onUpload(file, (percent) => setProgress(percent))
 ```
 
 If you only need callback-style interaction, function passing is simpler than a channel.
+
+**Cleanup** — the client calls the returned `unsubscribe()` when it's done; if the client disconnects first, the server's `onClose()` fires. See <Link href="#cleanup" />.
 
 
 ## Primitive: Concurrent `Promise` {#concurrent-promise}
@@ -224,6 +252,8 @@ const report = await res.report
 >   }
 > }
 > ```
+
+**Cleanup** — nothing to close: each promise resolves once, then it's done. See <Link href="#cleanup" />.
 
 
 ## Primitive: `ReadableStream` {#readable-stream}
@@ -339,6 +369,8 @@ export function onCompressVideo(video: ReadableStream<Uint8Array>): ReadableStre
 
 > A spawned process outlives the call and keeps burning CPU if the client navigates away mid-encode — so it's released in `onClose()`. See <Link text="Cleanup" href="#cleanup" />.
 
+**Cleanup** — a `ReadableStream` ends when it's read to the end; to stop early, `reader.cancel()` it (or `break` a `for await`). The server releases the source in `onClose()` — as the encoder is killed above.
+
 
 ## Primitive: `Channel` {#channel}
 
@@ -381,10 +413,53 @@ channel.listen((metrics) => updateCharts(metrics))
 
 This is the low-level primitive; most apps reach for a higher-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> instead. For the full API — typed messages, acknowledgements, binary, broadcast, and reconnection — see <Link href="/channel" />. Authorizing a channel works like any streaming primitive — see <Link text="Authorization" href="#authorization" /> below.
 
+**Cleanup** — a channel stays open until it's closed; it won't end on its own. From the client, `channel.close()` (graceful) or `channel.abort()` (immediate) — for example, on unmount:
+
+```tsx
+// Chat.tsx
+// Environment: client
+
+import { useEffect, useState } from 'react'
+import { onChat } from './Chat.telefunc'
+
+function Chat() {
+  const [messages, setMessages] = useState<string[]>([])
+
+  useEffect(() => {
+    const open = onChat() // Promise<{ channel }>
+    open.then(({ channel }) =>
+      channel.listen((msg) => setMessages((prev) => [...prev, msg])))
+    return () => {
+      open.then(({ channel }) => channel.close()) // close on unmount
+    }
+  }, [])
+
+  return <ul>{messages.map((m, i) => <li key={i}>{m}</li>)}</ul>
+}
+```
+
+> Reusing the `open` promise for both the listener and the cleanup closes the channel even if the handshake hasn't resolved by unmount — no `ref` or flag needed.
+
+On the server, release resources in `channel.onClose()` — as with `clearInterval` above. See <Link href="#cleanup" /> and <Link href="/channel#lifecycle" />.
+
 
 ## Cleanup
 
-Every streaming value eventually ends — the client finishes reading it, calls <Link text={<code>close()</code>} href="/onClose" />, navigates away, or the connection drops for good. However it ends, the server's `onClose()` hook fires so you can release whatever the telefunction opened. Get it from <Link text="getContext()" href="/getContext" />:
+Every stream must come to an end — otherwise it leaks. It ends on **one of two ends**: the **server** ends it (the value finishes, or the client disconnects), or **you** end it from the client.
+
+| Primitive | Ends on its own when | Close it yourself with |
+|---|---|---|
+| <Link text={<code>AsyncGenerator</code>} href="#async-generator" /> | it finishes (consumed to the end) | `break` / `gen.return()` (endless ones) |
+| <Link text={<code>ReadableStream</code>} href="#readable-stream" /> | it's read to the end | `reader.cancel()` |
+| <Link text="Concurrent Promise" href="#concurrent-promise" /> | all promises resolve | — |
+| <Link text="Callbacks" href="#function-passing" /> | — | the returned `unsubscribe()` |
+| <Link text={<code>Channel</code>} href="#channel" /> | the server closes it | `channel.close()` / `channel.abort()` |
+
+A full client **disconnect** (the user closes the tab) ends everything automatically. To close from the client, use each primitive's method above — or the catch-all <Link text={<code>close(value)</code>} href="/onClose#closing" />, which closes every stream nested in a return value at once. For the complete closing and listening API, see <Link href="/onClose" />.
+
+### Releasing server resources
+
+However a stream ends, the server's `onClose()` hook fires so you can release whatever the telefunction opened. Get it from <Link text="getContext()" href="/getContext" />:
 
 ```ts
 // AiChat.telefunc.ts
@@ -408,13 +483,7 @@ export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
 
 > **Pitfall** — anything a long-lived telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the call and **leaks** unless you release it in `onClose()`. If you set it up, tear it down.
 
-<Link text="Channels" href="#channel" /> and broadcasts expose `onClose()` (and `onOpen()`) directly on the instance — e.g. `dashboard.onClose(() => clearInterval(interval))` in the <Link text="Channel example" href="#channel" /> above. See <Link href="/channel#lifecycle" />.
-
-From the client, end a stream early with <Link text={<code>close()</code>} href="/onClose" /> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel. Even if you drop every reference without closing, Telefunc still cleans up automatically via garbage collection a few seconds later.
-
-See also:
-- <Link href="/onClose" />
-- <Link href="/channel#lifecycle" />
+<Link text="Channels" href="#channel" /> and broadcasts expose `onClose()` (and `onOpen()`) directly on the instance — e.g. `dashboard.onClose(() => clearInterval(interval))` in the <Link text="Channel example" href="#channel" /> above. See <Link href="/channel#lifecycle" /> and the full <Link text="onClose() API" href="/onClose" />.
 
 
 ## Authorization

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -137,7 +137,9 @@ for await (const n of onCountdown(3)) {
 }
 ```
 
-**Cleanup** — a generator ends on its own when it returns (the `for await` runs to completion). For an endless one, `break` out of the loop (which calls `return()` for you) or `gen.return()` it — for example, on React unmount:
+### Cleanup {#async-generator-cleanup}
+
+An `AsyncGenerator` ends when it returns. To stop it early, `break` out of the `for await` loop, or call `gen.return()`. For example, on unmount:
 
 ```tsx
 // Clock.tsx
@@ -194,7 +196,9 @@ await onUpload(file, (percent) => setProgress(percent))
 
 If you only need callback-style interaction, function passing is simpler than a channel.
 
-**Cleanup** — the client calls the returned `unsubscribe()` when it's done; if the client disconnects first, the server's `onClose()` fires. See <Link href="#cleanup" />.
+### Cleanup {#function-passing-cleanup}
+
+Return an `unsubscribe()` function (as above) and call it from the client when you're done. The server's `onClose()` also fires if the client disconnects first.
 
 
 ## Primitive: Concurrent `Promise` {#concurrent-promise}
@@ -253,7 +257,9 @@ const report = await res.report
 > }
 > ```
 
-**Cleanup** — nothing to close: each promise resolves once, then it's done. See <Link href="#cleanup" />.
+### Cleanup {#concurrent-promise-cleanup}
+
+Usually nothing to do — each `Promise` resolves once, then it's done. To cancel them before they resolve, close the call with <Link text={<code>close()</code>} href="/onClose#closing" />.
 
 
 ## Primitive: `ReadableStream` {#readable-stream}
@@ -369,7 +375,9 @@ export function onCompressVideo(video: ReadableStream<Uint8Array>): ReadableStre
 
 > A spawned process outlives the call and keeps burning CPU if the client navigates away mid-encode — so it's released in `onClose()`. See <Link text="Cleanup" href="#cleanup" />.
 
-**Cleanup** — a `ReadableStream` ends when it's read to the end; to stop early, `reader.cancel()` it (or `break` a `for await`). The server releases the source in `onClose()` — as the encoder is killed above.
+### Cleanup {#readable-stream-cleanup}
+
+A `ReadableStream` ends when it's read to completion. To stop early, `reader.cancel()` it, or `break` a `for await` loop.
 
 
 ## Primitive: `Channel` {#channel}
@@ -413,7 +421,9 @@ channel.listen((metrics) => updateCharts(metrics))
 
 This is the low-level primitive; most apps reach for a higher-level integration like <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> instead. For the full API — typed messages, acknowledgements, binary, broadcast, and reconnection — see <Link href="/channel" />. Authorizing a channel works like any streaming primitive — see <Link text="Authorization" href="#authorization" /> below.
 
-**Cleanup** — a channel stays open until it's closed; it won't end on its own. From the client, `channel.close()` (graceful) or `channel.abort()` (immediate) — for example, on unmount:
+### Cleanup {#channel-cleanup}
+
+A channel stays open until you close it. From the client, `channel.close()` (graceful) or `channel.abort()` (immediate). For example, on unmount:
 
 ```tsx
 // Chat.tsx
@@ -438,24 +448,22 @@ function Chat() {
 }
 ```
 
-> Reusing the `open` promise for both the listener and the cleanup closes the channel even if the handshake hasn't resolved by unmount — no `ref` or flag needed.
-
-On the server, release resources in `channel.onClose()` — as with `clearInterval` above. See <Link href="#cleanup" /> and <Link href="/channel#lifecycle" />.
+> Reusing the `open` promise for both the listener and the cleanup closes the channel even if the handshake hasn't resolved by unmount.
 
 
-## Cleanup
+## Cleanup {#cleanup}
 
-Every stream must come to an end — otherwise it leaks. It ends on **one of two ends**: the **server** ends it (the value finishes, or the client disconnects), or **you** end it from the client.
+A stream stays open until it ends. Either the **server** ends it — the value finishes, or the client disconnects — or **you** close it from the client. If neither happens, the stream leaks.
 
 | Primitive | Ends on its own when | Close it yourself with |
 |---|---|---|
-| <Link text={<code>AsyncGenerator</code>} href="#async-generator" /> | it finishes (consumed to the end) | `break` / `gen.return()` (endless ones) |
+| <Link text={<code>AsyncGenerator</code>} href="#async-generator" /> | it returns | `break` / `gen.return()` |
 | <Link text={<code>ReadableStream</code>} href="#readable-stream" /> | it's read to the end | `reader.cancel()` |
-| <Link text="Concurrent Promise" href="#concurrent-promise" /> | all promises resolve | — |
+| <Link text="Concurrent Promise" href="#concurrent-promise" /> | all promises resolve | `close()` to cancel early |
 | <Link text="Callbacks" href="#function-passing" /> | — | the returned `unsubscribe()` |
 | <Link text={<code>Channel</code>} href="#channel" /> | the server closes it | `channel.close()` / `channel.abort()` |
 
-A full client **disconnect** (the user closes the tab) ends everything automatically. To close from the client, use each primitive's method above — or the catch-all <Link text={<code>close(value)</code>} href="/onClose#closing" />, which closes every stream nested in a return value at once. For the complete closing and listening API, see <Link href="/onClose" />.
+A client disconnect — the user closing the tab — ends everything. To close from the client, use the per-primitive method above, or <Link text={<code>close(value)</code>} href="/onClose#closing" /> to close everything a telefunction returned in one call. For the full API, see <Link href="/onClose" />.
 
 ### Releasing server resources
 


### PR DESCRIPTION
Restructures stream-cleanup docs so each page has one job, per the maintainer's TODO in `/onClose`.

### `/stream` (the guide)
- **Each primitive section now mentions cleanup** with its specific closing mechanism:
  - `#async-generator` — `break` / `gen.return()`; the **Clock** (for-await) example moved here from `/onClose`
  - `#function-passing` — the returned `unsubscribe()`
  - `#concurrent-promise` — nothing to close
  - `#readable-stream` — `reader.cancel()`
  - `#channel` — `channel.close()` / `channel.abort()`; the **Chat** (channel) example moved here from `/onClose`
- **`#cleanup` is now the high-level guide**: the two-ends principle, a per-primitive automatic-vs-manual table (each row linked to its section), the client-disconnect note, the `close(value)` catch-all pointer, and server-side resource release via `onClose()`. The garbage-collection claim is gone.

### `/onClose` (the API page)
Stripped of all high-level narrative (intro, Warning, when/why, React examples). It's now an exhaustive low-level API reference:
- **Listening** — `context.onClose(cb)`, `context.signal`, `channel.onClose/onOpen` (table + per-API detail)
- **Closing** — `close(value)`, `gen.return()`/`break`, `reader.cancel()`, `channel.close()`/`abort()`, `abort(call)`, `withContext(fn, { signal })` (table + per-API detail)

It links to `/stream#cleanup` for the guide; the per-type APIs link to each primitive's section.

### No redundancy
The close-API table lives only in `/onClose`; each React example appears exactly once; the three layers (in-context note → overview table → API reference) serve distinct purposes. `/onClose` shed ~110 lines.

`node docs/check-docs.mjs` passes (51 pages, 97 anchor links resolve) — including the `/getContext` links to `/onClose#onclose` and `#signal`, preserved with explicit anchor IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42xgbZLyKNFQkebJqtnd6)_