### PR TITLE
docs: fix further inaccuracies found in deep docs-vs-code verification

### DIFF
--- a/docs/pages/channel-config/+Page.mdx
+++ b/docs/pages/channel-config/+Page.mdx
@@ -19,12 +19,12 @@ config.channel = {
   // Text buffers
   serverReplayBuffer: 262_144,          // Server replay buffer for text frames (bytes)
   clientReplayBuffer: 1_048_576,        // Client replay buffer for text frames (bytes)
-  bufferLimit: 524_288,                 // Per-peer buffer for text messages (bytes)
+  bufferLimit: 524_288,                 // Per-channel buffer for text sent while no client is connected (bytes)
 
   // Binary buffers — separate budget so binary can never evict text
   serverReplayBufferBinary: 2_097_152,  // Server replay buffer for binary frames (bytes)
   clientReplayBufferBinary: 2_097_152,  // Client replay buffer for binary frames (bytes)
-  bufferLimitBinary: 2_097_152,         // Per-peer buffer for binary messages (bytes)
+  bufferLimitBinary: 2_097_152,         // Per-channel buffer for binary sent while no client is connected (bytes)
 }
 ```
 

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -167,6 +167,8 @@ await chat.send(data, { ack: false }) // Promise<void>, no ack value
 const binaryAck = await chat.sendBinary(frame, { ack: true })
 ```
 
+> A channel-wide `{ ack: true }` only applies to `send()` — `sendBinary()` always opts in per call, so pass `{ ack: true }` to each `sendBinary()` that needs an acknowledgement.
+
 
 ### Binary data
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -291,7 +291,7 @@ The client receives the `File` / `Blob` as a **lazy, streaming** object: its byt
 
 ### One-shot reads
 
-The streaming download can only be consumed once — calling `.stream()`, `.bytes()`, `.text()`, `.arrayBuffer()`, `.slice()`, or any `saveTo*` method a second time throws.
+The streaming download can only be consumed once — calling `.stream()`, `.bytes()`, `.text()`, `.arrayBuffer()`, or any `saveTo*` method a second time throws. (`.slice()` is lazy: it doesn't consume on its own, but reading the resulting slice consumes the download.)
 
 > If you need the data more than once, materialize it once via `dl.saveToMemory()` (or `saveToOpfs()` for large files) and reuse the returned `File` / `Blob`.
 

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -76,7 +76,7 @@ const httpResponse = await serve({
 | `headers` | `[string, string][]` | Response headers |
 | `getReadableWebStream()` | `ReadableStream` | Web-standard stream (Hono, Cloudflare, Deno, etc.) |
 | `pipe(writable)` | `Promise<void>` | Pipe to Node.js writable (Express, Fastify) |
-| `getBody()` | `Promise<string>` | Full body as string (non-streaming only) |
+| `getBody()` | `Promise<string>` | Full body as string (awaits streaming if needed) |
 | `err` | `unknown` | The error thrown by your telefunction, if any (otherwise `undefined`) — see <Link href="/error-handling" /> |
 
 

--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -125,7 +125,7 @@ const telefunc = new Telefunc({
 })
 ```
 
-Only specified regions get Durable Objects. Requests from unspecified regions fall back to `locationFallback`.
+Only specified regions get Durable Objects. When you use the per-region object form, make sure to include every region your users connect from — a request whose nearest region isn't in the `scale` map throws. (`locationFallback` only applies when the request's location can't be resolved to one of the six regions, not as a fallback for a region you left out of the map.)
 
 
 ## Distributed broadcast
@@ -200,7 +200,7 @@ const telefunc = new Telefunc({
   instanceName: 'telefunc',              // Base name for DO instances (default)
   scale: 1,                              // DOs per region (default)
   locationFallback: 'weur',              // Fallback region (default)
-  jurisdiction: 'eu',                    // Restrict DOs to a jurisdiction
+  jurisdiction: 'eu',                    // Restrict DOs to a jurisdiction (optional, no default)
 })
 ```
 

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -39,7 +39,7 @@ for await (const message of gen) {
 | `telefuncUrl` | `string` | Override <Link text={<code>config.telefuncUrl</code>} href="/telefuncUrl" /> for this call and its channels. |
 | `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streaming. |
 | `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
-| `channel.connectionKey` | `string` | By default, all channel calls to the same URL share one connection. Set a key to split calls across separate connections: calls with the same key share a connection, while different keys (and keyless calls) each get their own. |
+| `channel.connectionKey` | `string` | By default, all channel calls to the same URL share one connection. Set a key to split calls across separate connections: calls with the same key share a connection, while different keys each get their own (keyless calls all share the default connection). |
 | `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
 
 


### PR DESCRIPTION
## What

A second, deeper verification pass of the Telefunc Stream docs — this time reading **full implementations and spec tests** (not just symbol lookups) and forcing resolution of every claim the first pass left uncertain. It surfaced a handful of claims that didn't match the code. This PR fixes them.

## Fixes

| File | Issue | Grounding |
|---|---|---|
| `stream/cloudflare` | A per-region `scale` object does **not** fall back to `locationFallback` for an omitted region — `getShardIndicesForBucket` asserts `shardCount > 0` and **throws** for any region not in the map. Reworded. | `wire-protocol/server/adapter/cloudflare/routing.ts:80` (`assert(shardCount > 0)`), `:164-178` (`getScaleCountForBucket` returns `0` for unspecified buckets) |
| `stream/cloudflare` | `jurisdiction: 'eu'` is an example, not a default — annotated. | `serve/cloudflare.ts:73` (no default) |
| `serve` | `getBody()` **awaits streaming** bodies; "(non-streaming only)" actually describes the `body` getter. | `runTelefunc.ts:131-142` (`getBody` iterates the stream) vs `:110-116` (`body` asserts string) |
| `withContext` | Keyless channel calls all **share** the default connection (cache key uses `connectionKey ?? ''`), not "each get their own". | `wire-protocol/client/connection.ts:240` (cache key), `:239` ("`connectionKey` opts callers out of the shared connection") |
| `channel-config` | `bufferLimit` / `bufferLimitBinary` are **per-channel** buffers used while no client is attached, not "per-peer". | `wire-protocol/server/ServerChannelBuffer.ts:14-33`, `server/channel.ts:131-134` (`_prePeerBuffer`) |
| `channel` | A channel-wide `{ ack: true }` only applies to `send()`; `sendBinary()` acks are always per-call — added a note. | `server/channel.ts:169` (text honors `this.ack`) vs `:215` (binary uses only `opts?.ack === true`) |
| `file-download` | `.slice()` is lazy and doesn't itself consume, so it doesn't throw on a second call — removed from the one-shot list with a note. | `wire-protocol/LazyFile.ts:61-67` (`slice` returns a lazy `SlicedBlob`, no `_markConsumed`) |

## Verification scope

Every substantive claim across all ~23 changed/added doc files was re-checked against the source. The vast majority were confirmed accurate and grounded — including all `config.channel` byte defaults, the six Cloudflare regions, presence/session TTLs, the full broadcast fan-out (Authority→Coordinator→DO), the `BroadcastTransport` interface, shield combinators, error strings, the `gen.return()`→server-`onClose()` chain, and GC-on-unreference for passed callbacks. The items above are the only ones that warranted a doc change. The `docs/check-docs.mjs` quality gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UPwvDoJ4tCju6cKk1Cr9H

---
_Generated by [Claude Code](https://claude.ai/code/session_012UPwvDoJ4tCju6cKk1Cr9H)_