### PR TITLE
feat(client): close() gracefully cancels in-flight uploads

### DIFF
--- a/packages/telefunc/client/remoteTelefunctionCall.ts
+++ b/packages/telefunc/client/remoteTelefunctionCall.ts
@@ -72,12 +72,25 @@ function remoteTelefunctionCall(
   objectAssign(callContext, { abortController })
 
   const { httpRequestBody, requestCloseHandlers } = serializeTelefunctionArguments(callContext)
-  objectAssign(callContext, { httpRequestBody, requestCloseHandlers })
+  const closeState = { gracefullyClosed: false }
+  objectAssign(callContext, { httpRequestBody, requestCloseHandlers, closeState })
+
+  // Gracefully cancel an in-flight request-streaming call (e.g. a file upload): close any
+  // request-side streams, then abort the request. `closeState.gracefullyClosed` tells
+  // makeHttpRequest to settle the call without an error — cancelling is an expected path.
+  const gracefulClose = () => {
+    closeState.gracefullyClosed = true
+    for (const closeHandler of requestCloseHandlers) void closeHandler()
+    abortController.abort()
+  }
 
   const telefunctionReturnPromise = makeHttpRequest(callContext)
 
   setAbortController(telefunctionReturnPromise, abortController)
-  addAsyncGeneratorInterface(telefunctionReturnPromise, abortController)
+  addAsyncGeneratorInterface(telefunctionReturnPromise, abortController, {
+    gracefulClose,
+    hasRequestStreams: requestCloseHandlers.length > 0,
+  })
 
   return telefunctionReturnPromise
 }

--- a/packages/telefunc/client/remoteTelefunctionCall/async-generator-interface.ts
+++ b/packages/telefunc/client/remoteTelefunctionCall/async-generator-interface.ts
@@ -8,7 +8,11 @@ import { setCloseHandlers } from '../close.js'
 
 /** Augment a promise with the AsyncGenerator interface
  *  so `for await...of` works directly without an intermediate `await`. */
-function addAsyncGeneratorInterface(promise: Promise<unknown>, abortController: AbortController) {
+function addAsyncGeneratorInterface(
+  promise: Promise<unknown>,
+  abortController: AbortController,
+  closeOptions: { gracefulClose: () => void; hasRequestStreams: boolean },
+) {
   // Single execution path: resolves to the real generator once the HTTP response is parsed.
   const resolvedGen: Promise<AsyncGenerator<unknown>> = (async () => {
     const returnValue = await promise
@@ -16,6 +20,19 @@ function addAsyncGeneratorInterface(promise: Promise<unknown>, abortController: 
     setAbortController(returnValue, abortController)
     return returnValue
   })()
+
+  // Track call settlement so close() picks the right strategy. While a request-streaming
+  // call (e.g. a file upload) is still in flight, close() gracefully cancels it by aborting
+  // the request; once the call has resolved to a generator, close() ends it via g.return().
+  let settled = false
+  void promise.then(
+    () => {
+      settled = true
+    },
+    () => {
+      settled = true
+    },
+  )
 
   // Register close handler synchronously so close(promise) works immediately,
   // even before the HTTP response arrives. The handler delegates to the real
@@ -25,7 +42,11 @@ function addAsyncGeneratorInterface(promise: Promise<unknown>, abortController: 
   resolvedGen.catch(() => {})
   const closeHandlers = new WeakMap<object, () => void>()
   closeHandlers.set(promise as object, () => {
-    void resolvedGen.then((g) => g.return(undefined))
+    if (!settled && closeOptions.hasRequestStreams) {
+      closeOptions.gracefulClose()
+    } else {
+      void resolvedGen.then((g) => g.return(undefined))
+    }
   })
   setCloseHandlers(promise, closeHandlers)
 

--- a/packages/telefunc/client/remoteTelefunctionCall/makeHttpRequest.ts
+++ b/packages/telefunc/client/remoteTelefunctionCall/makeHttpRequest.ts
@@ -35,6 +35,7 @@ async function makeHttpRequest(callContext: {
   abortController: AbortController
   channel: { transports: ChannelTransports }
   requestCloseHandlers: CloseHandler[]
+  closeState: { gracefullyClosed: boolean }
   extensionResponseTypes: ReviverType<TypeContract, ClientReviverContext>[]
   connectionKey?: string
   channelIdleTimeout?: number
@@ -63,6 +64,9 @@ async function makeHttpRequest(callContext: {
     })
   } catch (err) {
     if (callContext.abortController.signal.aborted) {
+      // Gracefully closed (e.g. the user cancelled an upload) — settle the call without
+      // an error: cancelling is an expected path, not a failure.
+      if (callContext.closeState.gracefullyClosed) return undefined
       throwAbortError(callContext.telefunctionName, callContext.telefuncFilePath, undefined)
     }
     throw new ConnectionError()

--- a/test/playground-stream/pages/abort/Abort.tsx
+++ b/test/playground-stream/pages/abort/Abort.tsx
@@ -244,9 +244,7 @@ function Abort() {
             const res = await promise
             setResult(JSON.stringify({ method: 'close(call)', resolved: true, result: res ?? null, error: null }))
           } catch (e: any) {
-            setResult(
-              JSON.stringify({ method: 'close(call)', resolved: false, error: e.message, isAbort: e instanceof TelefuncAbort }),
-            )
+            setResult(JSON.stringify({ method: 'close(call)', resolved: false, error: e.message }))
           }
         }}
       >

--- a/test/playground-stream/pages/abort/Abort.tsx
+++ b/test/playground-stream/pages/abort/Abort.tsx
@@ -8,7 +8,7 @@ import {
   onUploadAbortSingle,
   onUploadAbortMultiple,
 } from './Abort.telefunc'
-import { Abort as TelefuncAbort, abort, withContext } from 'telefunc/client'
+import { Abort as TelefuncAbort, abort, close, withContext } from 'telefunc/client'
 
 function Abort() {
   const [hydrated, setHydrated] = useState(false)
@@ -228,6 +228,29 @@ function Abort() {
         }}
       >
         Upload abort (multiple files)
+      </button>
+
+      <button
+        id="test-upload-close-graceful"
+        onClick={async () => {
+          setResult('')
+          // 1MB file; server reads slowly (sleep(100) between reads). close() mid-upload
+          // gracefully cancels: the call resolves (to undefined) instead of throwing.
+          const content = 'x'.repeat(1_000_000)
+          const file = new File([content], 'close-test.txt', { type: 'text/plain' })
+          const promise = onUploadAbortSingle(file)
+          setTimeout(() => close(promise), 300)
+          try {
+            const res = await promise
+            setResult(JSON.stringify({ method: 'close(call)', resolved: true, result: res ?? null, error: null }))
+          } catch (e: any) {
+            setResult(
+              JSON.stringify({ method: 'close(call)', resolved: false, error: e.message, isAbort: e instanceof TelefuncAbort }),
+            )
+          }
+        }}
+      >
+        Upload close (graceful)
       </button>
     </div>
   )

--- a/test/playground-stream/pages/abort/e2e-test.ts
+++ b/test/playground-stream/pages/abort/e2e-test.ts
@@ -160,6 +160,26 @@ function testAbort() {
     })
   })
 
