### PR TITLE
GC-track passed callback/stream stubs so their channels close

### DIFF
--- a/packages/telefunc/client/remoteTelefunctionCall/serializeTelefunctionArguments.ts
+++ b/packages/telefunc/client/remoteTelefunctionCall/serializeTelefunctionArguments.ts
@@ -8,17 +8,10 @@ import { createRequestReplacer } from '../../wire-protocol/client/request/regist
 import { encodeRequestEnvelope } from '../../wire-protocol/frame.js'
 import { pumpClientProducerToChannel } from '../../wire-protocol/client/request/pumpToChannel.js'
 import { ClientChannel } from '../../wire-protocol/client/channel.js'
-import { isObjectOrFunction } from '../../utils/isObjectOrFunction.js'
 import { makeAbortError } from './errors.js'
 import type { ChannelTransports, StreamTransport } from '../../wire-protocol/constants.js'
 import type { ReplacerType, TypeContract, ClientReplacerContext } from '../../wire-protocol/types.js'
 import { CloseHandler } from '../close.js'
-import { getGlobalObject } from '../../utils/getGlobalObject.js'
-import { GcRegistry } from '../../wire-protocol/gcRegistry.js'
-
-const globalObject = getGlobalObject('client/remoteTelefunctionCall/serializeTelefunctionArguments.ts', {
-  gcRegistry: new GcRegistry(),
-})
 
 type CallContext = {
   telefuncFilePath: string
@@ -85,26 +78,20 @@ function serializeTelefunctionArguments(callContext: CallContext): SerializeResu
       },
     },
     function onReplaced(replaced) {
-      {
-        // Track the user's actual value — when they drop all references to it, close.
-        // (Unlike the response side, we don't create a value here; the user already
-        //  holds the original, so it serves as its own GC anchor.)
-        const { value, close } = replaced
-        assert(isObjectOrFunction(value))
-        globalObject.gcRegistry.register(value, close)
-      }
-
-      {
-        const { close, abort } = replaced
-        abortSignal.addEventListener(
-          'abort',
-          () => {
-            abort(makeAbortError(undefined, callContext))
-          },
-          { once: true },
-        )
-        requestCloseHandlers.push(close)
-      }
+      // The client owns the original value here; it stays alive on this end via its channel
+      // listener / stream pump. Its holder-side counterpart (the server) GC-tracks the stub and
+      // closes the channel when done — so the client releases it on that close, on abort, or on
+      // an explicit `close()`. GC-tracking the original here would be the wrong side (and dead:
+      // the channel listener pins it).
+      const { close, abort } = replaced
+      abortSignal.addEventListener(
+        'abort',
+        () => {
+          abort(makeAbortError(undefined, callContext))
+        },
+        { once: true },
+      )
+      requestCloseHandlers.push(close)
     },
     callContext.extensionRequestTypes,
   )

--- a/packages/telefunc/client/remoteTelefunctionCall/serializeTelefunctionArguments.ts
+++ b/packages/telefunc/client/remoteTelefunctionCall/serializeTelefunctionArguments.ts
@@ -8,10 +8,17 @@ import { createRequestReplacer } from '../../wire-protocol/client/request/regist
 import { encodeRequestEnvelope } from '../../wire-protocol/frame.js'
 import { pumpClientProducerToChannel } from '../../wire-protocol/client/request/pumpToChannel.js'
 import { ClientChannel } from '../../wire-protocol/client/channel.js'
+import { isObjectOrFunction } from '../../utils/isObjectOrFunction.js'
 import { makeAbortError } from './errors.js'
 import type { ChannelTransports, StreamTransport } from '../../wire-protocol/constants.js'
 import type { ReplacerType, TypeContract, ClientReplacerContext } from '../../wire-protocol/types.js'
 import { CloseHandler } from '../close.js'
