### PR TITLE
docs(lint): catch absolute telefunc.com links as internal links

### DIFF
--- a/docs/check-docs.mjs
+++ b/docs/check-docs.mjs
@@ -2,9 +2,17 @@
 //
 // Checks, across docs/pages/**/+Page.mdx and docs/components/**/*.mdx:
 //   1. Anchor integrity — every internal `#anchor` link resolves to a real heading.
-//   2. Link convention — internal links use <Link>, not bare markdown links.
+//   2. Page integrity — every internal link points to a real page.
+//   3. Link convention — internal links use <Link>, not bare markdown links and not
+//      absolute `https://telefunc.com/...` URLs (telefunc.com is the docs site itself,
+//      so such a link is an internal link in disguise — it must be a relative <Link>).
 //
-// Run: `node docs/check-docs.mjs` (or `pnpm run docs:lint`).
+// Package & repo READMEs (README.md, packages/*/README.md) are plain Markdown rendered
+// on npm/GitHub, so they can't use <Link> and legitimately link to the docs via absolute
+// telefunc.com URLs. Those absolute links are still resolved here so a deep link can't
+// silently rot (e.g. a link to /scaling when the page lives at /stream/scale).
+//
+// Run: `node docs/check-docs.mjs` (run in CI by .github/workflows/ci.yml).
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -76,6 +84,29 @@ const components = walk(componentsDir, (name) => name.endsWith('.mdx')).map((fil
   url: null,
   rel: path.relative(docsDir, file),
   src: fs.readFileSync(file, 'utf8'),
+  kind: 'mdx',
+}))
+
+// Package & repo READMEs are plain Markdown (npm/GitHub), so the <Link> convention can't
+// apply — but their absolute telefunc.com links are still resolved (page + anchor) so a
+// deep link can't silently break. Listed explicitly to stay out of node_modules.
+const repoDir = path.join(docsDir, '..')
+const pkgsDir = path.join(repoDir, 'packages')
+const readmeFiles = [
+  path.join(repoDir, 'README.md'),
+  path.join(docsDir, 'README.md'),
+  ...(fs.existsSync(pkgsDir)
+    ? fs
+        .readdirSync(pkgsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => path.join(pkgsDir, d.name, 'README.md'))
+    : []),
+].filter((f) => fs.existsSync(f))
+const readmes = readmeFiles.map((file) => ({
+  url: null,
+  rel: path.relative(repoDir, file),
+  src: fs.readFileSync(file, 'utf8'),
+  kind: 'markdown',
 }))
 
 const linkSources = [
@@ -83,45 +114,75 @@ const linkSources = [
     url,
     rel: path.relative(pagesDir, page.file),
     src: page.src,
+    kind: 'mdx',
   })),
   ...components,
+  ...readmes,
 ]
+
+// telefunc.com is the docs site itself, so an absolute link to it is an internal link in
+// disguise. Recognize the common spellings of the origin (with/without www, http/https).
+const SELF_ORIGIN = /^https?:\/\/(www\.)?telefunc\.com/i
+
+// Reduce a link target to its docs-relative form ("/stream/scale#x", "#x", "/") or null
+// when it points elsewhere (other domains, mailto, etc.).
+function toInternal(target) {
+  if (SELF_ORIGIN.test(target)) return target.replace(SELF_ORIGIN, '') || '/'
+  if (target.startsWith('/') || target.startsWith('#')) return target
+  return null
+}
 
 // Strip fenced code blocks and code spans so links inside examples aren't checked.
 function stripCode(src) {
   return src.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '')
 }
 
