### PR TITLE
docs: suggestions for the Telefunc Stream docs (PR #264)

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -25,7 +25,7 @@ You can close Telefunc streams via `close()` and other methods, see:
 
 On the server-side, you can listen when a <Link href="/stream">Telefunc stream</Link> closes for:
 - Releasing resources
-- Cancel in-flight work
+- Cancelling in-flight work
 
 | API | Side | Fires when|
 |---|---|---|
@@ -35,7 +35,7 @@ On the server-side, you can listen when a <Link href="/stream">Telefunc stream</
 
 > The listeners are fired regardless of the closing reason — whether all streams finished, the client stops using the streams, the client manually closed, the client disconnected, or an error occurred.
 
-> Every stream eventually ends: at latest when the client disconnects (e.g the user navigates away from your website), but usually sooner when the client stops using the stream, the client manually closes the stream, the network connection is permanently lost (the network connection couldn't be recovered), or an error occurred.
+> Every stream eventually ends: at latest when the client disconnects (e.g. the user navigates away from your website), but usually sooner when the client stops using the stream, the client manually closes the stream, the network connection is permanently lost (the network connection couldn't be recovered), or an error occurred.
 
 
 ### `onClose()`
@@ -118,7 +118,7 @@ A stream automatically closes itself when the client stops using it.
 
 You therefore usually don't have to manually close streams yourself.
 
-> That said, there is a short delay (typically a few seconds) between the client stops using the stream and the stream being closed. (Because the garbage collector doesn't always immediately clears unused objects.)
+> That said, there is a short delay (typically a few seconds) between when the client stops using the stream and when the stream is closed. (Because the garbage collector doesn't always immediately clear unused objects.)
 
 For example:
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -408,7 +408,7 @@ export async function onInit(onTick: (n: number) => void) {
 Any resource a telefunction opens (`setInterval`, an event subscription, a DB cursor, an upstream stream) outlives the telefunction call — **make sure you always clear resources when the stream closes**.
 </Warning>
 
-You can also use a `signal` (`AbortSignal) and `channel.onClose()` for listening when a stream closes, see:
+You can also use a `signal` (`AbortSignal`) and `channel.onClose()` to listen for when a stream closes, see:
 - <Link href="/onClose#listening" />
 
 > A stream automatically closes when the client stops using it — you usually don't have to manually close streams, see:


### PR DESCRIPTION
Suggestions to improve the streaming docs introduced by #264. I reviewed the new/changed pages: `stream`, `channel`, `onClose`, `transport`, `Telefunc`, `serve`, `withContext`, `provideTelefuncContext`, `file-download`, `file-upload`, `tanstack-query`, `rxjs`, `redis`, `testing`, `stream/scale`, `stream/cloudflare`, plus the new components.

Overall the docs are in great shape — consistent cross-linking, clean anchors (spot-checked `#provide`/`#access`, `#typescript-automatic`, the `/channel#…` anchors, the `httpHeaders → headers` redirect), and a coherent "primitives → integrations → DX" structure. The notes below are polish.

## Applied in this PR (safe, high-confidence)

- **`stream`** — unbalanced backtick: `` a `signal` (`AbortSignal) `` rendered as broken inline code (the opening `` ` `` before `AbortSignal` had no closing match). Fixed, and tidied the trailing "for listening when a stream closes" → "to listen for when a stream closes".
- **`onClose`** — three small fixes:
  - list parallelism: "Releasing resources / **Cancel** in-flight work" → "**Cancelling** in-flight work".
  - `e.g the user navigates away` → `e.g.` (missing period).
  - GC-delay note grammar: "between *the client stops* using the stream and the stream being closed … doesn't always immediately **clears**" → "between **when** the client stops … and **when** the stream is closed … doesn't always immediately **clear**".

## Further suggestions (left for you to decide)

1. **`onClose` — the two `AsyncGenerator` examples overlap.** Both blocks carry the identical `// AiChat.telefunc.ts` header and the same `onAiPrompt` signature; the first shows a bare `onClose(() => …)`, the second adds an `AbortController`. Consider merging them, or differentiating the second (e.g. a comment "// Same example, now cancelling the upstream request"), so a reader doesn't think one supersedes the other.

2. **Inconsistent `ai.streamText` pseudo-API.** It's awaited in some places (`const stream = await ai.streamText({ prompt })` in `stream`) and used directly as an async iterable in others (`for await (const message of ai.streamText({ prompt }))` in `onClose`). Picking one shape across pages avoids implying the helper behaves two different ways.

3. **`transport` — the `*Key: … ❌ none*` legend under "Channel transport"** lists ❌ but that table has no ❌ cells (it's reused verbatim from the Stream-transport table). Minor; could trim the legend for that table.

4. **`file-download` — the memory footnote (`†`) omits `dl.bytes()`.** The footnote enumerates `saveToMemory()` / `text()` / `arrayBuffer()` as the "full payload" consumers, but the Reading-strategies table also marks `dl.bytes()` as "Full file in memory". Adding `bytes()` to the footnote keeps the two consistent.

5. **`stream` — `onCompressVideo` leaves `video.pipeTo(...)` unhandled.** If the client aborts mid-encode, the un-awaited `pipeTo` promise rejects with no handler. The `onClose(() => ffmpeg.kill())` covers cleanup, but a one-line `.catch(() => {})` (or a comment noting the rejection is expected on abort) would keep the example from modelling an unhandled rejection.

Happy to fold any of these into this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015fW1sPTgJRf6QQHzvbeizK)_