### PR TITLE
docs: address Stream docs audit feedback (links, AI API consistency, file-download progress/cancel)

### DIFF
--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -77,7 +77,7 @@ That said, if you want the stream to close as soon as possible, manually close i
 
 ## How to close
 
-From the client, you can manually close a stream early with <Link text={<code>close()</code>} href="/onClose" /> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel.
+From the client, you can manually close a stream early with <Link text={<code>close()</code>} href="#close" /> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel.
 
 There's one catch-all API, `close()`, plus several <Link href="/stream">per-stream-primitive</Link> APIs.
 
@@ -86,8 +86,8 @@ There's one catch-all API, `close()`, plus several <Link href="/stream">per-stre
 | `close(value)` | client | Graceful | Everything in the returned value (walked recursively) |
 | `gen.return()` / `break` | client | Graceful | One `AsyncGenerator` |
 | `reader.cancel()` | client | Graceful | One `ReadableStream` |
-| <Link text={<code>channel.close()</code>} href="/close" /> | client & server | Graceful | One `Channel` / `BroadcastChannel` (both ends) |
-| <Link text={<code>channel.abort(value?)</code>} href="/close" /> | client & server | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
+| <Link text={<code>channel.close()</code>} href="/channel#channel-methods" /> | client & server | Graceful | One `Channel` / `BroadcastChannel` (both ends) |
+| <Link text={<code>channel.abort(value?)</code>} href="/channel#channel-methods" /> | client & server | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
 | `abort(call)` | client | Immediate | The in-flight call and any channels it opened |
 | <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -223,6 +223,21 @@ imgEl.src = URL.createObjectURL(opfsFile)
 | `'opfs'` | Streams bytes through browser-private storage ([OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)), then triggers a native browser download. For large files where in-memory buffering isn't viable. Cross-browser. |
 
 
+## Progress & cancel
+
+**Environment**: client.
+
+A `download()` value exposes progress and cancellation on the client. (Native `File` / `Blob` returns don't — wrap your bytes with <Link text={<code>download()</code>} href="#passthrough" /> to opt in.)
+
+| Member | Type | Description |
+|---|---|---|
+| `dl.onProgress(cb)` | `(loaded, total) => void` | Register a callback fired as bytes arrive. `loaded` is the bytes received so far; `total` is the full size (from `download()`'s `size` / the upstream `Content-Length`), or `undefined` if unknown. Fires immediately with the current progress if bytes already arrived; can be called more than once to register multiple callbacks. |
+| `dl.loaded` | `number` | Bytes received so far. |
+| `dl.cancel()` | `void` | Abort the download. Any pending read (`saveToMemory()`, `text()`, …) then rejects. |
+
+See the <Link text="progress + cancel example" href="#example-progress-cancel" /> above.
+
+
 ## Error handling
 
 You handle errors the same way you do for Telefunc streams: <Link href="/stream#error-handling" />.

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -136,12 +136,13 @@ import { getContext } from 'telefunc'
 
 export async function* onAiPrompt(prompt: string): AsyncGenerator<string> {
   const { onClose } = getContext()
-  const { stream, cancel } = await ai(prompt)
 
   // When the client stops the stream (e.g. the user presses "Stop"), cancel the
   // upstream AI request — otherwise it keeps running and burning AI tokens
-  onClose(cancel)
+  const controller = new AbortController()
+  onClose(() => controller.abort())
 
+  const stream = await ai.streamText({ prompt, signal: controller.signal })
   for await (const message of stream) {
     yield message
   }


### PR DESCRIPTION
## What

Implements the review feedback left on the audit (PR #412) — the items marked *"Do it"* / *"Fix it"* / *"Fix all"*.

## Changes

**`close` page — links (your "Fix all" @ audit L94)**
- "manually close a stream early with `close()`" linked to `/onClose`; now points to the on-page `#close` section.
- The `channel.close()` and `channel.abort(value?)` table rows self-linked to `/close`; now point to `/channel#channel-methods`, where those methods are documented.

**`stream` page — AI API consistency (your "Fix it" @ audit L90)**
- The AI-chat example used `const { stream, cancel } = await ai(prompt)`, while the overview and the `onClose` page use `ai.streamText({ prompt })`. Unified to `ai.streamText({ prompt, signal })` with an `AbortController`, matching the `onClose` page's cancellation pattern.

**`file-download` page — document `onProgress` / `cancel` (your "Do it" @ audit L87)**
- `dl.onProgress()` and `dl.cancel()` were used in the examples but absent from the API reference. Added a **Progress & cancel** section documenting `dl.onProgress(cb)`, `dl.loaded`, and `dl.cancel()`, with signatures verified against `DownloadClasses.ts` / `types.ts` (`DownloadProgress = (loaded: number, total: number | undefined) => void`).
- Left the deferred *"Cancelling"* section (commented out, pending graceful cancellation) untouched.

> The typo fixes (your "Fix all" @ audit L104 — `apadter`, "all value", "clients refetches", "listing") were already resolved on `nitedani/streaming` by the prose pass, so no change was needed there.

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 118 anchor links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K713KPALRGSrdQvLMHYwWq)_