+import { getGlobalObject } from '../../utils/getGlobalObject.js'
+import { GcRegistry } from '../../wire-protocol/gcRegistry.js'
+
+const globalObject = getGlobalObject('client/remoteTelefunctionCall/serializeTelefunctionArguments.ts', {
+  gcRegistry: new GcRegistry(),
+})
 
 type CallContext = {
   telefuncFilePath: string
@@ -78,20 +85,26 @@ function serializeTelefunctionArguments(callContext: CallContext): SerializeResu
       },
     },
     function onReplaced(replaced) {
-      // The client owns the original value here; it stays alive on this end via its channel
-      // listener / stream pump. Its holder-side counterpart (the server) GC-tracks the stub and
-      // closes the channel when done — so the client releases it on that close, on abort, or on
-      // an explicit `close()`. GC-tracking the original here would be the wrong side (and dead:
-      // the channel listener pins it).
-      const { close, abort } = replaced
-      abortSignal.addEventListener(
-        'abort',
-        () => {
-          abort(makeAbortError(undefined, callContext))
-        },
-        { once: true },
-      )
-      requestCloseHandlers.push(close)
+      {
+        // Track the user's actual value — when they drop all references to it, close.
+        // (Unlike the response side, we don't create a value here; the user already
+        //  holds the original, so it serves as its own GC anchor.)
+        const { value, close } = replaced
+        assert(isObjectOrFunction(value))
+        globalObject.gcRegistry.register(value, close)
+      }
+
+      {
+        const { close, abort } = replaced
+        abortSignal.addEventListener(
+          'abort',
+          () => {
+            abort(makeAbortError(undefined, callContext))
+          },
+          { once: true },
+        )
+        requestCloseHandlers.push(close)
+      }
     },
     callContext.extensionRequestTypes,
   )

--- a/packages/telefunc/node/server/runTelefunc/parseHttpRequest.ts
+++ b/packages/telefunc/node/server/runTelefunc/parseHttpRequest.ts
@@ -14,12 +14,22 @@ import type { RequestContext } from '../context/requestContext.js'
 import { ServerChannel } from '../../../wire-protocol/server/channel.js'
 import { getChannelMux } from '../../../wire-protocol/server/mux.js'
 import { ChannelStreamSource } from '../../../wire-protocol/ChannelStreamSource.js'
+import { GcRegistry } from '../../../wire-protocol/gcRegistry.js'
+import { wrapProxy } from '../../../wire-protocol/wrapProxy.js'
+import { getGlobalObject } from '../../../utils/getGlobalObject.js'
+import { isObjectOrFunction } from '../../../utils/isObjectOrFunction.js'
 import type { ReviverType, TypeContract, ServerReviverContext } from '../../../wire-protocol/types.js'
 import { STREAM_TRANSPORT, type StreamTransport } from '../../../wire-protocol/constants.js'
 import { handleSseChannelRequest, type SseChannelHttpResponse } from '../../../wire-protocol/server/sse.js'
 import { buildShieldValidators, getArgumentShields, type ShieldLogConfig } from '../shield.js'
 import { toPathKey } from '../../../utils/pathKey.js'
 import type { Telefunction } from '../types.js'
+
+// Holder-side GC registry for revived request stubs (callback channels, streams). Mirrors the
+// client's response-side registry: once the telefunction drops a revived value, its channel closes.
+const globalObject = getGlobalObject('node/server/runTelefunc/parseHttpRequest.ts', {
+  gcRegistry: new GcRegistry(),
+})
 
 type RunContext = {
   request: Request
@@ -107,9 +117,24 @@ async function parseHttpRequest(runContext: RunContext): Promise<ParseResult> {
           ...baseContext,
           validators: buildShieldValidators(shields[toPathKey(segments)] ?? {}, shieldCtx),
         }),
-        ({ close, abort }) => {
-          requestContext.onTopLevelError(close)
-          requestContext.responseAbort.onAbort(abort)
+        (revived) => {
+          {
+            // Destructure into locals so nothing here closes over `revived` — a closure over it
+            // would pin `revived.value` (the wrapper) and defeat the GC-close. Same discipline as
+            // the client response path.
+            const { value, close } = revived
+            assert(isObjectOrFunction(value))
+            // Holder side: the telefunction gets a GC-anchor wrapper; once it drops it, the
+            // underlying channel/stream closes and the client releases the original.
+            const wrapper = wrapProxy(value)
+            globalObject.gcRegistry.register(wrapper, close)
+            revived.value = wrapper
+          }
+          {
+            const { close, abort } = revived
+            requestContext.onTopLevelError(close)
+            requestContext.responseAbort.onAbort(abort)
+          }
         },
       )
       return envelope.args

--- a/packages/telefunc/node/server/runTelefunc/parseHttpRequest.ts
+++ b/packages/telefunc/node/server/runTelefunc/parseHttpRequest.ts
@@ -25,8 +25,11 @@ import { buildShieldValidators, getArgumentShields, type ShieldLogConfig } from 
 import { toPathKey } from '../../../utils/pathKey.js'
 import type { Telefunction } from '../types.js'
 
