### PR TITLE
docs(stream): expand AsyncGenerator examples for short-lived streaming

### DIFF
--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -86,7 +86,15 @@ export function onCompress(data: ReadableStream<Uint8Array>): ReadableStream<Uin
 
 ## Primitive: `AsyncGenerator` (`function*`) {#async-generator}
 
-An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — the usual choice for structured values that arrive one piece at a time, such as AI tokens, notifications, or progress updates.
+An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — the natural choice for **short-lived streaming**: a finite sequence of values that arrive one at a time and then completes. For example:
+
+- AI tokens streaming from an LLM completion
+- Progress updates for a long-running task (upload, export, transcoding)
+- Search results streaming in as they're found
+- Rows of a large query or report, computed and sent one at a time
+- Log or build output lines from a single run
+
+> For **open-ended, long-lived** streams (live feeds, notifications, presence), reach for a <Link text={<code>Channel</code>} href="#channel" /> instead.
 
 Common use case:
 


### PR DESCRIPTION
## What

Fills in the `TODO: find more examples` in the `AsyncGenerator` (`function*`) section of the streaming docs (`docs/pages/stream/+Page.mdx`).

The section intro now frames `AsyncGenerator` around **short-lived streaming** — a finite sequence of values that arrive one at a time and then completes — and lists concrete use cases instead of just "AI tokens":

- AI tokens streaming from an LLM completion
- Progress updates for a long-running task (upload, export, transcoding)
- Search results streaming in as they're found
- Rows of a large query or report, computed and sent one at a time
- Log or build output lines from a single run

## Why

The previous one-liner ("AI tokens, notifications, or progress updates") under-sold the primitive and blurred the line with `Channel`. The examples chosen here are all genuinely finite/request-scoped, which is what `AsyncGenerator` is good at. A short callout now points readers to <code>Channel</code> for the open-ended, long-lived case (live feeds, notifications, presence), keeping the short-lived vs. long-lived distinction crisp and consistent with the rest of the page.

## Notes

- Docs-only change, no code touched.
- Uses the existing `<Link text={<code>...</code>} href=... />` JSX pattern already present elsewhere in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj

---
_Generated by [Claude Code](https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj)_