### PR TITLE
docs: merge Setup section into Install on integration pages

### DIFF
--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -13,8 +13,6 @@ Redis-backed broadcast fan-out across Telefunc instances — `publish()` on one 
 npm install @telefunc/redis ioredis
 ```
 
-## Setup
-
 ```ts
 // Environment: server
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -17,8 +17,6 @@ The `@telefunc/rxjs` integration lets you pass RxJS `Observable` and `Subject` d
 npm install @telefunc/rxjs rxjs
 ```
 
-## Setup
-
 The Telefunc bundler plugin (Vite, webpack, Next.js, Babel) detects `@telefunc/rxjs` in your dependencies and registers it automatically. Without a Telefunc bundler plugin, register it manually — `import '@telefunc/rxjs/server'` in your server entry and `import '@telefunc/rxjs/client'` in your client entry.
 
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -13,8 +13,6 @@ Live queries for [TanStack Query](https://tanstack.com/query) — invalidate a q
 npm install @telefunc/tanstack-query
 ```
 
-## Setup
-
 Wrap your `QueryClient` with `withTelefunc()`:
 
 ```tsx


### PR DESCRIPTION
## What

Merges the `## Setup` section into `## Install` on the integration docs pages, so installation and setup read as a single step rather than two adjacent headings.

Affected pages:
- `docs/pages/tanstack-query/+Page.mdx`
- `docs/pages/redis/+Page.mdx`
- `docs/pages/rxjs/+Page.mdx`

## Why

On each of these pages, `## Install` contained only the `npm install` command and was immediately followed by `## Setup`. The split added a heading without adding structure — the setup content now lives directly under `## Install`.

## Notes

- Only the heading was removed; all setup prose and code blocks are preserved.
- The redis page's `### Sharing an existing client` subsection now nests under `## Install`.
- No internal links referenced the removed `#setup` anchors.
- The standalone `## Setup` headings on the Cloudflare and Telefunc pages were left untouched — they have no adjacent `## Install` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFa6PQkxJqnEns9CxJc5cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFa6PQkxJqnEns9CxJc5cB)_