### PR TITLE
docs: fix subject-verb agreement and two double-spaces

### DIFF
--- a/docs/pages/provideTelefuncContext/+Page.mdx
+++ b/docs/pages/provideTelefuncContext/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: server.
 
-`provideTelefuncContext()` makes the `context` object available to telefunctions (via <Link href="/getContext">`getContext()`</Link>)  — useful when a telefunction runs **outside `telefunc.serve()`**, such as server-side rendering or unit tests.
+`provideTelefuncContext()` makes the `context` object available to telefunctions (via <Link href="/getContext">`getContext()`</Link>) — useful when a telefunction runs **outside `telefunc.serve()`**, such as server-side rendering or unit tests.
 
 ```ts
 // Environment: server

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -496,7 +496,7 @@ import { onTeamFeed } from './TeamFeed.telefunc'
 await onTeamFeed('acme', (text) => showMessage(text))
 ```
 
-`getContext()` and `throw Abort()` only work **before the telefunction returns** — so authorize at open time. The `context.user` you capture stays valid inside callbacks which runs later (via JavaScript closure).
+`getContext()` and `throw Abort()` only work **before the telefunction returns** — so authorize at open time. The `context.user` you capture stays valid inside callbacks which run later (via JavaScript closure).
 
 > **Consider re-checking.** For sensitive operations, you can re-check authorization with the captured `context.user` each time the callback runs, although most use cases don't need this.
 

--- a/docs/pages/testing/+Page.mdx
+++ b/docs/pages/testing/+Page.mdx
@@ -18,7 +18,7 @@ test('onHello', async () => {
 
 ## Providing context
 
-If a telefunction reads <Link href="/getContext">`getContext()`</Link>  (e.g. to get the logged-in user), provide the context in your test setup with <Link text={<code>provideTelefuncContext()</code>} href="/provideTelefuncContext" /> before calling it:
+If a telefunction reads <Link href="/getContext">`getContext()`</Link> (e.g. to get the logged-in user), provide the context in your test setup with <Link text={<code>provideTelefuncContext()</code>} href="/provideTelefuncContext" /> before calling it:
 
 ```ts
 // Team.telefunc.test.ts


### PR DESCRIPTION
## What

Three small fixes found while reviewing the latest batch of commits.

- **`stream`** (from `04d8ccc`): subject–verb agreement — "stays valid inside **callbacks which runs** later" → "**callbacks which run** later".
- **`provideTelefuncContext`** (from `5b9d3c3`): collapse a double space before the em dash — `getContext()`)␠␠— → `getContext()`)␠—.
- **`testing`** (from `5b9d3c3`): collapse a double space before the parenthesis — `getContext()`␠␠(e.g. → `getContext()`␠(e.g.

## Testing

- `node docs/check-docs.mjs` ✓ (53 pages, 2 components, internal links/anchors all resolve)

> Based on `nitedani/streaming`, so the diff is just these three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLdqD8gS5fi7b2GBPJXeCq)_