### PR TITLE
docs: implement TODO/ai markers in channel & stream primitive lists

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -7,16 +7,17 @@ import { TelefuncStreamBeta, NeedsLongRunningServer } from '../../components'
 
 The following low-level **primitives** enable all kinds of stream use cases.
 
-{/* TODO/ai: add links */}
-{/* TODO/ai: dedupe this list and the note with the one at /stream */}
-- **`new Channel()`** — direct messages between one server and one client.
-- **`Broadcast`** — a keyed pub/sub bus (`publish()`/`subscribe()`), server-side.
-- **`new broadcastchannel()`** — broadcast also on the client-side.
+- <Link text={<code>new Channel()</code>} href="#new-channel" /> — direct messages between one server and one client.
+- <Link text={<code>Broadcast</code>} href="#broadcast" /> — a keyed pub/sub bus (`publish()`/`subscribe()`), server-side.
+- <Link text={<code>new BroadcastChannel()</code>} href="#new-broadcastchannel" /> — broadcast also on the client-side.
 
-> You can use them for both one-way (aka streaming) and two-way streams (aka real-time).
+> You can use them for both one-way (aka streaming) and two-way streams (aka real-time):
 > - Chat rooms
-> - Live feeds (e.g. live sports events)
-> - TODO/ai: find more example
+> - Live feeds (sports scores, stock tickers)
+> - Collaborative editing (presence & cursors)
+> - Multiplayer games
+> - Live dashboards & metrics
+> - Notifications & activity feeds
 
 `new Channel()` and `new BroadcastChannel()` are returned from a telefunction — they serialize into client-side objects automatically. `Broadcast` is a server-side API, so there's nothing to return.
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -387,16 +387,7 @@ export function onCompressVideo(video: ReadableStream<Uint8Array>): ReadableStre
 
 ## Primitive: `Channel` {#channel}
 
-For ongoing two-way and broadcast messaging, you can use:
-
-- **`new Channel()`** — direct messages between one server and one client.
-- **`Broadcast`** — a keyed pub/sub bus (`publish()`/`subscribe()`), server-side.
-- **`new broadcastchannel()`** — broadcast also on the client-side.
-
-> You can use them for both one-way (aka streaming) and two-way streams (aka real-time).
-> - Chat rooms
-> - Live feeds (e.g. live sports events)
-> - TODO/ai: find more example
+For ongoing two-way and broadcast messaging, you can use <Link text={<code>new Channel()</code>} href="/channel#new-channel" />, <Link text={<code>Broadcast</code>} href="/channel#broadcast" />, and <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" /> — for real-time use cases like chat rooms, live feeds, collaborative editing, and multiplayer games. See <Link href="/channel" /> for the full list and API.
 
 <NeedsLongRunningServer />
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -86,7 +86,15 @@ export function onCompress(data: ReadableStream<Uint8Array>): ReadableStream<Uin
 
 ## Primitive: `AsyncGenerator` (`function*`) {#async-generator}
 
-An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — the usual choice for structured values that arrive one piece at a time, such as AI tokens, notifications, or progress updates.
+An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — the natural choice for **short-lived streaming**: a finite sequence of values that arrive one at a time and then completes. For example:
+
+- AI tokens streaming from an LLM completion
+- Progress updates for a long-running task (upload, export, transcoding)
+- Search results streaming in as they're found
+- Rows of a large query or report, computed and sent one at a time
+- Log or build output lines from a single run
+
+> For **open-ended, long-lived** streams (live feeds, notifications, presence), reach for a <Link text={<code>Channel</code>} href="#channel" /> instead.
 
 Common use case:
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -86,7 +86,7 @@ export function onCompress(data: ReadableStream<Uint8Array>): ReadableStream<Uin
 
 ## Primitive: `AsyncGenerator` (`function*`) {#async-generator}
 
