### PR TITLE
docs: fix mis-targeted Channel link, grammar typo, and trailing commas

### DIFF
--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -300,11 +300,11 @@ export async function onJoinChat(room: string, username: string) {
   const chat = new BroadcastChannel<ChatMessage>({ key: `chat:${room}` })
 
   chat.onOpen(() => {
-    chat.publish({ user: 'system', text: `${username} joined`, })
+    chat.publish({ user: 'system', text: `${username} joined` })
   })
 
   chat.onClose(() => {
-    chat.publish({ user: 'system', text: `${username} left`, })
+    chat.publish({ user: 'system', text: `${username} left` })
   })
 
   return chat

--- a/docs/pages/stream/scale/+Page.mdx
+++ b/docs/pages/stream/scale/+Page.mdx
@@ -13,7 +13,7 @@ If you use <Link href="/stream">Telefunc Stream</Link>, scaling Telefunc horizon
 
 ## Sticky sessions
 
-A <Link href="/channel#broadcast">`Channel`</Link> is a stateful connection. Its server-side state — the `new Channel()` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one server process. When the client reconnects (network issues, a page reload, an SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
+A <Link href="/channel#new-channel">`Channel`</Link> is a stateful connection. Its server-side state — the `new Channel()` instance, its `send()`/`listen()` closures, any interval the telefunction set up — lives in one server process. When the client reconnects (network issues, a page reload, an SSE→WS upgrade), the next request has to land on the same process or the channel can't recover.
 
 > This is the same constraint Socket.IO documents under [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/). The same load-balancer feature solves the problem for Telefunc: a sticky session, usually backed by a cookie or by the client IP.
 
@@ -91,7 +91,7 @@ type BroadcastTransport = {
 [Cloudflare Workers](https://www.cloudflare.com/products/workers/) takes a different approach: `telefunc/cloudflare` routes channels through [Durable Objects](https://developers.cloudflare.com/durable-objects/) instead of sticky sessions, and fans out broadcasts across regions automatically. As a result, neither a sticky load balancer nor a broadcast transport is needed. See:
 - <Link href="/stream/cloudflare" />
 
-> You scale with <Link href="/stream/cloudflare#scaling">the `scale` option</Link> instead of a using load balancer.
+> You scale with <Link href="/stream/cloudflare#scaling">the `scale` option</Link> instead of a load balancer.
 
 
 ## See also


### PR DESCRIPTION
## What

Three small fixes found while reviewing the latest commits on the channel and stream/scale pages.

**`stream/scale` — two bugs from `11b9cfc`:**
- The `` `Channel` `` link pointed to `/channel#broadcast` (the *Broadcast* section) — corrected to `/channel#new-channel` (the `new Channel()` section), which is what the text refers to.
- "You scale with the `scale` option **instead of a using load balancer**" → "**instead of a load balancer**" (stray "using").

**`channel` — leftover trailing commas:**
- Two `publish()` calls in the broadcast Chat example (lines 303, 307) still had `, })` trailing commas; `a695a73` removed the same pattern elsewhere in that example but missed these two.

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 2 components, internal links/anchors all resolve)

> Based on `nitedani/streaming`, so the diff is just these three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLdqD8gS5fi7b2GBPJXeCq)_