### PR TITLE
docs(file-download): add note on cancelling native File/Blob downloads

### DIFF
--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -241,7 +241,22 @@ cancelButton.onclick = () => dl.cancel() // Cancel the download mid-stream
 await dl.saveToDisk()
 ```
 
-TODO/ai: add note for native `File`/`Blob` use case.
+> **Returning a native `File` / `Blob`?** It resolves on the client to a fully-buffered value with no `dl` handle — so there's no `dl.cancel()`, and there's nothing to stream-cancel since the bytes arrive all at once. To cancel such a call, abort the whole telefunction call with an `AbortSignal` via <Link href="/withContext" />:
+
+```tsx
+// Invoice.tsx
+// Environment: client
+
+import { withContext } from 'telefunc/client'
+import { onRenderInvoice } from './Invoice.telefunc'
+
+const controller = new AbortController()
+cancelButton.onclick = () => controller.abort() // Cancel the call
+
+const pdf = await withContext(onRenderInvoice, { signal: controller.signal })(form)
+```
+
+> The same `signal` works for `download()` too — it cancels the call alongside `dl.cancel()`. Aborting also fires <Link text={<code>onClose()</code>} href="/onClose" /> on the server.
 
 On the server, use <Link text={<code>onClose()</code>} href="/onClose" /> to release resources your telefunction opened when the client cancels:
 

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -170,7 +170,7 @@ To release resources:
 import { getContext } from 'telefunc'
 import fs from 'node:fs'
 
-export async function onUpload(file: File) => void) {
+export async function onUpload(file: File) {
   const context = getContext()
   const dest = fs.createWriteStream(`./uploads/${file.name}`)
 


### PR DESCRIPTION
> **Base:** targets `nitedani/streaming` (where the Telefunc Stream beta docs live) — the branch shares no history with `main`.

## What

1. **Resolves the `TODO/ai`** in the **Cancelling** section of `docs/pages/file-download/+Page.mdx` by documenting the native `File` / `Blob` use case.
2. **Fixes a malformed code block** in `docs/pages/file-upload/+Page.mdx` that was breaking the docs preview test (see below).

## Why

**(1)** The Cancelling section only covered `download()`-wrapped streams via `dl.cancel()`. A telefunction that returns a native `File` / `Blob` resolves on the client to a fully-buffered value with **no `dl` handle**, so `dl.cancel()` doesn't apply — and there's nothing to stream-cancel since the bytes arrive all at once. Readers had no guidance on how to cancel those calls.

**(2)** The `onClose` resource-release example had a stray `=> void)` left over from the progress-callback example:

```ts
export async function onUpload(file: File) => void) {
```

This is invalid TypeScript, so docpress's `detype` transform failed and the docs preview e2e test (`docs/.test-preview.test.ts` → `HTML`) errored out. Corrected to `export async function onUpload(file: File) {`, matching the other `onUpload` definitions on the page and the function body (which only uses `file`).

## How

For (1), added a note plus a runnable example showing how to cancel the whole telefunction call with an `AbortSignal` via [`withContext()`](https://telefunc.com/withContext):

```tsx
const controller = new AbortController()
cancelButton.onclick = () => controller.abort()
const pdf = await withContext(onRenderInvoice, { signal: controller.signal })(form)
```

A follow-up note clarifies the same `signal` also works alongside `download()` / `dl.cancel()`, and that aborting fires `onClose()` on the server — tying into the existing server-side cleanup example right below.

Docs-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)