-// Holder-side GC registry for revived request stubs (callback channels, streams). Mirrors the
-// client's response-side registry: once the telefunction drops a revived value, its channel closes.
+// Holder-side GC tracking of revived request stubs (callback channels, streams). One shared
+// instance: it's a passive FinalizationRegistry, and its scan timer runs only while stubs are
+// tracked (see GcRegistry) — so it keeps nothing alive and doesn't block hibernation when idle.
+// It must NOT be created per-request: a per-request closure hung on the (rooted) request context
+// pins that request's `envelope.args` via the V8 scope chain, so the stub is never collected.
 const globalObject = getGlobalObject('node/server/runTelefunc/parseHttpRequest.ts', {
   gcRegistry: new GcRegistry(),
 })

--- a/packages/telefunc/wire-protocol/gcRegistry.spec.ts
+++ b/packages/telefunc/wire-protocol/gcRegistry.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import { GcRegistry } from './gcRegistry.js'
+
+const hasGc = typeof (globalThis as { gc?: () => void }).gc === 'function'
+
+async function forceGc(): Promise<void> {
+  // A few cycles so collection + the WeakRef scan / FinalizationRegistry callbacks all run.
+  for (let i = 0; i < 8; i++) {
+    ;(globalThis as { gc?: () => void }).gc!()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+}
+
+// Registers and drops the target inside a sync frame so it can't be retained by the caller's
+// (async) frame — the whole point is that dropping it triggers close.
+function registerAndDrop(gc: GcRegistry, onClose: () => void): void {
+  gc.register({ marker: true }, onClose)
+}
+
+// GC-driven cleanup is what holder-side stub tracking relies on (client response + server request
+// revival both register a wrapped stub, then close its channel once the consumer drops it). Needs
+// real GC, so these run only under `node --expose-gc` and skip otherwise.
+describe.skipIf(!hasGc)('GcRegistry (real GC)', () => {
+  test('fires close once the registered target is collected', async () => {
+    const gc = new GcRegistry(10)
+    let closed = 0
+    registerAndDrop(gc, () => {
+      closed++
+    })
+
+    await forceGc()
+
+    expect(closed).toBe(1)
+  })
+
+  test('keeps close pending while the target is still referenced', async () => {
+    const gc = new GcRegistry(10)
+    let closed = 0
+    const target = { marker: true }
+    gc.register(target, () => {
+      closed++
+    })
+
+    await forceGc()
+
+    expect(target.marker).toBe(true)
+    expect(closed).toBe(0)
+  })
+})

--- a/packages/telefunc/wire-protocol/gcRegistry.ts
+++ b/packages/telefunc/wire-protocol/gcRegistry.ts
@@ -22,14 +22,19 @@ type Entry = {
  *    been collected but the FinalizationRegistry callback hasn't run yet.
  *
  * Both paths funnel into the same idempotent `fireCleanup`, so neither double-runs.
+ *
+ * The scan timer runs **only while entries are tracked** — it starts on the first
+ * `register()` and stops once the set empties. So a single shared instance keeps no
+ * timer when idle: an isolate with nothing tracked (e.g. a Cloudflare Durable Object
+ * with no open callback/stream channels) has no pending work and can hibernate.
  */
 class GcRegistry {
   private finalReg: FinalizationRegistry<Entry>
   private entries = new Set<Entry>()
+  private scanTimer: ReturnType<typeof setInterval> | null = null
 
-  constructor(periodicScanMs = 5000) {
+  constructor(private readonly periodicScanMs = 5000) {
     this.finalReg = new FinalizationRegistry<Entry>((entry) => this.fireCleanup(entry))
-    unrefTimer(setInterval(() => this.scan(), periodicScanMs))
   }
 
   register(target: object, close: CloseFn): void {
@@ -38,12 +43,14 @@ class GcRegistry {
     // Pass `entry` as both held value and unregister token so we can deregister
     // from inside fireCleanup without keeping a separate token map.
     this.finalReg.register(target, entry, entry)
+    if (!this.scanTimer) this.scanTimer = unrefTimer(setInterval(() => this.scan(), this.periodicScanMs))
   }
 
   private scan(): void {
     for (const entry of this.entries) {
       if (entry.ref.deref() === undefined) this.fireCleanup(entry)
     }
+    this.stopScanIfIdle()
   }
 
   private fireCleanup(entry: Entry): void {
@@ -56,6 +63,14 @@ class GcRegistry {
     } catch {
       // Cleanup errors are swallowed — there's no caller to surface them to,
       // and a throw here would break other entries' cleanup in the same scan.
+    }
+    this.stopScanIfIdle()
+  }
+
+  private stopScanIfIdle(): void {
+    if (this.scanTimer && this.entries.size === 0) {
+      clearInterval(this.scanTimer)
+      this.scanTimer = null
     }
   }
 }

--- a/test/playground-stream/+server.ts
+++ b/test/playground-stream/+server.ts
@@ -45,6 +45,19 @@ app.post('/api/cleanup-state/reset', async (c) => {
   return c.json({ ok: true })
 })
 
+// Forces server-side GC so tests can deterministically exercise GC-driven cleanup (e.g. a
+// dropped passed-callback's stub being reclaimed → its channel closing → context.onClose firing).
+// Requires the server to run with `--expose-gc` (see this playground's dev/preview scripts).
+app.post('/api/gc', async (c) => {
+  const gc = (globalThis as { gc?: () => void }).gc
+  if (!gc) return c.json({ ok: false, reason: 'gc not exposed (run node with --expose-gc)' }, 500)
+  for (let i = 0; i < 5; i++) {
+    gc()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  return c.json({ ok: true })
+})
+
 app.post('/api/server-close-trigger', async (c) => {
   const channelId = c.req.query('channelId')
   if (!channelId) return c.json({ ok: false, reason: 'missing channelId' }, 400)

--- a/test/playground-stream/e2e-utils.ts
+++ b/test/playground-stream/e2e-utils.ts
@@ -1,4 +1,14 @@
-export { resetCleanupState, getCleanupState, navigate, getResult, sleep, restartProxy, stopProxy, startProxy }
+export {
+  resetCleanupState,
+  getCleanupState,
+  forceServerGc,
+  navigate,
+  getResult,
+  sleep,
+  restartProxy,
+  stopProxy,
+  startProxy,
+}
 
 import { page, getServerUrl } from '@brillout/test-e2e'
 import { execSync } from 'node:child_process'
@@ -37,6 +47,11 @@ async function resetCleanupState() {
 async function getCleanupState(): Promise<Record<string, string>> {
   const resp = await fetch(`${getServerUrl()}/api/cleanup-state`)
   return resp.json()
+}
+
+/** Forces a full GC on the server (via `/api/gc`) so GC-driven cleanup is deterministic in tests. */
+async function forceServerGc() {
+  await fetch(`${getServerUrl()}/api/gc`, { method: 'POST' })
 }
 
 /**

--- a/test/playground-stream/package.json
+++ b/test/playground-stream/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
-    "dev": "fuser -k 24679/tcp 2>/dev/null; rm -rf ./node_modules/.vite && vike dev",
+    "dev": "fuser -k 24679/tcp 2>/dev/null; rm -rf ./node_modules/.vite && NODE_OPTIONS='--expose-gc' vike dev",
     "dev:prof": "fuser -k 24679/tcp 2>/dev/null; rm -rf ./node_modules/.vite && mkdir -p profiles && NODE_OPTIONS='--cpu-prof --cpu-prof-dir=./profiles' vike dev",
     "build": "vike build",
-    "preview": "vike build && node dist/nested/server/index.mjs",
+    "preview": "vike build && node --expose-gc dist/nested/server/index.mjs",
     "preview:prof": "vike build && mkdir -p profiles && node --cpu-prof --cpu-prof-dir=./profiles dist/nested/server/index.mjs",
     "preview:cluster": "vike build && docker compose down --remove-orphans && exec docker compose up 2>&1",
     "preview:cluster:prof": "vike build && docker compose down --remove-orphans && exec docker compose -f compose.yaml -f compose.prof.yaml up 2>&1",

--- a/test/playground-stream/pages/close/Close.telefunc.ts
+++ b/test/playground-stream/pages/close/Close.telefunc.ts
@@ -7,6 +7,7 @@ export {
   onCloseChannelOnClose,
   onCloseStreamAndChannelOnClose,
   onClosePassedFnOnClose,
+  onGcPassedFnOnClose,
 }
 
 import { Channel, getContext } from 'telefunc'
@@ -111,6 +112,25 @@ async function onClosePassedFnOnClose(callback: () => void) {
     cleanupState.closePassedFnOnClose_contextOnClose = 'fired'
   })
   return { callback }
+}
+
+/**
+ * Client passes a function, then drops it without ever calling `close()`. The server neither
+ * stores nor returns the callback, so once GC reclaims its stub the request-side channel must
+ * close and `context.onClose` must fire — no explicit close from the client.
+ * Regression test for holder-side GC cleanup of passed callbacks.
+ */
+async function onGcPassedFnOnClose(callback: () => void) {
+  cleanupState.gcPassedFnOnClose_contextOnClose = 'not-fired'
+  cleanupState.gcPassedFnOnClose_callbackCalled = 'false'
+  callback()
+  cleanupState.gcPassedFnOnClose_callbackCalled = 'true'
+  getContext().onClose(() => {
+    cleanupState.gcPassedFnOnClose_contextOnClose = 'fired'
+  })
+  // Deliberately returns nothing referencing `callback`: its server-side stub is now
+  // unreachable and must be collectable.
+  return { ok: true }
 }
 
 // ── Mixed ────────────────────────────────────────────────────────────

--- a/test/playground-stream/pages/close/Close.tsx
+++ b/test/playground-stream/pages/close/Close.tsx
@@ -12,6 +12,7 @@ import {
   onCloseChannelOnClose,
   onCloseStreamAndChannelOnClose,
   onClosePassedFnOnClose,
+  onGcPassedFnOnClose,
 } from './Close.telefunc'
 
 function Close() {
@@ -206,6 +207,22 @@ function Close() {
         }}
       >
         Close passed fn result
+      </button>
+
+      <h2>Passed function GC cleanup</h2>
+
+      <button
+        id="test-gc-passed-fn-onclose"
+        onClick={async () => {
+          setResult('')
+          // Pass a throwaway callback and keep no reference to it or the result. The server's
+          // stub becomes collectable; a forced server GC must then close the request-side channel
+          // and fire context.onClose — with no explicit close() from the client.
+          await onGcPassedFnOnClose(() => {})
+          setResult(JSON.stringify({ method: 'gc(passed-fn-onclose)', phase: 'returned' }))
+        }}
+      >
+        Passed fn: context.onClose fires after server GC
       </button>
 
       <h2>{'Mixed: { generator, stream, channel, fn }'}</h2>

--- a/test/playground-stream/pages/close/e2e-test.ts
+++ b/test/playground-stream/pages/close/e2e-test.ts
@@ -1,7 +1,7 @@
 export { testClose }
 
 import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
-import { resetCleanupState, getCleanupState, navigate, getResult, sleep } from '../../e2e-utils'
+import { resetCleanupState, getCleanupState, forceServerGc, navigate, getResult, sleep } from '../../e2e-utils'
 
 function testClose() {
   // ── Targeted: generator ──────────────────────────────────────────────
@@ -182,6 +182,35 @@ function testClose() {
     await autoRetry(async () => {
       const state = await getCleanupState()
       expect(state.closePassedFnOnClose_contextOnClose).toBe('fired')
+    })
+  })
+
+  // ── Passed function: context.onClose fires after server GC (no explicit close) ──
+
+  test('close: passed function GC — context.onClose fires after the server GC-reclaims a dropped callback', async () => {
+    await navigate(`${getServerUrl()}/close`)
+    await resetCleanupState()
+
+    await page.click('#test-gc-passed-fn-onclose')
+
+    // Telefunc returned and the server invoked the callback.
+    await autoRetry(async () => {
+      const result = await getResult('#close-result')
+      expect(result.method).toBe('gc(passed-fn-onclose)')
+      expect(result.phase).toBe('returned')
+    })
+    await autoRetry(async () => {
+      const state = await getCleanupState()
+      expect(state.gcPassedFnOnClose_callbackCalled).toBe('true')
+    })
+
+    // No explicit close() and no returned reference: the callback's server-side stub is
+    // unreachable. Forcing GC must reclaim it, close the request-side channel, and fire
+    // context.onClose. Force GC each retry so it keeps trying until the stub is collected.
+    await autoRetry(async () => {
+      await forceServerGc()
+      const state = await getCleanupState()
+      expect(state.gcPassedFnOnClose_contextOnClose).toBe('fired')
     })
   })
 


### PR DESCRIPTION
## What

A function or `ReadableStream` passed as a telefunction argument is backed by a
request-side channel. The server held a stub for it but never GC-tracked it, so
when the telefunction dropped it the channel stayed open — leaking it (and the
request context), and `ctx.onClose` never fired — until an explicit `close()`,
abort, or disconnect.

## Fix

The server now GC-tracks each revived request stub (mirroring the client's
response side): once the telefunction drops it, GC closes its channel and the
client releases the original.

The tracking uses one shared `GcRegistry` whose fallback scan `setInterval` runs
**only while stubs are tracked** — an idle isolate keeps no timer, so a Cloudflare
Durable Object can still hibernate.

## Tests

- `gcRegistry.spec.ts` — real-GC proof (drop → close fires), gated behind `--expose-gc`.
- `playground-stream` e2e — a client-passed callback, dropped with no explicit
  close, fires `ctx.onClose` after the server GC-reclaims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
