### PR TITLE
docs(file-download): clarify graceful vs abort-style cancel

### DIFF
--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -236,7 +236,7 @@ The streaming download can only be consumed once — calling `.stream()`, `.byte
 
 ## Cancelling
 
-You can cancel a file download at any time — simply call `dl.cancel()` (or `reader.cancel()` on `dl.stream()`).
+You can cancel a file download at any time. Stopping the stream you're reading — `break` out of a `for await`, or `reader.cancel()` on `dl.stream()` — ends gracefully. `dl.cancel()` is the immediate, abort-style cancel: a pending whole-file read (`dl.saveToMemory()` / `dl.saveToDisk()` / `bytes()` / `text()`) then rejects, since it can't return a complete file (handle it like any stream error — see <Link text="Error handling" href="#error-handling" /> below).
 
 ```tsx
 // Download.tsx
@@ -269,7 +269,7 @@ export async function onDownload(dir: string) {
 }
 ```
 
-> **You don't always need `onClose()`.** When the `download()` source is a plain stream — like a <Link text="S3 passthrough" href="#passthrough" /> — the upstream read is automaticlaly cancelled.
+> **You don't always need `onClose()`.** When the `download()` source is a plain stream — like a <Link text="S3 passthrough" href="#passthrough" /> — the upstream read is automatically cancelled.
 
 
 ## Error handling


### PR DESCRIPTION
Follow-up from the download-cancel discussion. The `/file-download` Cancelling intro just said "call `dl.cancel()` (or `reader.cancel()`)" without explaining what happens to a pending read — yet the example does `await dl.saveToDisk()` after cancel, which **rejects**. This makes the behavior precise.

## The distinction (verified in code)

It depends on *how* you read:

- **Streaming consumption** — `break` a `for await`, or `reader.cancel()` on `dl.stream()` — ends **gracefully** (you stop pulling; the completion-error path never runs).
- **Whole-file reads** — `dl.saveToMemory()` / `dl.saveToDisk()` / `bytes()` / `text()` — read to the end, so after `dl.cancel()` they hit the cancelled-before-complete check (`createReadableChunkStream.ts` / `getStreamCompletionError.ts`, default `cancelBehavior: 'error'`) and **reject**.

This mirrors the upload `close` / `abort` split: `dl.cancel()` is the abort-equivalent, and rejecting a pending whole-file read is correct — `saveToMemory()` promised the *complete* file, and a cut-short read can't deliver one (rejecting beats silently handing back a partial file, and matches `await fetch(url, {signal})` rejecting with `AbortError`).

> Note: `cancelBehavior` is **not** user-facing on downloads (`dl.stream()`/`bytes()` take no options), so it's intentionally not mentioned.

## Changes

- Rewrote the Cancelling intro to state the graceful (streaming) vs. rejecting (whole-file `dl.cancel()`) behavior, pointing to Error handling.
- Fixed a typo in the same section: `automaticlaly` → `automatically`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj

---
_Generated by [Claude Code](https://claude.ai/code/session_012r5b3Je87RZzA3GVrcDgzj)_