### PR TITLE
docs: round 3 — sentence clarity & naturalness pass on Telefunc Stream docs

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -6,7 +6,7 @@ Manually close <Link href="/stream">Telefunc streams</Link>.
 
 > The `close()` function is one of several ways to manually close streams — see all methods at <Link href="#how-to-close" />.
 
-> You usually don't need to manually close streams yourself, see: <Link href="#when-to-close" />.
+> You usually don't need to manually close streams yourself — see: <Link href="#when-to-close" />.
 
 > For listening to streams closing, see: <Link href="/onClose" />.
 
@@ -71,7 +71,7 @@ function Clock() {
 }
 ```
 
-It's optional: if you don't return `clear`, the stream will still automatically close itself after React unmounts the component: the garbage collector clears the stream object and then the stream closes itself.
+It's optional: if you don't return `clear`, the stream still closes itself automatically after React unmounts the component — the garbage collector clears the stream object and then the stream closes itself.
 
 That said, if you want the stream to close as soon as possible, manually close it yourself — return `clear` in this example.
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -82,7 +82,7 @@ function Download({ s3Key }: { s3Key: string }) {
 }
 ```
 
-Calling `dl.cancel()` aborts the download — the pending `saveToMemory` call then rejects.
+Calling `dl.cancel()` aborts the download — the pending `saveToMemory()` call then rejects.
 
 
 ## Example: multiple concurrent downloads

--- a/docs/pages/redis/+Page.mdx
+++ b/docs/pages/redis/+Page.mdx
@@ -5,7 +5,7 @@ import { TelefuncStreamBeta } from '../../components'
 
 <TelefuncStreamBeta />
 
-Redis-backed <Link href="/channel#broadcast">broadcast</Link> fan-out across server instances — a `publish()` on any instance reaches every `subscribe()` on all the others.
+Redis-backed <Link href="/channel#broadcast">broadcast</Link> fan-out across server instances — a `publish()` on any instance reaches every `subscribe()` on every other instance.
 
 > You only need this if you scale horizontally — see <Link href="/stream/scale" />.
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -149,7 +149,7 @@ document.addEventListener('mousemove', e => {
 ```
 
 
-## Example: angular
+## Example: Angular
 
 Angular uses RxJS extensively. With `@telefunc/rxjs`, telefunctions return Observables directly — pipe them into templates with `| async`, use them in services, or compose them with the rest of your RxJS code.
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -521,7 +521,7 @@ See also:
 
 ## Cancelling
 
-You can cancel a stream at anytime by <Link href="/close">manually closing it</Link> — you can then use the <Link href="/onClose">`onClose()` hook</Link> to clear resources (server-side).
+You can cancel a stream at any time by <Link href="/close">manually closing it</Link> — you can then use the <Link href="/onClose">`onClose()` hook</Link> to clear resources (server-side).
 
 ```tsx
 // Search.tsx

--- a/docs/pages/stream/scale/+Page.mdx
+++ b/docs/pages/stream/scale/+Page.mdx
@@ -55,7 +55,7 @@ In the target group's attributes, enable **Stickiness** with type **Load balance
 
 ### Cloud Run / serverless
 
-Serverless platforms that don't expose sticky-session routing aren't a good fit for `Channel`. Broadcasts still work (publishes round-trip through Redis), but channel reconnects can fail unpredictably. Most teams pair Telefunc with a long-running server tier when they need channels at scale.
+Serverless platforms that don't expose sticky-session routing aren't a good fit for `Channel`. Broadcasts still work (each publish round-trips through Redis), but channel reconnects can fail unpredictably. Most teams pair Telefunc with a long-running server tier when they need channels at scale.
 
 
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -169,7 +169,7 @@ Query:
 
 Mutation:
 1. <Link href="#install">`withTelefunc()`</Link> sends all the global keys from <Link href="#mutations">`meta.invalidates`</Link> alongside the telefunction mutation call.
-1. The server <Link href="/channel#broadcast">broadcasts</Link> an invalidation event to the clients that subscribe to a query key that matches a global key.
+1. The server <Link href="/channel#broadcast">broadcasts</Link> an invalidation event to the clients subscribed to a query key that matches a global key.
 1. Every connected client (with a subscription that matches a global key) calls [`invalidateQueries()`](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys).
 
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -58,7 +58,7 @@ Controls how streaming values are delivered over HTTP.
 
 ## Channel transport
 
-Set the network protocol used by <Link text={<code>new Channel()</code>} href="/channel" />, <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, and <Link href="/stream">stream primivites</Link> that use channels under the hood.
+Set the network protocol used by <Link text={<code>new Channel()</code>} href="/channel" />, <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, and <Link href="/stream">stream primitives</Link> that use channels under the hood.
 
 | Transport | Description |
 |---|---|


### PR DESCRIPTION
## What

A **third** sentence-by-sentence technical-writing review over every Telefunc Stream page, run against the latest base (which now includes your two commits `a5b0d4c` and `be2ab35` on top of the round-1 #413 and round-2 #414 changes). All ~573 prose units were re-rated for **clarity** and **naturalness**; this PR applies **9 targeted fixes across 8 pages**.

After two prior rounds plus your own edits the prose is already strong, so round 3 is mostly verification — the surviving fixes are a typo, a capitalization error, a few agreement/aspect issues, and two punctuation lifts.

## Edits

| File | Fix |
|------|-----|
| `transport` | **typo**: "stream **primivites**" → "stream **primitives**" (introduced in `be2ab35`) |
| `rxjs` | **capitalization**: heading "Example: **angular**" → "Example: **Angular**" |
| `stream` | **grammar**: "cancel a stream at **anytime**" → "at **any time**" |
| `file-download` | **consistency**: "the pending **saveToMemory** call" → "**saveToMemory()** call" (matches the parenthesized method style used everywhere else) |
| `tanstack-query` | **aspect**: "clients **that subscribe to** a query key" → "clients **subscribed to** a query key" (matches "with a subscription" on the next line) |
| `redis` | **naturalness**: "every `subscribe()` on **all the others**" → "on **every other instance**" |
| `stream/scale` | **agreement**: "(**publishes round-trip** through Redis)" → "(**each publish round-trips** through Redis)" |
| `close` | **punctuation**: comma splice "yourself, see:" → "yourself — see:" (parallel to the callout above) |
| `close` | **punctuation**: double-colon "It's optional" sentence → em dash + tightened adverb order |

## Respecting your wording

This round explicitly avoided reverting any sentence to an earlier round's phrasing out of preference — only genuine defects/errors were changed. Two agent edits that re-touched wording you had **just set** (the `stream` "underlying stream automatically closes itself…" callout and the `tanstack-query` "every client using a query key that matches" line) were **reverted before commit** and left exactly as you wrote them. Your parenthetical "(Because …)" / "Idempotent (…)" forms and the "become special" intro were likewise left untouched.

## Two standing flags (not changed)

- `close`: the `close()` link points to `href="/onClose"` while every other `close()` reference points to `/close` — suspected wrong target, left as-is (non-prose href, ambiguous correct destination).
- `stream` (inside a code fence): the Channel client example calls `channel.listen(...)` but the awaited variable is named `dashboard` — looks like a variable-name mismatch; out of prose scope.

## Note

No review-document file is added to the repo this time (you removed the round-1 and round-2 ones); the full per-sentence record is kept as a separate artifact.

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 3 components, 113 internal anchor links resolve)

> Based on `nitedani/streaming`, so the diff is just these 9 wording fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLdqD8gS5fi7b2GBPJXeCq)_