+  // close() mid-upload gracefully cancels: the call resolves (to null) without throwing,
+  // and the server still fires onClose().
+  test('close: single file upload — graceful cancel, call resolves without error', async () => {
+    await navigate(`${getServerUrl()}/abort`)
+    await resetCleanupState()
+
+    await page.click('#test-upload-close-graceful')
+    await autoRetry(async () => {
+      const result = await getResult('#abort-result')
+      expect(result.method).toBe('close(call)')
+      expect(result.resolved).toBe(true)
+      expect(result.error).toBe(null)
+      expect(result.result).toBe(null)
+    })
+    await autoRetry(async () => {
+      const state = await getCleanupState()
+      expect(state.uploadAbortSingle).toBe('cleaned-up')
+    })
+  })
+
   // Three 50MB files — file1 consumed fully, client aborts at 3s during
   // post-file1 sleep, file2+file3 error on disconnect
   test('abort: multiple file upload — file1 received, file2+file3 error on disconnect', async () => {


### PR DESCRIPTION
Separate PR for the runtime change discussed on the docs thread: make `close(call)` gracefully cancel an in-flight upload, since cancelling is an expected path, not an error.

## The bug

`close(call)` on a non-generator call was a **silent no-op**. `addAsyncGeneratorInterface` attaches a close handler to every call, but for a non-generator the handler awaits a `resolvedGen` that rejects — so nothing happens. A `close()` during an in-flight upload didn't stop it; the upload ran to completion. (This corrects my earlier claim that it *threw* — it doesn't, it silently does nothing.)

## The change

`close(call)` on a still-in-flight call **that has request-side streams** (a `File`/`Blob`/`ReadableStream`/callback argument — i.e. an upload) now gracefully cancels it:

1. Runs the request-side close handlers, then aborts the request.
2. A new `closeState.gracefullyClosed` flag tells `makeHttpRequest` to **resolve the call to `undefined`** instead of throwing — so `await call` settles cleanly. This is the key difference from `abort(call)`, which still rejects with an `Abort` error.

Server-side is already correct and needs nothing: the disconnect fires `onClose()` and is recognized as expected (`handleError.ts`: "Client disconnected mid-stream — not a bug, nothing to log").

### Why it's safe for existing behavior

The graceful-cancel path only runs when a call is **both** still in flight **and** has request streams (`hasRequestStreams = requestCloseHandlers.length > 0`):
- **Pure generators** (`onAiPrompt(prompt: string)`) have no request args → `hasRequestStreams` is false → the close handler keeps the existing `g.return()` behavior unchanged.
- **Resolved calls** take the `settled` branch → `g.return()` for generators, no-op for plain values.
- `abort(call)` is untouched (the new flag is only set by `close()`).
- `close(value)` on returned download/stream objects is unaffected — that walks the *return value's* handlers, not the call-promise handler changed here.

## Files

- `client/remoteTelefunctionCall.ts` — build `closeState` + `gracefulClose`, pass them through.
- `client/remoteTelefunctionCall/makeHttpRequest.ts` — on a gracefully-closed abort, return `undefined` instead of throwing.
- `client/remoteTelefunctionCall/async-generator-interface.ts` — track settlement; branch the close handler (graceful-cancel in-flight request-streaming calls vs. `g.return()` for resolved generators).
- `test/playground-stream/pages/abort/*` — e2e test: `close()` mid-upload resolves without throwing **and** still fires the server's `onClose()` (mirrors the existing `abort()` upload test, asserting graceful resolve instead of an `Abort` throw).

## Verification

- `tsc --build` passes for `packages/telefunc` (only the pre-existing, unrelated `vite/client` env error remains).
- The e2e test runs under the existing Playground Stream matrix in CI (browser-driven; I couldn't execute it locally).

Docs for this (`/file-upload`, `/file-download`, `/stream` Cancelling sections) are being handled on the separate docs branch and will be updated to `close(call)` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj

---
_Generated by [Claude Code](https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj)_