### PR TITLE
docs: final clarity pass on Telefunc Stream docs

### DIFF
--- a/docs/components/NeedsLongRunningServer.mdx
+++ b/docs/components/NeedsLongRunningServer.mdx
@@ -1,3 +1,3 @@
 import { Link } from '@brillout/docpress'
 
-> **Needs a long-running server.** A channel holds a connection open for its entire lifetime, so channels and broadcasts don't work on most serverless platforms (e.g. Vercel, AWS Lambda), which terminate a connection after a short time limit. See <Link href="/stream/scale" /> for running multiple instances, or <Link href="/stream/cloudflare" /> for Cloudflare's Durable Objects.
+> **Needs a long-running server.** A channel holds a connection open for its entire lifetime, so channels and broadcasts don't work on most serverless platforms (e.g. Vercel, AWS Lambda), which enforce a short time limit on connections. See <Link href="/stream/scale" /> for running multiple instances, or <Link href="/stream/cloudflare" /> for Cloudflare's Durable Objects.

--- a/docs/pages/stream/scale/+Page.mdx
+++ b/docs/pages/stream/scale/+Page.mdx
@@ -6,7 +6,7 @@ import { TelefuncStreamBeta } from '../../../components'
 If you use <Link href="/stream">Telefunc Stream</Link>, scaling Telefunc horizontally (multiple Node instances, multiple containers, multiple machines) adds two requirements:
 
 - **Sticky sessions** (so a reconnecting client returns to the same server instance) — your load balancer must route every request from a given client to the same instance.
-  > Required: every stream requires this.
+  > Required: every stream needs this.
 - **Cross-instance broadcast transport** (a <Link href="/channel#broadcast">broadcast</Link> must reach subscribers on every server instance) — install one such as <Link href="/redis">`@telefunc/redis`</Link>.
   > Optional: this is required only for streams that broadcast.
 

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -20,7 +20,7 @@ installRedis(redis)
 
 That swaps Telefunc's default in-memory broadcast transport for Redis Pub/Sub. All subscribers across the cluster observe the same publish order for a given key.
 
-`Channel` is per-instance — reconnects must land on the instance holding the channel's state. Pair this package with sticky sessions at the load balancer; see [Scaling](https://telefunc.com/scaling).
+`Channel` is per-instance — reconnects must land on the instance holding the channel's state. Pair this package with sticky sessions at the load balancer; see [Scaling](https://telefunc.com/stream/scale).
 
 ### Sharing an existing client
 


### PR DESCRIPTION
## What

A focused follow-up to the sentence-level review in #418, after your review commit (`1e91475`) that **kept** the structural/grammar fixes from that pass and **reverted** the stylistic ones (restoring "seamless", "(i.e. referencing)", "the deciding factor is DX", the "listen" verb, etc.).

Reading that signal, this round sticks to **objective fixes only** — the kind that survived last time — and leaves your stylistic choices untouched:

| File | Change | Why |
|---|---|---|
| `packages/redis/README.md` | `telefunc.com/scaling` → `telefunc.com/stream/scale` | **Broken link** — there's no `/scaling` page or redirect; the page lives at `/stream/scale` (the in-repo `redis` docs page already links there correctly). |
| `docs/components/NeedsLongRunningServer.mdx` | "terminate a connection after a short time limit" → "enforce a short time limit on connections" | The original mixes "after a [duration]" with "limit", and uses a singular "a connection" in a general statement. |
| `docs/pages/stream/scale/+Page.mdx` | "Required: every stream **requires** this." → "…**needs** this." | Drops the Required/requires word-root echo. |

## Notes

- I re-read all 19 new Stream docs pages in their current (post-review) state. The prose is in very good shape and clearly reflects your intent, so I kept this round deliberately small rather than re-litigating reverted edits.
- One thing I did **not** change but want to flag for you: on `docs/pages/close/+Page.mdx` (line ~80), the inline `close()` link points to `href="/onClose"` — on the `/close` page itself, that looks like it may have meant `#close` (or `/close`). Left as-is since it's a link target, not prose, and might be intentional — let me know if you'd like it changed.

Based on `nitedani/streaming` so the diff is just these docs edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhgVDbL7qVcHK3yN8dbFRY)_