### PR TITLE
chore: @brillout/docpress@^0.17.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   },
   "========= The telefunc dependency is a trick for triggering the docs to rebuild upon releasing a new Telefunc version (so that the Telefunc version shown on telefunc.com is up-to-date)": "",
   "dependencies": {
-    "@brillout/docpress": "^0.16.50",
+    "@brillout/docpress": "^0.17.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",

--- a/docs/pages/RPC-vs-GraphQL-REST/+Page.mdx
+++ b/docs/pages/RPC-vs-GraphQL-REST/+Page.mdx
@@ -106,7 +106,7 @@ while the backend (another Node.js server, Ruby on Rails, ...) can be developed 
 
 Another common misbelief is that GraphQL/REST is required to develop several frontends.
 
-You can develop multiple frontends as well with RPC by having one <Link text="Telefunc Server" href="#telefunc-server" /> per frontend.
+You can develop multiple frontends as well with RPC by having one <Link href="#telefunc-server">Telefunc Server</Link> per frontend.
 
 > The rise of edge computing,
 > such as Cloudflare Workers,

--- a/docs/pages/babel-plugin/+Page.mdx
+++ b/docs/pages/babel-plugin/+Page.mdx
@@ -1,4 +1,4 @@
 import { Link } from '@brillout/docpress'
 
-Telefunc's [Babel](https://babeljs.io) plugin adds the <Link text="Telefunc Transformer" href="/transformer" /> to Babel apps, such as:
+Telefunc's [Babel](https://babeljs.io) plugin adds the <Link href="/transformer">Telefunc Transformer</Link> to Babel apps, such as:
  - <Link href="/react-native" />

--- a/docs/pages/channel-config/+Page.mdx
+++ b/docs/pages/channel-config/+Page.mdx
@@ -28,7 +28,7 @@ config.channel = {
 }
 ```
 
-> This is the **server-side** `config.channel` — a separate object from the **client-side** <Link text={<code>config.channel.transports</code>} href="/transport" /> (`telefunc/client`).
+> This is the **server-side** `config.channel` — a separate object from the **client-side** <Link href="/transport"><code>config.channel.transports</code></Link> (`telefunc/client`).
 
 > **What to tune**: the defaults suit typical stream use cases; tune these only if you run into one of the issues below:
 > - Slow/flaky clients dropping with `NetworkError` (`isChannel: true`) → raise `reconnectTimeout` (how long the server holds a channel open while a client is gone).

--- a/docs/pages/channel/+Page.mdx
+++ b/docs/pages/channel/+Page.mdx
@@ -7,9 +7,9 @@ import { TelefuncStreamBeta } from '../../components'
 
 The following low-level **primitives** enable all kinds of <Link href="/stream">stream</Link> use case.
 
-- <Link text={<code>new Channel()</code>} href="#new-channel" /> — direct messages between one server and one client.
-- <Link text={<code>Broadcast</code>} href="#broadcast" /> — a keyed pub/sub bus (`publish()`/`subscribe()`), server-side.
-- <Link text={<code>new BroadcastChannel()</code>} href="#new-broadcastchannel" /> — broadcast also on the client-side.
+- <Link href="#new-channel"><code>new Channel()</code></Link> — direct messages between one server and one client.
+- <Link href="#broadcast"><code>Broadcast</code></Link> — a keyed pub/sub bus (`publish()`/`subscribe()`), server-side.
+- <Link href="#new-broadcastchannel"><code>new BroadcastChannel()</code></Link> — broadcast also on the client-side.
 
 > You can use them for one-way streams (aka streaming) as well as two-way streams (aka real-time):
 > - Chat rooms
@@ -280,7 +280,7 @@ info.timestamp  // server timestamp (Unix epoch ms)
 
 **Keys are capabilities** — anyone who knows the `key` joins the group. Secure a broadcast in one of two ways:
 - **Guard the key**: derive it from **authorized server-side context** (e.g. the user ID from <Link href="/getContext">`getContext()`</Link>), never from client-side input.
-- **Guard the payload**: whatever you `publish()` reaches every subscriber, so broadcast only non-sensitive data. That's how <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" /> stays safe — it broadcasts only a *"refetch"* signal, and each client loads the actual data through its own authorized telefunction.
+- **Guard the payload**: whatever you `publish()` reaches every subscriber, so broadcast only non-sensitive data. That's how <Link href="/tanstack-query"><code>@telefunc/tanstack-query</code></Link> stays safe — it broadcasts only a *"refetch"* signal, and each client loads the actual data through its own authorized telefunction.
 
 See also:
 - <Link href="/stream#authorization" />
@@ -372,7 +372,7 @@ broadcast.subscribe((n) => showToast(n))
 | `close()` | Close gracefully. |
 | `abort(abortValue?)` | Terminate immediately. |
 
-> The instance is bound to its `key`, so `publish(data)` / `subscribe(cb)` take no key. The static <Link text={<code>Broadcast.publish(key, data)</code>} href="#broadcast" /> / `Broadcast.subscribe(key, cb)` have no `onOpen` / `onClose` / `close` / `abort` since there's no instance to manage.
+> The instance is bound to its `key`, so `publish(data)` / `subscribe(cb)` take no key. The static <Link href="#broadcast"><code>Broadcast.publish(key, data)</code></Link> / `Broadcast.subscribe(key, cb)` have no `onOpen` / `onClose` / `close` / `abort` since there's no instance to manage.
 
 
 ## `new BroadcastChannel()` VS `new Channel()`
@@ -401,7 +401,7 @@ Only the two ends of a channel can use it, while anything that knows a broadcast
 | Message type | Asymmetric:<ul><li>Two different types: `Channel<ClientMessageType, ServerMessageType>`</li><li>The server uses the `new Channel()` instance, and returns `channel.client` to the client</li></ul> | Symmetric:<ul><li>Same type for every member: `BroadcastChannel<MessageType>`</li><li>The server uses and returns the same `BroadcastChannel` instance</li></ul> |
 | Message return | The other end's reply (if `{ ack: true }`) | A receipt: `{ key, seq, timestamp }` |
 | `close()` | Closes the channel for both ends | Detaches this member; the group lives on |
-| Multi-server | <Link text="Sticky sessions" href="/stream/scale#sticky-sessions" /> | <Link text="Broadcast transport" href="/stream/scale#broadcast" /> |
+| Multi-server | <Link href="/stream/scale#sticky-sessions">Sticky sessions</Link> | <Link href="/stream/scale#broadcast">Broadcast transport</Link> |
 
 
 ## Errors

--- a/docs/pages/close/+Page.mdx
+++ b/docs/pages/close/+Page.mdx
@@ -77,7 +77,7 @@ That said, if you want the stream to close as soon as possible, manually close i
 
 ## How to close
 
-From the client, you can manually close a stream early with <Link text={<code>close()</code>} href="#close" /> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel.
+From the client, you can manually close a stream early with <Link href="#close"><code>close()</code></Link> — or simply stop reading: `break` out of a `for await`, `reader.cancel()` a `ReadableStream`, or `channel.close()` a channel.
 
 There's one catch-all API, `close()`, plus several <Link href="/stream">per-stream-primitive</Link> APIs.
 
@@ -86,10 +86,10 @@ There's one catch-all API, `close()`, plus several <Link href="/stream">per-stre
 | `close(value)` | client | Graceful | Everything in the returned value (walked recursively) |
 | `gen.return()` / `break` | client | Graceful | One `AsyncGenerator` |
 | `reader.cancel()` | client | Graceful | One `ReadableStream` |
-| <Link text={<code>channel.close()</code>} href="/channel#channel-methods" /> | client & server | Graceful | One `Channel` / `BroadcastChannel` (both ends) |
-| <Link text={<code>channel.abort(value?)</code>} href="/channel#channel-methods" /> | client & server | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
+| <Link href="/channel#channel-methods"><code>channel.close()</code></Link> | client & server | Graceful | One `Channel` / `BroadcastChannel` (both ends) |
+| <Link href="/channel#channel-methods"><code>channel.abort(value?)</code></Link> | client & server | Immediate | One `Channel` / `BroadcastChannel`, with an abort value |
 | `abort(call)` | client | Immediate | The in-flight call and any channels it opened |
-| <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" /> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
+| <Link href="/withContext"><code>{'withContext(fn, { signal })'}</code></Link> | client | Immediate | The call and any channels it opened, via an `AbortSignal` |
 
 **Graceful**: flush buffered data, then close.  
 **Immediate**: cancel in-flight work.  
@@ -127,7 +127,7 @@ const call = onLoadDashboard()
 abort(call) // cancels the in-flight call
 ```
 
-To abort via an `AbortSignal` instead, use <Link text={<code>{'withContext(fn, { signal })'}</code>} href="/withContext" />.
+To abort via an `AbortSignal` instead, use <Link href="/withContext"><code>{'withContext(fn, { signal })'}</code></Link>.
 
 
 ## See also

--- a/docs/pages/error-handling/+Page.mdx
+++ b/docs/pages/error-handling/+Page.mdx
@@ -109,7 +109,7 @@ See also: <Link href="/permissions#getcontext-wrapping" doNotInferSectionTitle={
 
 **2. Handle the error on the server-side.**
 
-Register an <Link text={<code>onBug()</code>} href="/onBug" /> hook — it's called whenever a telefunction throws a bug (any error that isn't `Abort()`):
+Register an <Link href="/onBug"><code>onBug()</code></Link> hook — it's called whenever a telefunction throws a bug (any error that isn't `Abort()`):
 
 ```ts
 // server.ts

--- a/docs/pages/event-based/+Page.mdx
+++ b/docs/pages/event-based/+Page.mdx
@@ -256,7 +256,7 @@ This convention is optional and you can opt-out.
 
 ### Opt out
 
-Telefunc shows a warning if you don't follow the naming convention — you can opt-out of the convention and remove the warning by setting <Link text={<code>config.disableNamingConvention</code>} href="/disableNamingConvention" />.
+Telefunc shows a warning if you don't follow the naming convention — you can opt-out of the convention and remove the warning by setting <Link href="/disableNamingConvention"><code>config.disableNamingConvention</code></Link>.
 
 <EventBasedRecommendation samePage />
 

--- a/docs/pages/file-download/+Page.mdx
+++ b/docs/pages/file-download/+Page.mdx
@@ -176,7 +176,7 @@ You can choose between `download()` and a native `File`/`Blob`:
 
 ### `download()`
 
-A `download()` value exposes progress and cancellation on the client. (Native `File` / `Blob` returns don't — wrap your bytes with <Link text={<code>download()</code>} href="#passthrough" /> to opt in.)
+A `download()` value exposes progress and cancellation on the client. (Native `File` / `Blob` returns don't — wrap your bytes with <Link href="#passthrough"><code>download()</code></Link> to opt in.)
 
 | Member | Type | Description |
 |---|---|---|
@@ -258,7 +258,7 @@ await dl.saveToDisk()
 
 TO-DO: add note for native `File`/`Blob` use case?
 
-On the server, use <Link text={<code>onClose()</code>} href="/onClose" /> to release resources your telefunction opened when the client cancels:
+On the server, use <Link href="/onClose"><code>onClose()</code></Link> to release resources your telefunction opened when the client cancels:
 
 ```ts
 // Download.telefunc.ts
