### PR TITLE
docs: rename stream primitive section headers

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -17,7 +17,7 @@ Telefunc has two real-time **primitives** — and one **composition** of them:
 
 <NeedsLongRunningServer />
 
-> For short-lived callbacks (e.g. progress updates), <Link href="/stream#function-passing">function passing</Link> is usually simpler.
+> For short-lived callbacks (e.g. progress updates), <Link href="/stream#callback">function passing</Link> is usually simpler.
 
 
 ## `new Channel()`

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -68,7 +68,7 @@ function FileUpload() {
 
 ## Upload with progress
 
-Combine file upload with <Link href="/stream#function-passing">function passing</Link> to report progress while the server reads the stream.
+Combine file upload with <Link href="/stream#callback">function passing</Link> to report progress while the server reads the stream.
 
 ```ts
 // Upload.telefunc.ts

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -35,7 +35,7 @@ On the server-side, you can listen when a <Link href="/stream">Telefunc stream</
 
 > The listeners are fired regardless of the closing reason — whether all streams finished, the client stops using the streams, the client manually closed, the client disconnected, or an error occurred.
 
-> Every stream eventually ends: at latest when the client disconnects (e.g the user navigates away from your website), but usually sooner when the client stops using the stream, the client manually closes the stream, the network connection is permanently lost (the network connction couldn't be recovered), or an error occured.
+> Every stream eventually ends: at latest when the client disconnects (e.g the user navigates away from your website), but usually sooner when the client stops using the stream, the client manually closes the stream, the network connection is permanently lost (the network connection couldn't be recovered), or an error occurred.
 
 
 ### `onClose()`

--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -136,7 +136,7 @@ function Chat() {
     const open = onChat() // Promise<{ channel }>
     open.then(({ channel }) => {
       channel.listen((msg) => setMessages((prev) => [...prev, msg]))
-    }
+    })
     // Optional:
     const clear = () => open.then(({ channel }) => channel.close())
     return clear

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -24,7 +24,7 @@ export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
 }
 ```
 
-<Link href="#function-passing" text={<><code>function</code> passing (callbacks)</>} />:
+<Link href="#callback" text={<>Callback (<code>function</code> passing)</>} />:
 ```ts
 // Notifications.telefunc.ts
 // Environment: server
@@ -37,7 +37,7 @@ export async function onSubscribe(onNotification: (text: string) => void) {
 }
 ```
 
-<Link href="#concurrent-promise" text={<>Concurrent <code>Promise</code></>} />:
+<Link href="#multiple-promise" text={<>Multiple <code>Promise</code></>} />:
 ```ts ts-only
 // Dashboard.telefunc.ts
 // Environment: server
@@ -138,8 +138,7 @@ for await (const n of onCountdown(3)) {
 ```
 
 
-{/* TODO/ai rename to `## Primitive: Callback (`function` passing) {#callback}` */}
-## Primitive: `function` passing (callbacks) {#function-passing}
+## Primitive: Callback (`function` passing) {#callback}
 
 Telefunc can pass functions between client and server:
 
@@ -170,8 +169,7 @@ await onUpload(file, (percent) => setProgress(percent))
 If you only need callback-style interaction, function passing is simpler than a channel.
 
 
-{/* TODO/ai rename to `## Primitive: Multiple `Promise` {#multiple-promise}` */}
-## Primitive: Concurrent `Promise` {#concurrent-promise}
+## Primitive: Multiple `Promise` {#multiple-promise}
 
 Put promises inside the response object **without awaiting them**. The client receives the rest of the object immediately, and each promise resolves on its own.
 
@@ -418,7 +416,7 @@ You can also use a `signal` (`AbortSignal) and `channel.onClose()` for listening
 
 ## Authorization
 
-A streaming telefunction authorizes like any other telefunction (see <Link href="/permissions" />): check <Link text="getContext()" href="/getContext" /> and `throw Abort()` **at open time**, before you stream anything back. Here the client passes a <Link text="callback" href="#function-passing" /> and the server calls it:
+A streaming telefunction authorizes like any other telefunction (see <Link href="/permissions" />): check <Link text="getContext()" href="/getContext" /> and `throw Abort()` **at open time**, before you stream anything back. Here the client passes a <Link text="callback" href="#callback" /> and the server calls it:
 
 ```ts
 // TeamFeed.telefunc.ts


### PR DESCRIPTION
## What

Implements the two `TODO/ai` items in `docs/pages/stream/+Page.mdx`, which asked to rename two "Primitive" section headers:

- `## Primitive: `function` passing (callbacks)` → `## Primitive: Callback (`function` passing)` (anchor `#function-passing` → `#callback`)
- `## Primitive: Concurrent `Promise`` → `## Primitive: Multiple `Promise`` (anchor `#concurrent-promise` → `#multiple-promise`)

## Changes

- Renamed both headers and their anchor IDs, and removed the `TODO/ai` comments.
- Updated the in-page table-of-contents `<Link>` labels and `href`s to match.
- Updated all cross-references to the changed anchors:
  - `docs/pages/stream/+Page.mdx` (the "open time" callback link)
  - `docs/pages/file-upload/+Page.mdx`
  - `docs/pages/channel/+Page.mdx`

No stale `#function-passing` / `#concurrent-promise` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHUFcCQZNTPUhwAdX6VJzf)_