### PR TITLE
docs(tanstack-query): clarify why queryFn must return the call directly

### DIFF
--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -43,7 +43,7 @@ When using `@telefunc/tanstack-query`, keys prefixed with `global:` are special 
 
 > All other keys remain normal (invalidate locally, i.e. current tab only).
 
-> **How does it work?** Under the hood, the `global:` key is sent to the server then <Link href="/channel#broadcast">broadcasted</Link> to all clients that use a maching query. It's powered by <Link href="/stream">Telefunc Stream</Link>.
+> **How does it work?** Under the hood, the `global:` key is sent to the server then <Link href="/channel#broadcast">broadcasted</Link> to all clients that use a matching query. It's powered by <Link href="/stream">Telefunc Stream</Link>.
 
 ```js
 queryKey: ['todos']                          // local — current tab only
@@ -58,9 +58,9 @@ queryKey: ['global:documents', docId]        // global
 > For global keys to work, make sure that:
 >
 > - **`queryFn` and `mutationFn` must call a telefunction.** With a non-telefunc `queryFn` (e.g. plain `fetch()`), a global key silently behaves like a local one. The same goes for mutations (so that global keys in `meta.invalidates` are sent to server when the mutation succeeds).
-> - **Return the telefunction call directly.** The `@telefunc/tanstack-query` integration reads the invalidation subscription from whatever `queryFn` returns. Transform the result with `select` instead of inside `queryFn`:
+> - **Return the telefunction call directly.** The integration sets up live invalidation based on the value `queryFn` returns, so `queryFn` must return the telefunction call as-is. Unwrapping or transforming the result inside `queryFn` breaks this, and the global key silently falls back to local-only. Transform the result with `select` instead:
 >   ```js
->   // ❌ Broken: queryFn doesn't direclty return getTodos()
+>   // ❌ Broken: transforming inside queryFn breaks invalidation
 >   queryFn: async () => (await getTodos()).items
 >
 >   // ✅ Return the call directly, transform with select


### PR DESCRIPTION
## What

Clarifies an ambiguous sentence in the `@telefunc/tanstack-query` docs:

> The `@telefunc/tanstack-query` integration reads the invalidation subscription from whatever `queryFn` returns.

## Why

The original wording didn't explain *what* is being read or *why* `queryFn` must return the telefunction call directly. The mechanism (see `packages/tanstack-query/src/client.ts`) is:

- For a global key, the telefunction call resolves to an internal wrapper object carrying both the data (`__tq__data`) and a channel (`__tq__channel`) used to subscribe to invalidation events.
- The `withTelefunc()` persister inspects the value `queryFn` resolves to. If it's that wrapper, it reads the channel, subscribes via `channel.listen(...)`, and hands TanStack Query only the unwrapped data.
- If the value has been unwrapped/transformed inside `queryFn`, the wrapper-detection check fails, the channel is lost, and the global key silently degrades to local-only.

## Change

Rewrites the bullet to spell out the wrapper-carries-the-channel mechanism and the consequence of transforming inside `queryFn`, and updates the code-comment in the example accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfiR3YjYMVXfqZeUuLsa5a)_