### PR TITLE
docs: fix inaccurate claims found in docs-vs-code verification

### DIFF
--- a/docs/pages/RPC/+Page.mdx
+++ b/docs/pages/RPC/+Page.mdx
@@ -175,12 +175,12 @@ The `hello.telefunc.js` file is never loaded in the browser: instead Telefunc tr
 ```js
 // hello.telefunc.js (after Telefunc transformation)
 // Environment: Browser
-import { __internal_makeHttpRequest } from 'telefunc/client'
-export const hello = (...args) => __internal_makeHttpRequest('/hello.telefunc.js:hello', args)
+import { __remoteTelefunctionCall } from 'telefunc/client'
+export const hello = (...args) => __remoteTelefunctionCall('/hello.telefunc.js', 'hello', args)
 ```
 
 When `hello('Eva')` is called in the browser-side, the following happens:
- 1. On the browser-side, the `__internal_makeHttpRequest()` function makes an HTTP request to the server.
+ 1. On the browser-side, the `__remoteTelefunctionCall()` function makes an HTTP request to the server.
     ```
     POST /_telefunc HTTP/1.1
     {

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -234,7 +234,7 @@ info.seq        // monotonic sequence number for this key
 info.timestamp  // server timestamp (Unix epoch ms)
 ```
 
-`seq` is monotonic per `key`, which is useful for ordering and gap detection. `publish()` resolves to `info` once the message is accepted.
+`seq` is monotonic per `key`, which is useful for ordering and gap detection. `publish()` resolves to `{ seq, timestamp }` once the message is accepted.
 
 > By default, broadcast is in-memory — messages only reach subscribers on the same server. This works out-of-the-box for single-server deployments.
 >

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -75,7 +75,7 @@ const httpResponse = await serve({
 | `statusCode` | `200 \| 400 \| 403 \| 422 \| 500` | HTTP status code |
 | `headers` | `[string, string][]` | Response headers |
 | `getReadableWebStream()` | `ReadableStream` | Web-standard stream (Hono, Cloudflare, Deno, etc.) |
-| `pipe(writable)` | `void` | Pipe to Node.js writable (Express, Fastify) |
+| `pipe(writable)` | `Promise<void>` | Pipe to Node.js writable (Express, Fastify) |
 | `getBody()` | `Promise<string>` | Full body as string (non-streaming only) |
 | `err` | `unknown` | The error thrown by your telefunction, if any (otherwise `undefined`) — see <Link href="/error-handling" /> |
 

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -421,7 +421,7 @@ export async function onDashboard() {
 // Environment: client
 
 const dashboard = await onDashboard()
-channel.listen((metrics) => updateCharts(metrics))
+dashboard.listen((metrics) => updateCharts(metrics))
 ```
 
 

--- a/docs/pages/tanstack-query/+Page.mdx
+++ b/docs/pages/tanstack-query/+Page.mdx
@@ -141,7 +141,7 @@ invalidate(['global:articles'])
 invalidate(['global:documents', docId])
 ```
 
-> `invalidate()` only accepts global keys.
+> `invalidate()` is for global keys only — local keys have no cross-client subscribers, so they wouldn't reach any client.
 
 > Invalidation is prefix-based: invalidating `['global:documents']` matches `['global:documents', docId]` too. This is the same behavior as TanStack Query's [`invalidateQueries()`](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys).
 


### PR DESCRIPTION
## What

I verified every technical claim in the new Telefunc Stream docs against the actual source in `packages/` (~200 claims across 23 changed/added doc files). The overwhelming majority are correctly grounded in code. This PR fixes the small set of claims that were inaccurate or imprecise.

## Fixes

| File | Before | After | Grounding |
|---|---|---|---|
| `serve/+Page.mdx` | `pipe(writable): void` | `pipe(writable): Promise<void>` | `runTelefunc.ts:52` returns `Promise<void>` |
| `stream/+Page.mdx` | client snippet calls `channel.listen(...)` after `const dashboard = …` | `dashboard.listen(...)` | variable-name typo in example |
| `RPC/+Page.mdx` | transform pseudo-code imports `__internal_makeHttpRequest` with `('/file:export', args)` | real export `__remoteTelefunctionCall` with `(filePath, exportName, args)` | `client/index.ts:24`, `transformTelefuncFileClientSideSync.ts:38,44` |
| `channel/+Page.mdx` | `publish()` resolves to `info` (implying it carries `key`) | resolves to `{ seq, timestamp }` | static `Broadcast.publish()` returns `BroadcastPublishResult` (no `key`) — `server-broadcast.ts:311`, `broadcast.ts:16` |
| `tanstack-query/+Page.mdx` | "`invalidate()` only accepts global keys" (implies enforcement) | clarified as guidance — local keys have no cross-client subscribers | no runtime guard in `server.ts:53-55` |

## Not changed

Everything else verified clean, including all `config.channel` byte defaults, the six Cloudflare regions, presence/session TTLs, the `x-telefunc-session` header, all error-message strings, the `getContext()` error text, and all 13 shield combinators. A few wording nuances were judged accurate in context and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UPwvDoJ4tCju6cKk1Cr9H

---
_Generated by [Claude Code](https://claude.ai/code/session_012UPwvDoJ4tCju6cKk1Cr9H)_