### PR TITLE
docs(cloudflare): fix "nor" → "or" after negative verb

### DIFF
--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -52,7 +52,7 @@ export default {
 > - **Durable Objects** provide stateful compute: each channel lives on a Durable Object, which holds the connection and its state.
 > - **KV** provides shared storage: it's how stateless workers find the Durable Object that holds the state, no matter which worker a request lands on.
 >
-> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` nor `BroadcastChannel`, there's no state to keep — you can skip both bindings and use <Link text={<code>serve()</code>} href="/serve" /> instead.
+> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` or `BroadcastChannel`, there's no state to keep — you can skip both bindings and use <Link text={<code>serve()</code>} href="/serve" /> instead.
 >
 > See <Link href="#architecture" /> for implementation details.
 


### PR DESCRIPTION
## What

Grammar fix on the Cloudflare page, in the "Both bindings are required" callout (from `2c51dce`):

- Before: "If your app doesn't use `Channel` **nor** `BroadcastChannel`…"
- After: "If your app doesn't use `Channel` **or** `BroadcastChannel`…"

After the negated verb ("doesn't use"), the correct conjunction is "or" (or restructure to "uses **neither** … **nor** …").

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 2 components, internal links/anchors all resolve)

> Based on `nitedani/streaming`, so the diff is just this one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLdqD8gS5fi7b2GBPJXeCq)_