### PR TITLE
docs(onClose): use canonical "Telefunc Stream" in /stream link

### DIFF
--- a/docs/pages/onClose/+Page.mdx
+++ b/docs/pages/onClose/+Page.mdx
@@ -23,7 +23,7 @@ You can close Telefunc streams via `close()` and other methods, see:
 
 **Environment**: server.
 
-On the server-side, you can listen when a <Link href="/stream">Telefunc stream</Link> closes for:
+On the server-side, you can listen when a <Link href="/stream">Telefunc Stream</Link> closes for:
 - Releasing resources
 - Cancelling in-flight work
 


### PR DESCRIPTION
## What

Applies the link-text normalization from commit a9b645d everywhere it was still missing.

Commit a9b645d replaced the periphrastic `<Link href="/stream">Telefunc's streaming capabilities</Link>` with the canonical brand name `<Link href="/stream">Telefunc Stream</Link>` on the stream/scale page. Sweeping the rest of the docs, every `<Link href="/stream">` feature reference already uses the capitalized **"Telefunc Stream"** — except one:

- `docs/pages/onClose/+Page.mdx` — a linked reference read `Telefunc stream` (lowercase). Now `Telefunc Stream`.

## Why

Consistent branding: every internal link to `/stream` that names the feature now reads "Telefunc Stream", matching `stream/scale`, `stream/cloudflare`, `serve`, and the `PoweredByTelefuncStream` / `TelefuncStreamBeta` components.

## Notes

Bare-prose, instance-level mentions of streams were intentionally left lowercase (e.g. `onClose` line 18, "close Telefunc streams via `close()`"), since they refer to individual stream instances rather than the named feature. The `streamed values` / `streaming primitive` link texts on the transport and shield pages were also left as-is — they describe data/primitives, not the feature name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014hjmDZzEU7fE2yg2b1ToKm)_