### PR TITLE
docs(channel): add simple two-way Channel example

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -64,7 +64,31 @@ channel.listen((time) => console.log(time)) // 1700000000000, 1700000001000, ...
 
 Two-way example:
 
-TODO/ai: add simple two-way example
+```ts
+// Echo.telefunc.ts
+// Environment: server
+
+import { Channel } from 'telefunc'
+
+export async function onEcho() {
+  const channel = new Channel<string, string>()
+  channel.listen((text) => channel.send(`echo: ${text}`))
+  return { channel: channel.client }
+}
+```
+
+```ts
+// Echo.tsx
+// Environment: client
+
+import { onEcho } from './Echo.telefunc'
+
+const { channel } = await onEcho()
+channel.listen((text) => console.log(text)) // 'echo: Hello!'
+channel.send('Hello!')
+```
+
+> The client `send()`s and the server `listen()`s, while the server `send()`s and the client `listen()`s — both ends talk over the same channel.
 
 ### Channel methods
 


### PR DESCRIPTION
## What

Implements the `TODO/ai: add simple two-way example` placeholder in `docs/pages/channel/+Page.mdx`.

The `## new Channel()` section had a one-way (server→client) "Simple example" (the Clock), followed by a "Two-way example:" heading whose content was still a TODO. This adds a minimal echo example for it:

- **Server** creates `new Channel<string, string>()`, `listen()`s for messages and `send()`s a reply, then returns `channel.client`.
- **Client** `listen()`s for replies and `send()`s a message.

The example mirrors the style of the existing Clock example (plain message types, no acks) and stays deliberately simpler than the typed `Room` / `chat` example further down the page. A short note clarifies that both ends `send()` and `listen()` over the same channel.

## Why

Fills in the missing documentation so the two-way `Channel` usage is shown with a minimal, copy-pasteable snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGtSBVUiDXdJnxCTA5Gwec)_