@@ -280,7 +280,7 @@ export async function onDownload(dir: string) {
 }
 ```
 
-> **You don't always need `onClose()`.** When the `download()` source is a plain stream — like a <Link text="S3 passthrough" href="#passthrough" /> — the upstream read is automatically cancelled.
+> **You don't always need `onClose()`.** When the `download()` source is a plain stream — like a <Link href="#passthrough">S3 passthrough</Link> — the upstream read is automatically cancelled.
 
 */}
 

--- a/docs/pages/file-upload/+Page.mdx
+++ b/docs/pages/file-upload/+Page.mdx
@@ -121,9 +121,9 @@ Passing a `File` / `Blob` argument is one of several ways to move binary data wi
 | Method | Backpressure | Best for |
 |---|---|---|
 | `File` / `Blob` argument | TCP-level | Finite uploads — files, images, CSV imports |
-| <Link text={<code>ReadableStream</code>} href="/stream#readable-stream" /> argument | Yes | Long-lived streams — video feed, sensor data, continuous audio |
-| <Link text={<code>new Channel().sendBinary()</code>} href="/channel#binary-data" /> | <Link text="Opt-in" href="/channel#backpressure" /> — `await` each send | Low-latency frames — skip the `await` for fire-and-forget |
-| <Link text={<code>new BroadcastChannel().publishBinary()</code>} href="/channel#new-broadcastchannel" /> | Publish-side only | Broadcast binary — video to multiple subscribers |
+| <Link href="/stream#readable-stream"><code>ReadableStream</code></Link> argument | Yes | Long-lived streams — video feed, sensor data, continuous audio |
+| <Link href="/channel#binary-data"><code>new Channel().sendBinary()</code></Link> | <Link href="/channel#backpressure">Opt-in</Link> — `await` each send | Low-latency frames — skip the `await` for fire-and-forget |
+| <Link href="/channel#new-broadcastchannel"><code>new BroadcastChannel().publishBinary()</code></Link> | Publish-side only | Broadcast binary — video to multiple subscribers |
 
 
 ## Reading strategies

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -30,7 +30,7 @@ It's most commonly used for implementing permissions, see <Link href="/permissio
 
 You can add `context` properties when calling `telefunc.serve()` — see <Link href="/Telefunc" />.
 
-> You can also provide `context` outside the server middleware (e.g. when <Link href="/testing">testing</Link>) via <Link text={<code>provideTelefuncContext()</code>} href="/provideTelefuncContext" />.
+> You can also provide `context` outside the server middleware (e.g. when <Link href="/testing">testing</Link>) via <Link href="/provideTelefuncContext"><code>provideTelefuncContext()</code></Link>.
 
 
 ## Access

--- a/docs/pages/headers/+Page.mdx
+++ b/docs/pages/headers/+Page.mdx
@@ -17,7 +17,7 @@ config.headers = {
 }
 ```
 