-An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — the natural choice for **short-lived streaming**: a finite sequence of values that arrive one at a time and then completes. For example:
+An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) returns an [`AsyncGenerator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) — a great fit for **short-lived streaming**: a sequence of values that arrive one at a time. For example:
 
 - AI tokens streaming from an LLM completion
 - Progress updates for a long-running task (upload, export, transcoding)
@@ -94,7 +94,9 @@ An [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 - Rows of a large query or report, computed and sent one at a time
 - Log or build output lines from a single run
 
-> For **open-ended, long-lived** streams (live feeds, notifications, presence), reach for a <Link text={<code>Channel</code>} href="#channel" /> instead.
+A generator **closes itself when it completes**: once it returns (the client's `for await` loop ends), Telefunc closes the stream automatically. A <Link text="callback" href="#callback" /> has no such completion signal — it stays open until the call closes, so you clean it up yourself (see <Link text="Cleanup" href="#cleanup" />).
+
+> Generators aren't limited to short streams — they can be <Link text="long-lived" href="/close" /> too. The dividing line with a <Link text={<code>Channel</code>} href="#channel" /> isn't lifetime but direction: a generator streams one way (server → client), whereas a channel is for **two-way or broadcast** messaging.
 
 Common use case:
 
@@ -102,8 +104,14 @@ Common use case:
 // AiChat.telefunc.ts
 // Environment: server
 
+import { getContext } from 'telefunc'
+
 export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
-  const stream = await ai.streamText({ prompt })
+  // `signal` aborts when the client stops the stream (e.g. the user presses "Stop"),
+  // cancelling the upstream AI request instead of letting it run on and burn tokens
+  const { signal } = getContext()
+
+  const stream = await ai.streamText({ prompt, signal })
   for await (const message of stream) {
     yield message
   }
@@ -117,10 +125,16 @@ export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
 import { onAiPrompt } from './AiChat.telefunc'
 
 const gen = onAiPrompt('Tell me a joke')
+
+// "Stop" button — close the stream early; this aborts the stream on the server
+stopButton.onclick = () => gen.return()
+
 for await (const message of gen) {
   console.log(message) // Each message arrives as it's yielded
 }
 ```
+
+> Pressing "Stop" closes the generator (`gen.return()`), which fires the server's `signal` and aborts the upstream AI request. To release resources that aren't an `AbortSignal` (timers, subscriptions, spawned processes), use <Link text={<code>onClose()</code>} href="#cleanup" /> instead.
 
 Simple example:
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -109,12 +109,11 @@ import { getContext } from 'telefunc'
 export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
   const { onClose } = getContext()
 
-  // When the client stops the stream (e.g. the user presses "Stop"), abort the
+  const { stream, cancel } = await ai(prompt)
+  // When the client stops the stream (e.g. the user presses "Stop"), cancel the
   // upstream AI request — otherwise it keeps running and burning tokens
-  const controller = new AbortController()
-  onClose(() => controller.abort())
+  onClose(cancel)
 
-  const stream = await ai.streamText({ prompt, signal: controller.signal })
   for await (const message of stream) {
     yield message
   }

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -107,11 +107,14 @@ Common use case:
 import { getContext } from 'telefunc'
 
 export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
-  // `signal` aborts when the client stops the stream (e.g. the user presses "Stop"),
-  // cancelling the upstream AI request instead of letting it run on and burn tokens
-  const { signal } = getContext()
+  const { onClose } = getContext()
 
-  const stream = await ai.streamText({ prompt, signal })
+  // When the client stops the stream (e.g. the user presses "Stop"), abort the
+  // upstream AI request — otherwise it keeps running and burning tokens
+  const controller = new AbortController()
+  onClose(() => controller.abort())
+
+  const stream = await ai.streamText({ prompt, signal: controller.signal })
   for await (const message of stream) {
     yield message
   }
@@ -126,7 +129,7 @@ import { onAiPrompt } from './AiChat.telefunc'
 
 const gen = onAiPrompt('Tell me a joke')
 
-// "Stop" button — close the stream early; this aborts the stream on the server
+// "Stop" button — close the stream early; this fires onClose() on the server
 stopButton.onclick = () => gen.return()
 
 for await (const message of gen) {
@@ -134,7 +137,7 @@ for await (const message of gen) {
 }
 ```
 
-> Pressing "Stop" closes the generator (`gen.return()`), which fires the server's `signal` and aborts the upstream AI request. To release resources that aren't an `AbortSignal` (timers, subscriptions, spawned processes), use <Link text={<code>onClose()</code>} href="#cleanup" /> instead.
+> Pressing "Stop" closes the generator (`gen.return()`), which fires `onClose()` on the server and aborts the upstream AI request. `onClose()` is the general-purpose cleanup hook — use it to release any resource (timers, subscriptions, spawned processes, ...) when the stream closes; see <Link text="Cleanup" href="#cleanup" />.
 
 Simple example:
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -9,8 +9,8 @@ Telefunc has two transport settings to control how messages are delivered:
 
 | Setting | Controls |
 |---|---|
-| `config.stream.transport` | <Link href="/stream">Streaming values</Link> (`AsyncGenerator`, `ReadableStream`, `Promise`) |
-| `config.channel.transports` | <Link text={<code>new Channel()</code>} href="/channel" /> (callbacks, <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />) |
+| `config.stream.transport` | <Link href="/stream">Streaming values</Link> (<Link text={<code>AsyncGenerator</code>} href="/stream#async-generator" />, <Link text={<code>ReadableStream</code>} href="/stream#readable-stream" />, <Link text={<code>Promise</code>} href="/stream#multiple-promise" />) |
+| `config.channel.transports` | <Link text={<code>new Channel()</code>} href="/channel" /> (<Link text="callbacks" href="/stream#callback" />, <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />) |
 
 These settings only affect <Link href="/stream">streams</Link> — plain telefunction calls are always `text/plain` JSON.
 


### PR DESCRIPTION
Implements the four `TODO/ai` markers across the Channel primitives docs.

## `docs/pages/channel/+Page.mdx`

- **`add links`** — each primitive in the intro list now links to its section on the page (`#new-channel`, `#broadcast`, `#new-broadcastchannel`). Also fixed the casing of `new broadcastchannel()` → `new BroadcastChannel()`.
- **`find more example`** — expanded the real-time use-case list (added collaborative editing, multiplayer games, live dashboards & metrics, notifications & activity feeds; refined "live feeds" with concrete examples).

## `docs/pages/stream/+Page.mdx`

- **`dedupe this list and the note with the one at /stream`** — the `Channel` section here repeated the same primitives list and use-case note verbatim. Since this section is a summary that already links to `/channel`, I replaced the duplicated list + note with a one-line pointer to `/channel` (keeping the unique Dashboard example below it). `/channel` is now the single source of truth.

## Notes

- Docs-only change, no code touched.
- Merged latest `nitedani/streaming` first; resolved an unrelated conflict in `transport/+Page.mdx` in favor of the base's latest wording (its table already includes my merged #399 links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj

---
_Generated by [Claude Code](https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj)_