### PR TITLE
docs: fix broken Channel client example on the Stream page

### DIFF
--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -420,8 +420,10 @@ export async function onDashboard() {
 // Dashboard.tsx
 // Environment: client
 
+import { onDashboard } from './Dashboard.telefunc'
+
 const dashboard = await onDashboard()
-channel.listen((metrics) => updateCharts(metrics))
+dashboard.listen((metrics) => updateCharts(metrics))
 ```
 
 


### PR DESCRIPTION
## What

Fixes a broken code example on the `/stream` page (`docs/pages/stream/+Page.mdx`), in the `Channel` primitive section.

## Problem

The client snippet called `channel.listen(...)` on a variable that doesn't exist:

```ts
const dashboard = await onDashboard()
channel.listen((metrics) => updateCharts(metrics))  // ❌ `channel` is undefined
```

The server returns `dashboard.client`, so `await onDashboard()` resolves to the channel itself — bound here to `dashboard`. As written, the example throws `ReferenceError: channel is not defined`.

## Fix

- Call `listen()` on the awaited value (`dashboard.listen(...)`).
- Add the `import { onDashboard } from './Dashboard.telefunc'` line, matching the sibling client examples on the same page.

```ts
import { onDashboard } from './Dashboard.telefunc'

const dashboard = await onDashboard()
dashboard.listen((metrics) => updateCharts(metrics))
```

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 113 anchor links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K713KPALRGSrdQvLMHYwWq)_