-> To set headers on a **single call** rather than globally, use <Link text={<code>withContext()</code>} href="/withContext" />.
+> To set headers on a **single call** rather than globally, use <Link href="/withContext"><code>withContext()</code></Link>.
 
 <ConfigWhereClient />
 

--- a/docs/pages/onAbort/+Page.mdx
+++ b/docs/pages/onAbort/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 **Environment**: client.
 
-The `onAbort()` hook is called whenever the browser makes a telefunction call that fails because the telefunction ran <Link text={<code>throw Abort()</code>} href="/Abort" />.
+The `onAbort()` hook is called whenever the browser makes a telefunction call that fails because the telefunction ran <Link href="/Abort"><code>throw Abort()</code></Link>.
 
 It does **not** run when other errors are thrown, see <Link href="/abort-vs-error" />.
 

--- a/docs/pages/rxjs/+Page.mdx
+++ b/docs/pages/rxjs/+Page.mdx
@@ -193,7 +193,7 @@ export class DashboardComponent {
 
 ## Lifecycle
 
-Unsubscribing stops data flow immediately. The underlying <Link href="/channel" text="channel" /> is cleaned up <Link href="/close#when-to-close">automatically via GC</Link>, or immediately if you use <Link href="/close">`close()`</Link>.
+Unsubscribing stops data flow immediately. The underlying <Link href="/channel">channel</Link> is cleaned up <Link href="/close#when-to-close">automatically via GC</Link>, or immediately if you use <Link href="/close">`close()`</Link>.
 
 
 ## See also

--- a/docs/pages/serve/+Page.mdx
+++ b/docs/pages/serve/+Page.mdx
@@ -4,13 +4,13 @@ import { Link } from '@brillout/docpress'
 
 Low-level function that turns a telefunction HTTP request into an HTTP response. It's a pure function: stateless and side-effect-free. It runs in any runtime, with no adapter required.
 
-> **Most apps should use <Link text={<code>new Telefunc()</code>} href="/Telefunc" /> instead** — it's the standard server integration.
+> **Most apps should use <Link href="/Telefunc"><code>new Telefunc()</code></Link> instead** — it's the standard server integration.
 >
 > `new Telefunc()` has full-fledged support for <Link href="/stream">Telefunc Stream</Link>, whereas `serve()` doesn't support the following:
-> - <Link text="WebSocket" href="/transport#channel-transport" />
+> - <Link href="/transport#channel-transport">WebSocket</Link>
 >   > You can still use <Link href="/stream">Telefunc Stream</Link>, but not over the WebSocket transport — Telefunc falls back to another transport instead.
-> - <Link text="Channels" href="/channel" /> on Cloudflare
->   > You won't be able to use channels on Cloudflare at all. (Because channels need <Link text="Durable Objects" href="/stream/cloudflare" />.)
+> - <Link href="/channel">Channels</Link> on Cloudflare
+>   > You won't be able to use channels on Cloudflare at all. (Because channels need <Link href="/stream/cloudflare">Durable Objects</Link>.)
 
 
 ## Web `Request`

--- a/docs/pages/shield/+Page.mdx
+++ b/docs/pages/shield/+Page.mdx
@@ -43,7 +43,7 @@ export async function hello({ name }: { name: string }) {
 
 With Telefunc, not only can you seamlessly re-use types across your frontend and backend code, but you also get automatic type-safety at runtime. If you use a TypeScript ORM (e.g. [Prisma](https://www.prisma.io/)) or SQL builder (e.g. [Kysely](https://github.com/koskimas/kysely) and [others](https://github.com/stars/brillout/lists/sql)), then you get end-to-end type safety all the way from database to frontend.
 
-> Telefunc guarantees that **every** value arriving at the server is validated — not just a telefunction's top-level arguments, but also every value the client sends through a <Link href="/stream" text="streaming primitive" /> (callbacks, channels, streams).
+> Telefunc guarantees that **every** value arriving at the server is validated — not just a telefunction's top-level arguments, but also every value the client sends through a <Link href="/stream">streaming primitive</Link> (callbacks, channels, streams).
 
 > For a faster development, Telefunc doesn't generate `shield()` and your telefunction arguments aren't validated during development.
 > Telefunc only generates `shield()` upon building your app for production.

--- a/docs/pages/stream/+Page.mdx
+++ b/docs/pages/stream/+Page.mdx
@@ -12,7 +12,7 @@ import { TelefuncStreamBeta } from '../../components'
 
 #### Primitives
 
-1. <Link href="#async-generator" text={<><code>AsyncGenerator</code> (<code>function*</code>)</>} />:
+1. <Link href="#async-generator"><><code>AsyncGenerator</code> (<code>function*</code>)</></Link>:
    ```ts
    // AiChat.telefunc.ts
    // Environment: server
@@ -26,7 +26,7 @@ import { TelefuncStreamBeta } from '../../components'
    }
    ```
 
-1. <Link href="#callback" text={<>Callback (<code>function</code> passing)</>} />:
+1. <Link href="#callback"><>Callback (<code>function</code> passing)</></Link>:
    ```ts
    // Notifications.telefunc.ts
    // Environment: server
@@ -39,7 +39,7 @@ import { TelefuncStreamBeta } from '../../components'
    }
    ```
 
-1. <Link href="#multiple-promise" text={<>Multiple <code>Promise</code></>} />:
+1. <Link href="#multiple-promise"><>Multiple <code>Promise</code></></Link>:
    ```ts ts-only
    // Dashboard.telefunc.ts
    // Environment: server
@@ -54,7 +54,7 @@ import { TelefuncStreamBeta } from '../../components'
    }
    ```
 
-1. <Link href="#readable-stream" text={<code>ReadableStream</code>} />:
+1. <Link href="#readable-stream"><code>ReadableStream</code></Link>:
    ```ts
    // Compress.telefunc.ts
    // Environment: server
@@ -65,14 +65,14 @@ import { TelefuncStreamBeta } from '../../components'
    }
    ```
 
-1. <Link href="#channel" text={<code>Channel</code>} />: API for advanced real-time use cases.
+1. <Link href="#channel"><code>Channel</code></Link>: API for advanced real-time use cases.
 
 > A single telefunction can [mix primitives](https://gist.github.com/brillout/155c8eb4cbaa043bc52e96c0c2ed7086) (generators, channels, promises, ...) side by side, each resolving independently.
 
 #### Integrations
 
-<Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" />: automatically synced TanStack queries.  
-<Link text={<code>@telefunc/rxjs</code>} href="/rxjs" />: reactive streams and operators.  
+<Link href="/tanstack-query"><code>@telefunc/tanstack-query</code></Link>: automatically synced TanStack queries.  
+<Link href="/rxjs"><code>@telefunc/rxjs</code></Link>: reactive streams and operators.  
 
 > Integrations provide an even more seamless DX: they handle more for you. They're powered by the primitives listed on this page.
 
@@ -201,7 +201,7 @@ await onUpload(file, (percent) => setProgress(percent))
 
 > The underlying stream automatically closes itself when the client stops using (i.e. stops referencing) `onProgress`, but you can also manually close it (eagerly), see <Link href="/close" />.
 
-> Under the hood, a passed function is just a <Link text={<code>Channel</code>} href="#channel" />. A callback has the same lifecycle as a channel, only exposed with a nicer JavaScript DX.
+> Under the hood, a passed function is just a <Link href="#channel"><code>Channel</code></Link>. A callback has the same lifecycle as a channel, only exposed with a nicer JavaScript DX.
 >
 > Reach for a raw `Channel` if you need more than call-and-return — e.g. two-way messaging, broadcast, or binary.
 
@@ -389,7 +389,7 @@ export function onCompressVideo(video: ReadableStream<Uint8Array>): ReadableStre
 
 > The memory consumption is constant regardless of file size.
 
-> A spawned process outlives the call and keeps burning CPU if the client navigates away mid-encode — make sure to terminate it in `onClose()`, see <Link text="Cleanup" href="#cleanup" />.
+> A spawned process outlives the call and keeps burning CPU if the client navigates away mid-encode — make sure to terminate it in `onClose()`, see <Link href="#cleanup">Cleanup</Link>.
 
 
 ## Primitive: `Channel` {#channel}
@@ -399,7 +399,7 @@ For ongoing two-way or broadcast messaging, you can use a channel, see:
 
 > This is the low-level primitive that powers most of Telefunc Stream.
 
-> Instead of directly using channels, most users reach for high-level primitives (e.g. <Link href="#callback">callbacks</Link>) and high-level integrations (e.g. <Link text={<code>@telefunc/tanstack-query</code>} href="/tanstack-query" />).
+> Instead of directly using channels, most users reach for high-level primitives (e.g. <Link href="#callback">callbacks</Link>) and high-level integrations (e.g. <Link href="/tanstack-query"><code>@telefunc/tanstack-query</code></Link>).
 
 ```js
 // Dashboard.telefunc.js
@@ -468,7 +468,7 @@ You can also use a `signal` (`AbortSignal`) and `channel.onClose()` to listen fo
 
 **Environment**: server.
 
-A streaming telefunction authorizes like any other telefunction (see <Link href="/permissions" />): check <Link href="/getContext">`getContext()`</Link> and `throw Abort()` **at open time**, before you stream anything back to the client. Here the client passes a <Link text="callback" href="#callback" /> and the server calls it:
+A streaming telefunction authorizes like any other telefunction (see <Link href="/permissions" />): check <Link href="/getContext">`getContext()`</Link> and `throw Abort()` **at open time**, before you stream anything back to the client. Here the client passes a <Link href="#callback">callback</Link> and the server calls it:
 
 ```ts
 // TeamFeed.telefunc.ts

--- a/docs/pages/stream/cloudflare/+Page.mdx
+++ b/docs/pages/stream/cloudflare/+Page.mdx
@@ -52,13 +52,13 @@ export default {
 > - **Durable Objects** provide stateful compute: each channel lives on a Durable Object, which holds the connection and its state.
 > - **KV** provides shared storage: it's how stateless workers find the Durable Object that holds the state, no matter which worker a request lands on.
 >
-> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` or `BroadcastChannel`, there's no state to keep — you can skip both bindings and use <Link text={<code>serve()</code>} href="/serve" /> instead.
+> Both bindings are required whenever you use `telefunc/cloudflare`. If your app doesn't use `Channel` or `BroadcastChannel`, there's no state to keep — you can skip both bindings and use <Link href="/serve"><code>serve()</code></Link> instead.
 >
 > See <Link href="#architecture" /> for implementation details.
 
 ## Context
 
-Pass per-request data to telefunctions via <Link text={<code>getContext()</code>} href="/getContext" />:
+Pass per-request data to telefunctions via <Link href="/getContext"><code>getContext()</code></Link>:
 
 ```ts
 const telefunc = new Telefunc({

--- a/docs/pages/stream/scale/+Page.mdx
+++ b/docs/pages/stream/scale/+Page.mdx
@@ -63,7 +63,7 @@ Serverless platforms that don't expose sticky-session routing aren't a good fit 
 
 <Link href="/channel#broadcast">`Broadcast`</Link> is different: publishers and subscribers are intentionally decoupled — they only share a `key` string. Each instance keeps its own subscriber list locally, and the broadcast transport is what makes a publisher on instance A reach a subscriber on instance B.
 
-In a single-instance setup, the default in-memory transport is enough. In a multi-instance setup, install a transport that fans out across the cluster — such as <Link text={<code>@telefunc/redis</code>} href="/redis" />.
+In a single-instance setup, the default in-memory transport is enough. In a multi-instance setup, install a transport that fans out across the cluster — such as <Link href="/redis"><code>@telefunc/redis</code></Link>.
 
 > Redis is the only adapter shipped today, but the `BroadcastTransport` interface is small (about four methods), so you can write a custom transport on top of NATS, Kafka, RabbitMQ, or any other message broker.
 

--- a/docs/pages/testing/+Page.mdx
+++ b/docs/pages/testing/+Page.mdx
@@ -18,7 +18,7 @@ test('onHello', async () => {
 
 ## Providing context
 
-If a telefunction reads <Link href="/getContext">`getContext()`</Link> (e.g. to get the logged-in user), provide the context in your test setup with <Link text={<code>provideTelefuncContext()</code>} href="/provideTelefuncContext" /> before calling it:
+If a telefunction reads <Link href="/getContext">`getContext()`</Link> (e.g. to get the logged-in user), provide the context in your test setup with <Link href="/provideTelefuncContext"><code>provideTelefuncContext()</code></Link> before calling it:
 
 ```ts
 // Team.telefunc.test.ts
@@ -38,7 +38,7 @@ This is also how you test <Link href="/permissions">permissions</Link> — set u
 
 ## Channels & the wire protocol
 
-A telefunction that opens a <Link text={<code>Channel</code>} href="/channel" /> is still a plain function — call it directly to assert it authorizes correctly and wires up its listeners.
+A telefunction that opens a <Link href="/channel"><code>Channel</code></Link> is still a plain function — call it directly to assert it authorizes correctly and wires up its listeners.
 
 The wire protocol — reconnection, multi-client broadcast, transport upgrades — only exists over a real connection, so cover it with an **end-to-end test** against a running server.
 

--- a/docs/pages/transformer/+Page.mdx
+++ b/docs/pages/transformer/+Page.mdx
@@ -3,7 +3,7 @@ import { Link } from '@brillout/docpress'
 Telefunc plugins transforms `.telefunc.js` files for:
 
 - The client-side, replacing `.telefunc.js` imports with a thin HTTP client.
-- The server-side, for <Link text="automatic TypeScript runtime validation" href="/shield#typescript-automatic" doNotInferSectionTitle={true} />.
+- The server-side, for <Link href="/shield#typescript-automatic" doNotInferSectionTitle={true}>automatic TypeScript runtime validation</Link>.
 
 Telefunc plugins also automatically crawl your `.telefunc.js` files (so that you don't have to use <Link href="/telefuncFiles">`config.telefuncFiles`</Link>).
 

--- a/docs/pages/transport/+Page.mdx
+++ b/docs/pages/transport/+Page.mdx
@@ -9,8 +9,8 @@ Telefunc has two transport settings that control which network protocol is used 
 
 | Setting | Controls |
 |---|---|
-| `config.stream.transport` | Streaming (<Link text={<code>AsyncGenerator</code>} href="/stream#async-generator" />, <Link text={<code>ReadableStream</code>} href="/stream#readable-stream" />, <Link text={<code>Promise</code>} href="/stream#multiple-promise" />) |
-| `config.channel.transports` | <Link text={<code>new Channel()</code>} href="/channel" /> (<Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, <Link text="callbacks" href="/stream#callback" />) |
+| `config.stream.transport` | Streaming (<Link href="/stream#async-generator"><code>AsyncGenerator</code></Link>, <Link href="/stream#readable-stream"><code>ReadableStream</code></Link>, <Link href="/stream#multiple-promise"><code>Promise</code></Link>) |
+| `config.channel.transports` | <Link href="/channel"><code>new Channel()</code></Link> (<Link href="/channel#new-broadcastchannel"><code>new BroadcastChannel()</code></Link>, <Link href="/stream#callback">callbacks</Link>) |
 
 > These settings only affect <Link href="/stream">streams</Link> — plain telefunction calls are always `text/plain` JSON.
 
@@ -47,7 +47,7 @@ Controls how streaming values are delivered over HTTP.
 | `'binary-inline'` | ✅ | 🟡 | ❌ | None |
 | `'sse-inline'` | 🟡 | ✅ | ❌ | None |
 | `'channel'` (SSE) | 🟡 | ✅ | ✅ | None |
-| `'channel'` (WS) | ✅ | 🟡 | ✅ | <Link text="Server setup" href="/Telefunc" /> |
+| `'channel'` (WS) | ✅ | 🟡 | ✅ | <Link href="/Telefunc">Server setup</Link> |
 
 *✅ good · 🟡 partial / caveats · ❌ none*
 
@@ -60,7 +60,7 @@ Controls how streaming values are delivered over HTTP.
 
 ## Channel transport
 
-Set the network protocol used by <Link text={<code>new Channel()</code>} href="/channel" />, <Link text={<code>new BroadcastChannel()</code>} href="/channel#new-broadcastchannel" />, and <Link href="/stream">stream primitives</Link> that use channels under the hood.
+Set the network protocol used by <Link href="/channel"><code>new Channel()</code></Link>, <Link href="/channel#new-broadcastchannel"><code>new BroadcastChannel()</code></Link>, and <Link href="/stream">stream primitives</Link> that use channels under the hood.
 
 | Transport | Description |
 |---|---|
@@ -102,7 +102,7 @@ All channels share a single multiplexed connection per server URL, so opening ma
 
 ## Per-call overrides
 
-Override transport for a single call (instead of globally) with <Link text={<code>withContext()</code>} href="/withContext" />:
+Override transport for a single call (instead of globally) with <Link href="/withContext"><code>withContext()</code></Link>:
 
 ```js
 // Environment: client

--- a/docs/pages/vite-plugin/+Page.mdx
+++ b/docs/pages/vite-plugin/+Page.mdx
@@ -4,7 +4,7 @@ Telefunc's [Vite](https://vitejs.dev) plugin automatically adds Telefunc to Vite
 
 The plugin:
  - Transforms your `.telefunc.js` files, see <Link href="/transformer" />.
- - Automatically adds the <Link text="Telefunc Server Middleware" href="/Telefunc" /> to Vite's development server as well as Vite's preview server.
+ - Automatically adds the <Link href="/Telefunc">Telefunc Server Middleware</Link> to Vite's development server as well as Vite's preview server.
  - Lazy-loads your `.telefunc.js` files for optimal development speed (aka on-demand compilation).
 
 You can pass Telefunc server configurations to the Vite plugin:

--- a/docs/pages/webpack-plugin/+Page.mdx
+++ b/docs/pages/webpack-plugin/+Page.mdx
@@ -1,5 +1,5 @@
 import { Link } from '@brillout/docpress'
 
-Telefunc's [webpack](https://webpack.js.org) plugin adds the <Link text="Telefunc Transformer" href="/transformer" /> to webpack apps, such as:
+Telefunc's [webpack](https://webpack.js.org) plugin adds the <Link href="/transformer">Telefunc Transformer</Link> to webpack apps, such as:
  - <Link href="/next" />
  - <Link href="/nuxt" />

--- a/docs/pages/withContext/+Page.mdx
+++ b/docs/pages/withContext/+Page.mdx
@@ -35,10 +35,10 @@ for await (const message of gen) {
 | Option | Type | Description |
 |---|---|---|
 | `signal` | `AbortSignal` | Cancel this call and any channels it opens. See also: <Link href="/close" />. |
-| `headers` | `Record<string, string>` | Extra HTTP headers for this call. Global default: <Link text={<code>config.headers</code>} href="/headers" />. |
-| `telefuncUrl` | `string` | Override <Link text={<code>config.telefuncUrl</code>} href="/telefuncUrl" /> for this call and its channels. |
-| `stream.transport` | <Link text="Stream transport" href="/transport#stream-transport" /> | Override `config.stream.transport` for streaming. |
-| `channel.transports` | <Link text="Channel transport" href="/transport#channel-transport" /> | Override `config.channel.transports` for channels. |
+| `headers` | `Record<string, string>` | Extra HTTP headers for this call. Global default: <Link href="/headers"><code>config.headers</code></Link>. |
+| `telefuncUrl` | `string` | Override <Link href="/telefuncUrl"><code>config.telefuncUrl</code></Link> for this call and its channels. |
+| `stream.transport` | <Link href="/transport#stream-transport">Stream transport</Link> | Override `config.stream.transport` for streaming. |
+| `channel.transports` | <Link href="/transport#channel-transport">Channel transport</Link> | Override `config.channel.transports` for channels. |
 | `channel.connectionKey` | `string` | By default, all channel calls to the same URL share one connection. Set a key to split calls across separate connections: calls with the same key share a connection, while different keys each get their own (keyless calls all share the default connection). |
 | `channel.idleTimeout` | `number` | How long (ms) to keep the underlying connection open after all channels close. Default `60_000`; `0` closes it immediately. |
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
   docs:
     dependencies:
       '@brillout/docpress':
-        specifier: ^0.16.50
-        version: 0.16.50(@algolia/client-search@5.31.0)(@types/react@19.2.14)(@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.44.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@0.4.259(@cloudflare/workers-types@4.20260615.1)(@types/express@5.0.3)(react-streaming@0.4.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(srvx@0.11.16)(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0))
+        specifier: ^0.17.0
+        version: 0.17.0(@algolia/client-search@5.31.0)(@types/react@19.2.14)(@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.44.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@0.4.259(@cloudflare/workers-types@4.20260615.1)(@types/express@5.0.3)(react-streaming@0.4.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(srvx@0.11.16)(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -760,10 +760,6 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
@@ -1320,8 +1316,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@brillout/docpress@0.16.50':
-    resolution: {integrity: sha512-Kop78xd1LccxdWYK0soC0Q5XF3Lqg9dCRvvdSR+LvSgk3u/lkGXLM0yV2AJrho45VMtICa1JVB3I1mxcbOvqHA==}
+  '@brillout/docpress@0.17.0':
+    resolution: {integrity: sha512-cezCgnBUh2NmhwFn1d+Qqv5ERelU+imptKIJAlJuGUA5rC0ZQqN2s6MmIFJa/0p4E4/c2UVkOIl4VeAQev4mFQ==}
     peerDependencies:
       '@vitejs/plugin-react': '>=4.0.0'
       react: '>=18.0.0'
@@ -7297,8 +7293,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0)':
@@ -7701,12 +7695,12 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.0)':
     dependencies:
@@ -7974,7 +7968,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@brillout/docpress@0.16.50(@algolia/client-search@5.31.0)(@types/react@19.2.14)(@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.44.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@0.4.259(@cloudflare/workers-types@4.20260615.1)(@types/express@5.0.3)(react-streaming@0.4.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(srvx@0.11.16)(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0))':
+  '@brillout/docpress@0.17.0(@algolia/client-search@5.31.0)(@types/react@19.2.14)(@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.44.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@0.4.259(@cloudflare/workers-types@4.20260615.1)(@types/express@5.0.3)(react-streaming@0.4.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(srvx@0.11.16)(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0)))(vite@8.0.16(@types/node@24.0.10)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
       '@brillout/picocolors': 1.0.30
       '@brillout/shiki-transformers': 4.0.2
@@ -9015,7 +9009,7 @@ snapshots:
       accepts: 1.3.8
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 4.4.0
+      debug: 4.4.3
       lru-cache: 11.0.2
       multipipe: 4.0.0
       on-headers: 1.0.2
@@ -13907,7 +13901,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.0.10)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.0(@types/node@24.0.10)(jiti@2.7.0)(lightningcss@1.32.0)


### PR DESCRIPTION
Bumps `@brillout/docpress` from `^0.16.50` to `^0.17.0`.

## Why CI was red

docpress 0.17 removes the `text` prop of `<Link>`: rendering `<Link text="..." />` now throws `[DocPress][Wrong Usage] The `text` prop of `<Link>` is deprecated, use `<Link>...</Link>` instead`. This broke the docs build (`docs:build`) and, on `main`, would break the website deployment.

## Fix

Migrated every `<Link text=... href=... />` in the docs to the new children form `<Link href=...>...</Link>`, across 24 `.mdx` pages. Extra props (e.g. `doNotInferSectionTitle`) and JSX/code-span content (e.g. `<code>...</code>`, `{'withContext(fn, { signal })'}`) are preserved.

## Verification

- `pnpm run docs:build` — passes (58 HTML documents pre-rendered)
- `node docs/check-docs.mjs` (docs quality gate / `docs:lint`) — passes, all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdcTLPfis2Yd5tpPKeHJYd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdcTLPfis2Yd5tpPKeHJYd)_