### PR TITLE
docs(transport): fix missing article in client-side configs callout

### DIFF
--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -23,7 +23,7 @@ config.stream.transport = 'binary-inline' // default
 config.channel.transports = ['sse', 'ws'] // default
 ```
 
-> These are **client-side** configs — separate from following **server-side** settings:
+> These are **client-side** configs — separate from the following **server-side** settings:
 > - <Link href="/channel-config">`config.channel`</Link>: reconnect/idle timeouts and per-peer buffer limits
 > - <Link href="/stream/scale#broadcast">`config.broadcast.transport`</Link>: cross-instance broadcast for multi-server deployments
 


### PR DESCRIPTION
## What

One-word grammar fix on the transport page, in the intro callout added by `a7b229b`:

- Before: "These are **client-side** configs — separate from **following** server-side settings:"
- After: "These are **client-side** configs — separate from **the following** server-side settings:"

The list introducer was missing its article ("the following").

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 3 components, 113 internal anchor links resolve)

> Based on `nitedani/streaming`, so the diff is just this one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLdqD8gS5fi7b2GBPJXeCq)_