### PR TITLE
docs: clarify channel.connectionKey description

### DIFF
--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -39,7 +39,7 @@ for await (const message of gen) {
 | `telefuncUrl` | `string` | Override <Link text={<code>config.telefuncUrl</code>} href="/telefuncUrl" /> for this call and its channels. |
 | `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streaming. |
 | `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
-| `channel.connectionKey` | `string` | Calls with the same key share one connection; different keys use separate connections. |
+| `channel.connectionKey` | `string` | By default, all channel calls to the same URL share one connection. Set a key to isolate calls onto separate connections: calls with the same key share a connection, while different keys (and keyless calls) each get their own. |
 | `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
 
 


### PR DESCRIPTION
## What

Rewrites the `channel.connectionKey` row in the `withContext()` options table so the behavior is self-explanatory.

## Why

The old wording — *"Calls with the same key share one connection; different keys use separate connections"* — states the rule without the context that makes it meaningful. The reader has no way to know that, by default, **all** channel calls to the same URL already share a single multiplexed connection (as documented on the [transport page](https://telefunc.com/transport)). Without that baseline, "same key share one connection" reads as if a key is *required* to get connection sharing, when in fact the option exists to **opt out** of the default sharing and isolate calls onto their own connection.

## Change

New text states the default first, then frames the key as an isolation tool:

> By default, all channel calls to the same URL share one connection. Set a key to isolate calls onto separate connections: calls with the same key share a connection, while different keys (and keyless calls) each get their own.

This matches the actual implementation in `wire-protocol/client/connection.ts`, where `connectionKey` is a client-side cache-key extension that partitions the shared `ClientConnection` cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016iBJnFVNdGFyfaKL9ohbvS)_