-for (const { url, rel, src } of linkSources) {
+for (const { url, rel, src, kind } of linkSources) {
   const prose = stripCode(src)
 
+  // Link targets: JSX/HTML href="..." plus every markdown ](target) (classified via toInternal).
   const hrefs = [...src.matchAll(/href="([^"]+)"/g)].map((m) => m[1])
-  const mdLinks = [...prose.matchAll(/\]\((\/[^)\s]*|#[^)\s]*)\)/g)].map((m) => m[1])
+  const mdLinks = [...prose.matchAll(/\]\(([^)\s]+)\)/g)].map((m) => m[1])
 
-  // Anchor integrity: every internal `#anchor` link resolves to a real heading.
-  for (const href of [...hrefs, ...mdLinks]) {
-    if (!href.includes('#')) continue
-    if (/^https?:/.test(href)) continue
-    const [rawPath, anchor] = href.split('#')
-    if (!anchor) continue
-    // A page-relative anchor in a URL-less component can't be resolved — skip it.
+  // Page + anchor integrity. Relative links keep their historical scope (resolved only when
+  // they carry an `#anchor`, since a bare `/page` may point at a redirect). Absolute
+  // telefunc.com links are always resolved, page existence included.
+  for (const link of [...hrefs, ...mdLinks]) {
+    const internal = toInternal(link)
+    if (internal === null) continue // external link — not ours to check
+    const isSelf = SELF_ORIGIN.test(link)
+    // Relative ("/page", "#anchor") links are docs-relative only in MDX; in plain-Markdown
+    // READMEs they're repo-relative (GitHub), so there only absolute telefunc.com links are ours.
+    if (!isSelf && kind !== 'mdx') continue
+    const [rawPath, anchor] = internal.split('#')
+    if (!isSelf && !anchor) continue
+    // A page-relative anchor ("#x") in a URL-less source (component / README) can't resolve.
     if (rawPath === '' && url === null) continue
     const targetUrl = rawPath === '' ? url : rawPath.replace(/\/$/, '')
-    const target = pages[targetUrl]
-    if (!target) {
-      errors.push(`${rel}: link to unknown page "${href}" (no ${targetUrl}/+Page.mdx)`)
-    } else if (!target.slugs.has(anchor)) {
-      errors.push(`${rel}: broken anchor "${href}" — no heading "#${anchor}" on ${targetUrl}`)
+    if (targetUrl === '/' || targetUrl === '') continue // docs home — nothing to resolve
+    const page = pages[targetUrl]
+    if (!page) {
+      errors.push(`${rel}: link to unknown page "${link}" (no ${targetUrl}/+Page.mdx)`)
+    } else if (anchor && !page.slugs.has(anchor)) {
+      errors.push(`${rel}: broken anchor "${link}" — no heading "#${anchor}" on ${targetUrl}`)
     }
   }
 
-  // Link convention: internal links use <Link>, not bare markdown links.
-  for (const m of mdLinks) {
-    errors.push(`${rel}: bare markdown internal link "](${m})" — use <Link href="${m}" /> instead`)
+  // Link convention (MDX only — READMEs are plain Markdown and can't use <Link>): internal
+  // links must use <Link>, never a bare markdown link nor an absolute telefunc.com URL.
+  if (kind === 'mdx') {
+    for (const m of mdLinks) {
+      const internal = toInternal(m)
+      if (internal === null) continue
+      errors.push(`${rel}: bare markdown internal link "](${m})" — use <Link href="${internal}" /> instead`)
+    }
+    for (const href of hrefs) {
+      if (!SELF_ORIGIN.test(href)) continue
+      const internal = href.replace(SELF_ORIGIN, '') || '/'
+      errors.push(`${rel}: absolute internal link href="${href}" — use a relative href="${internal}" instead`)
+    }
   }
 }
-
-const linkCount = linkSources.reduce((n, s) => n + [...s.src.matchAll(/href="[^"]*#/g)].length, 0)
 
 if (errors.length) {
   console.error(`\n✗ docs quality gate: ${errors.length} issue(s)\n`)
@@ -130,5 +191,6 @@ if (errors.length) {
   process.exit(1)
 }
 console.log(
-  `✓ docs quality gate: ${files.length} pages, ${components.length} components, ${linkCount} internal anchor links — all resolve.`,
+  `✓ docs quality gate: ${files.length} pages, ${components.length} components, ${readmes.length} READMEs — ` +
+    `internal links (anchors, pages, and absolute telefunc.com URLs) all resolve.`,
 )


### PR DESCRIPTION
## What

You flagged that `[Scaling](https://telefunc.com/stream/scale)` doesn't make sense as a hand-written absolute link, and that the docs linter should catch it. This does that.

The linter (`docs/check-docs.mjs`) already flagged bare markdown internal links (`](/page)`, `](#anchor)`) but **missed internal links written as absolute `https://telefunc.com/...` URLs** — which is exactly how my earlier broken `/scaling` link (the page lives at `/stream/scale`) slipped through.

## Change

`check-docs.mjs` now treats any `https://telefunc.com/...` link as the internal link it is:

- **In MDX pages/components** — flagged as a convention violation telling you to use a relative `<Link href="/...">` (covers both markdown `](…)` links and `href="…"` attributes).
- **Everywhere, including package/repo READMEs** — the link's **page and `#anchor` are resolved**, so a deep link can't silently rot. READMEs are plain Markdown rendered on npm/GitHub, so they legitimately use absolute URLs and can't use `<Link>` — but their telefunc.com links are now validated, which is what would have caught the original `/scaling` mistake.

Relative-link handling is unchanged for MDX. In READMEs, root-relative `/…` links are repo-relative on GitHub (e.g. `/CONTRIBUTING.md`), so they're deliberately left alone — only absolute telefunc.com links are validated there.

## About the README link itself

I kept `packages/redis/README.md` using the absolute `https://telefunc.com/stream/scale` URL: a published README can't use the JSX `<Link>` component (npm/GitHub render raw Markdown), and a root-relative `/stream/scale` would resolve against the repo, not the docs site. So an absolute URL is the correct form there — the fix is that it's now **linter-validated** rather than unchecked. Happy to drop the deep link entirely if you'd rather READMEs not point into the docs site.

## Verification

- `node docs/check-docs.mjs` passes on the current docs (53 pages, 3 components, 4 READMEs).
- Confirmed it now catches each target case (and rejected a false positive along the way — repo-relative `/CONTRIBUTING.md#docs` in `docs/README.md`):

| Injected | Caught as |
|---|---|
| `](https://telefunc.com/stream/scale)` in an MDX page | convention → use `<Link href="/stream/scale" />` |
| `<Link href="https://telefunc.com/channel" />` in MDX | convention → use relative `href="/channel"` |
| `](https://telefunc.com/nope-page)` | unknown page |
| `https://telefunc.com/scaling` in the README | unknown page |
| `https://telefunc.com/stream/scale#no-such-heading` in the README | broken anchor |
| `https://telefunc.com/stream/scale#broadcast` (valid) | passes |

Based on `nitedani/streaming`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhgVDbL7qVcHK3yN8dbFRY)_