### PR TITLE
refactor: Room API — architectural split & simplification pass

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -168,8 +168,8 @@ class RedisTransport implements BroadcastTransport {
   //
   // `{<key>}` braces force seq counter and broadcast channel onto the same Redis
   // Cluster hash slot, so the publish Lua script can touch both keys atomically.
-  // KV keys are unbraced: they're single-key operations, and `keys()` needs them
-  // spread across slots rather than pinned to one.
+  // KV keys are unbraced: every KV operation is single-key, so no cross-key
+  // atomicity — and thus no hash tag — is needed.
 
   private seqKey(key: string): string {
     return `${this.prefix}seq:{${key}}`

--- a/packages/telefunc/wire-protocol/room/client.ts
+++ b/packages/telefunc/wire-protocol/room/client.ts
@@ -1,14 +1,16 @@
 export { ClientRoom, ClientRoomParticipant, ClientStandaloneParticipant }
 
-import { assert, assertUsage } from '../../utils/assert.js'
+import { assert } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { makePublishInfo, type ChannelPublishAck, type ChannelPublishInfo } from '../channel.js'
 import type { ClientBroadcast, ClientChannel } from '../client/channel.js'
 import {
+  ParticipantBase,
   RoomState,
   frameWithMemberId,
   hasRoomTag,
+  normalizeJoinOptions,
   sizeFromWire,
   unframeMemberId,
   type BinaryWants,
@@ -50,10 +52,10 @@ class ClientRoom implements Room {
       meta: snapshot.meta,
       size: sizeFromWire(snapshot.size),
       members: snapshot.members,
+      closed: snapshot.closed,
       onListenersChanged: () => this._syncBinarySub(),
       onCallbackError: reportRoomError,
     })
-    this._state.closed = snapshot.closed
 
     // Text events always flow (they carry presence); binary is subscribed on demand.
     stub.subscribe((envelope, info) => this._onEnvelope(envelope, info))
@@ -86,9 +88,7 @@ class ClientRoom implements Room {
   }
 
   async join(meta: ParticipantMeta = {}, options?: JoinOptions): Promise<LocalParticipant> {
-    assertUsage(isObject(meta), 'join() meta should be an object')
-    assertUsage(options === undefined || isObject(options), 'join() options should be an object')
-    const selfDelivery = options?.selfDelivery !== false
+    const selfDelivery = normalizeJoinOptions(meta, options)
     const ack = (await this._request({ __r: 'req-join', meta, selfDelivery })) as ReqJoinAck
     if (!ack.ok) throw new Error(ack.err)
     const participant = new ClientRoomParticipant(this, ack.id, meta, selfDelivery)
@@ -254,79 +254,24 @@ class ClientRoom implements Room {
 // Local participants
 // ---------------------------------------------------------------------------
 
-/** Shared behavior of both client-side `LocalParticipant` flavors. */
-abstract class ClientParticipantBase implements LocalParticipant {
-  readonly id: string
-  readonly selfDelivery: boolean
-  /** @internal */ _meta: ParticipantMeta
+/** Client-side half of both `LocalParticipant` flavors: links `selfDelivery` suppression
+ *  to the sibling room via the registry below. */
+abstract class ClientParticipantBase extends ParticipantBase {
   protected readonly _roomId: string
-  protected _left = false
-  private _leftFired = false
-  private _leaveCbs: Array<() => void> = []
-  private readonly _messageCbs: Array<(data: unknown, fromId: string) => void> = []
 
   constructor(roomId: string, id: string, meta: ParticipantMeta, selfDelivery: boolean) {
+    super(id, meta, selfDelivery)
     this._roomId = roomId
-    this.id = id
-    this._meta = meta
-    this.selfDelivery = selfDelivery
     if (!selfDelivery) setSuppressed(roomId, id, true)
   }
 
-  get meta(): ParticipantMeta {
-    return this._meta
-  }
-
-  abstract publish(data: unknown): Promise<ChannelPublishAck>
-  abstract publishBinary(data: Uint8Array): Promise<ChannelPublishAck>
-  abstract send(to: string | RemoteParticipant, data: unknown): Promise<void>
-  abstract setMeta(meta: ParticipantMeta): Promise<void>
-  abstract leave(): Promise<void>
-
-  listen(callback: (data: unknown, fromId: string) => void): () => void {
-    this._messageCbs.push(callback)
-    return () => {
-      const i = this._messageCbs.indexOf(callback)
-      if (i >= 0) this._messageCbs.splice(i, 1)
-    }
-  }
-
-  /** @internal — a direct message arrived on this member's inbox. */
-  _deliverMessage(fromId: string, data: unknown): void {
-    for (const cb of [...this._messageCbs]) {
-      try {
-        cb(data, fromId)
-      } catch (err) {
-        reportRoomError(err)
-      }
-    }
-  }
-
-  onLeave(callback: () => void): () => void {
-    if (this._leftFired) {
-      invokeCallback(callback)
-      return () => {}
-    }
-    this._leaveCbs.push(callback)
-    return () => {
-      const i = this._leaveCbs.indexOf(callback)
-      if (i >= 0) this._leaveCbs.splice(i, 1)
-    }
-  }
-
-  /** @internal — the member is gone (left, kicked, room closed, or wire death). */
-  _onLeft(): void {
-    this._left = true
-    if (this._leftFired) return
-    this._leftFired = true
+  override _onLeft(): void {
     setSuppressed(this._roomId, this.id, false)
-    const cbs = this._leaveCbs
-    this._leaveCbs = []
-    for (const cb of cbs) invokeCallback(cb)
+    super._onLeft()
   }
 
-  protected _assertActive(): void {
-    if (this._left) throw new Error('Participant has left the room')
+  protected _reportError(err: unknown): void {
+    reportRoomError(err)
   }
 }
 
@@ -471,14 +416,6 @@ function unwrapPublishAck(ack: unknown): ChannelPublishAck {
   const res = ack as ReqPublishAck
   if (!res.ok) throw new Error(res.err)
   return res.ack
-}
-
-function invokeCallback(cb: () => void): void {
-  try {
-    cb()
-  } catch (err) {
-    reportRoomError(err)
-  }
 }
 
 function reportRoomError(err: unknown): void {

--- a/packages/telefunc/wire-protocol/room/room.spec.ts
+++ b/packages/telefunc/wire-protocol/room/room.spec.ts
@@ -374,6 +374,20 @@ describe('direct messages', () => {
     await alice.leave()
     await expect(alice.send(bob.id, 'x')).rejects.toThrow('Participant has left')
   })
+
+  it("delivers to a member the sender's stale local view doesn't know yet (KV fallback)", async () => {
+    const a = await Room.create('dm-lag')
+    const alice = await a.join({ name: 'Alice' })
+    const b = await Room.get('dm-lag') // snapshot: alice only
+    const bob = await a.join({ name: 'Bob' }) // b is unobserved — it missed this join
+    const bobInbox: unknown[] = []
+    bob.listen((data, fromId) => bobInbox.push([data, fromId]))
+
+    // b's local view lags; the KV member record is authoritative.
+    await (b as ServerRoom)._sendDm(alice.id, bob.id, 'catch-up')
+
+    expect(bobInbox).toEqual([['catch-up', alice.id]])
+  })
 })
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/telefunc/wire-protocol/room/room.spec.ts
+++ b/packages/telefunc/wire-protocol/room/room.spec.ts
@@ -287,6 +287,13 @@ describe('data pub/sub', () => {
     expect(seenOnB).toEqual(['echoed', 'not-here']) // everyone else: sees both
   })
 
+  it('rejects a stub binary publish from a participant that already left — like the text path', async () => {
+    const lobby = await Room.create('late-frame')
+    const me = (await lobby.join()) as ServerLocalParticipant
+    await me.leave()
+    expect(() => me._publishFramed(frameWithMemberId(me.id, new Uint8Array([1])))).toThrow('Participant has left')
+  })
+
   it('binary round-trips with the 16-byte member ID frame, preserving high-bit bytes', async () => {
     const a = await Room.create('bin')
     const b = await Room.get('bin')

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -213,8 +213,8 @@ class ServerRoom implements Room {
   private readonly _stubs = new Set<RoomStubChannel>()
   private readonly _localParticipants = new Map<string, ServerLocalParticipant>()
 
-  private _mainUnsub: (() => void) | null = null
-  private _mainBinaryUnsub: (() => void) | null = null
+  private readonly _mainSub = new SubSlot()
+  private readonly _mainBinarySub = new SubSlot()
   private readonly _memberTextUnsubs = new Map<string, () => void>()
   private readonly _memberBinaryUnsubs = new Map<string, () => void>()
   private readonly _dmUnsubs = new Map<string, () => void>()
@@ -274,7 +274,7 @@ class ServerRoom implements Room {
   async getParticipants(): Promise<RemoteParticipant[]> {
     // While observed, the event stream keeps the local view fresh. While unobserved,
     // no listeners exist that a change could notify — resync silently from KV.
-    if (!this._state.closed && !this._mainUnsub) await this._refreshMembers()
+    if (!this._state.closed && !this._mainSub.active) await this._refreshMembers()
     return this._state.listRemotes()
   }
 
@@ -606,8 +606,8 @@ class ServerRoom implements Room {
       this._localParticipants.size > 0 ||
       state.eventListenerCount + state.dataListenerCount + state.binaryListenerCount > 0
 
-    const becomesObserved = open && observed && this._mainUnsub === null
-    this._setSub('_mainUnsub', open && observed, () =>
+    const becomesObserved = open && observed && !this._mainSub.active
+    this._mainSub.sync(open && observed, () =>
       adapter.subscribe(roomMainKey(this.id), (serialized, info) => this._onText(serialized, info)),
     )
     // Events between construction (KV snapshot) and this subscription were missed — resync.
@@ -632,7 +632,7 @@ class ServerRoom implements Room {
         adapter.subscribeBinary(roomMemberDataKey(this.id, memberId), (framed, info) => this._onBinary(framed, info)),
       )
     } else {
-      this._setSub('_mainBinaryUnsub', wantAnyBinary, () =>
+      this._mainBinarySub.sync(wantAnyBinary, () =>
         adapter.subscribeBinary(roomMainKey(this.id), (framed, info) => this._onBinary(framed, info)),
       )
     }
@@ -656,16 +656,6 @@ class ServerRoom implements Room {
       for (const id of stub._binaryWants.members) members.add(id)
     }
     return { all: false, members }
-  }
-
-  private _setSub(field: '_mainUnsub' | '_mainBinaryUnsub', want: boolean, subscribe: () => () => void): void {
-    const current = this[field]
-    if (want && !current) {
-      this[field] = subscribe()
-    } else if (!want && current) {
-      this[field] = null
-      current()
-    }
   }
 
   private _syncMemberSubs(
@@ -991,6 +981,25 @@ async function listMemberKeys(kv: RoomKV, roomId: string): Promise<Array<{ key: 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** One adapter subscription, reconciled to a desired on/off state. */
+class SubSlot {
+  private _unsub: (() => void) | null = null
+
+  get active(): boolean {
+    return this._unsub !== null
+  }
+
+  sync(want: boolean, subscribe: () => () => void): void {
+    if (want && !this._unsub) {
+      this._unsub = subscribe()
+    } else if (!want && this._unsub) {
+      const unsub = this._unsub
+      this._unsub = null
+      unsub()
+    }
+  }
+}
 
 async function publishCtrl(roomId: string, event: RoomCtrlEnvelope): Promise<void> {
   await getBroadcastAdapter().publish(roomMainKey(roomId), stringify(event))

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -263,12 +263,11 @@ class ServerRoom implements Room {
 
   async join(meta: ParticipantMeta = {}, options?: JoinOptions): Promise<LocalParticipant> {
     const selfDelivery = normalizeJoinOptions(meta, options)
-    const { id, joinedAt } = await this._createMember(meta)
-    const participant = new ServerLocalParticipant(this, id, meta, joinedAt, selfDelivery)
-    this._localParticipants.set(id, participant)
-    this._syncSubs() // subscribe before announcing, so cross-node events flow from now on
-    this._state.applyJoin(id, meta, joinedAt)
-    await publishCtrl(this.id, { __r: 'join', id, meta, joinedAt })
+    let participant!: ServerLocalParticipant
+    await this._admitMember(meta, (id, joinedAt) => {
+      participant = new ServerLocalParticipant(this, id, meta, joinedAt, selfDelivery)
+      this._localParticipants.set(id, participant)
+    })
     return participant
   }
 
@@ -315,8 +314,23 @@ class ServerRoom implements Room {
 
   // ── Membership operations (shared by local participants and stub requests) ──
 
-  /** @internal — KV half of a join, guarding against a concurrent `Room.close()`. */
-  async _createMember(meta: ParticipantMeta): Promise<{ id: string; joinedAt: number }> {
+  /** Join choreography shared by local `join()` and stub `req-join`. `track` registers the
+   *  holder first — the member must count as owned before `_syncSubs()` brings up its inbox
+   *  subscription and heartbeat, and before its join is announced. */
+  private async _admitMember(
+    meta: ParticipantMeta,
+    track: (id: string, joinedAt: number) => void,
+  ): Promise<{ id: string; joinedAt: number }> {
+    const { id, joinedAt } = await this._createMember(meta)
+    track(id, joinedAt)
+    this._syncSubs()
+    this._state.applyJoin(id, meta, joinedAt)
+    await publishCtrl(this.id, { __r: 'join', id, meta, joinedAt })
+    return { id, joinedAt }
+  }
+
+  /** KV half of a join, guarding against a concurrent `Room.close()`. */
+  private async _createMember(meta: ParticipantMeta): Promise<{ id: string; joinedAt: number }> {
     const kv = getRoomKV()
     await this._assertOpen(kv)
     const id = crypto.randomUUID()
@@ -523,11 +537,9 @@ class ServerRoom implements Room {
       switch (req.__r) {
         case 'req-join': {
           const meta = isObject(req.meta) ? req.meta : {}
-          const { id, joinedAt } = await this._createMember(meta)
-          stub._stubMembers.set(id, { selfDelivery: req.selfDelivery !== false })
-          this._syncSubs() // subscribe before announcing, so cross-node events flow from now on
-          this._state.applyJoin(id, meta, joinedAt)
-          await publishCtrl(this.id, { __r: 'join', id, meta, joinedAt })
+          const { id, joinedAt } = await this._admitMember(meta, (id) =>
+            stub._stubMembers.set(id, { selfDelivery: req.selfDelivery !== false }),
+          )
           return { ok: true, id, joinedAt }
         }
         case 'req-leave':

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -877,9 +877,8 @@ class RoomStubChannel extends ServerBroadcast {
   constructor(serverRoom: ServerRoom) {
     super({ key: roomMainKey(serverRoom.id) })
     this._room = serverRoom
-    // Requests ride the plain channel message path. `ServerBroadcast` blocks the public
-    // `listen()` (a `Room` isn't user-listenable) — register through the base class.
-    ServerChannel.prototype.listen.call(this, (msg: unknown) => this._room._handleStubRequest(this, msg))
+    // Stub requests (join/leave/set-meta/dm/sub-binary) arrive as channel messages.
+    this._listen((msg: unknown) => this._room._handleStubRequest(this, msg))
   }
 
   override _onPeerPublishAckReqMessage(text: string, seq: number): Promise<void> {

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -384,7 +384,11 @@ class ServerRoom implements Room {
    *  the target's owning node subscribes to (see `_onDm`). */
   async _sendDm(from: string, to: string, data: unknown): Promise<void> {
     if (this._state.closed) throw new Error(`Room is closed: ${this.id}`)
-    if (!this._state.getRemote(to)) throw new Error(`Participant not found: ${to}`)
+    // The local view lags while unobserved (and briefly right after the observe transition,
+    // until the KV resync lands) — consult the authoritative record before rejecting.
+    if (!this._state.getRemote(to) && (await getRoomKV().get(roomMemberKvKey(this.id, to))) === null) {
+      throw new Error(`Participant not found: ${to}`)
+    }
     const envelope: RoomDmEnvelope = { __r: 'dm', to, from, data }
     await getBroadcastAdapter().publish(roomDmKey(this.id, to), stringify(envelope))
   }

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -9,7 +9,7 @@ import { isObject } from '../../utils/isObject.js'
 import { unrefTimer } from '../../utils/unrefTimer.js'
 import { makePublishInfo, type ChannelPublishAck, type ChannelPublishInfo } from '../channel.js'
 import { ROOM_HEARTBEAT_INTERVAL_MS, ROOM_MEMBER_TTL_MS } from '../constants.js'
-import { getBroadcastAdapter } from '../server/broadcast.js'
+import { getBroadcastAdapter, type BroadcastAdapter } from '../server/broadcast.js'
 import { ServerChannel } from '../server/channel.js'
 import { ServerBroadcast } from '../server/server-broadcast.js'
 import { ACK_STATUS, encodePublishBinary, encodePublishText, type WirePublishInfo } from '../shared-ws.js'
@@ -22,6 +22,7 @@ import {
   normalizeJoinOptions,
   roomConfigKvKey,
   roomDmKey,
+  roomIdFromConfigKey,
   roomMainKey,
   roomMemberDataKey,
   roomMemberKvKey,
@@ -119,23 +120,19 @@ async function createRoom(id: string, options?: RoomOptions): Promise<Room> {
 }
 
 async function getRoom(id: string): Promise<Room> {
-  assertRoomId(id)
-  const kv = getRoomKV()
-  const config = await readConfig(kv, id)
-  if (config === null) throw new Error(`Room not found: ${id}`)
-  return new ServerRoom(id, config, await readMembers(kv, id, 'reap'))
+  const { kv, config } = await requireRoom(id)
+  return new ServerRoom(id, config, await readMembers(kv, id))
 }
 
 async function listRooms(): Promise<RoomInfo[]> {
   const kv = getRoomKV()
-  const configSuffix = ':config'
   const rooms: RoomInfo[] = []
   for (const key of await kv.keys(ROOM_KEY_NAMESPACE)) {
-    if (!key.endsWith(configSuffix)) continue
-    const id = key.slice(ROOM_KEY_NAMESPACE.length, -configSuffix.length)
+    const id = roomIdFromConfigKey(key)
+    if (id === null) continue
     const config = await readConfig(kv, id)
     if (config === null) continue // closed concurrently
-    const count = (await readMembers(kv, id, 'reap')).length
+    const count = (await readMembers(kv, id)).length
     const size = sizeFromWire(config.size)
     rooms.push({ id, meta: config.meta, size, count, isEmpty: count === 0, isFull: count >= size })
   }
@@ -143,11 +140,8 @@ async function listRooms(): Promise<RoomInfo[]> {
 }
 
 async function updateRoom(id: string, options: RoomOptions): Promise<void> {
-  assertRoomId(id)
   const { meta, size } = normalizeOptions(options)
-  const kv = getRoomKV()
-  const config = await readConfig(kv, id)
-  if (config === null) throw new Error(`Room not found: ${id}`)
+  const { kv, config } = await requireRoom(id)
   assertUsage(
     options?.isolated === undefined || options.isolated === config.isolated,
     "A room's `isolated` mode is fixed at creation — room.update() cannot change it",
@@ -158,24 +152,20 @@ async function updateRoom(id: string, options: RoomOptions): Promise<void> {
 }
 
 async function closeRoom(id: string): Promise<void> {
-  assertRoomId(id)
-  const kv = getRoomKV()
-  if ((await readConfig(kv, id)) === null) throw new Error(`Room not found: ${id}`)
+  const { kv } = await requireRoom(id)
   // Event first so observers disconnect promptly; then KV cleanup. A join racing the
   // cleanup re-checks the config after writing its member record and rolls back.
   await publishCtrl(id, { __r: 'closed' })
-  for (const member of await readMembers(kv, id, 'keep')) await kv.delete(roomMemberKvKey(id, member.id))
+  for (const { key } of await listMemberKeys(kv, id)) await kv.delete(key)
   await kv.delete(roomConfigKvKey(id))
 }
 
 async function removeParticipant(id: string, participantId: string): Promise<void> {
-  assertRoomId(id)
   assertUsage(
     typeof participantId === 'string' && participantId.length > 0,
     'The participant ID should be a non-empty string',
   )
-  const kv = getRoomKV()
-  if ((await readConfig(kv, id)) === null) throw new Error(`Room not found: ${id}`)
+  const { kv } = await requireRoom(id)
   const memberKey = roomMemberKvKey(id, participantId)
   if ((await kv.get(memberKey)) === null) throw new Error(`Participant not found: ${participantId}`)
   await kv.delete(memberKey)
@@ -183,16 +173,12 @@ async function removeParticipant(id: string, participantId: string): Promise<voi
 }
 
 async function announceToRoom(id: string, data: unknown): Promise<void> {
-  assertRoomId(id)
-  const kv = getRoomKV()
-  if ((await readConfig(kv, id)) === null) throw new Error(`Room not found: ${id}`)
+  await requireRoom(id)
   await getBroadcastAdapter().publish(roomMainKey(id), stringify({ __r: 'announce', data } satisfies RoomEnvelope))
 }
 
 async function sendToParticipant(id: string, participantId: string, data: unknown): Promise<void> {
-  assertRoomId(id)
-  const kv = getRoomKV()
-  if ((await readConfig(kv, id)) === null) throw new Error(`Room not found: ${id}`)
+  const { kv } = await requireRoom(id)
   if ((await kv.get(roomMemberKvKey(id, participantId))) === null) {
     throw new Error(`Participant not found: ${participantId}`)
   }
@@ -689,7 +675,7 @@ class ServerRoom implements Room {
 
   private async _refreshMembers(): Promise<void> {
     const version = this._state.membershipVersion
-    const members = await readMembers(getRoomKV(), this.id, 'reap')
+    const members = await readMembers(getRoomKV(), this.id)
     // An event that applied while we were reading is fresher than the snapshot — drop it.
     if (this._state.membershipVersion === version) this._state.reconcile(members)
   }
@@ -735,7 +721,7 @@ class ServerRoom implements Room {
         const record = parse(raw) as RoomMemberRecord
         await kv.set(memberKey, stringify({ ...record, seenAt: Date.now() } satisfies RoomMemberRecord))
       }
-      await readMembers(kv, this.id, 'reap')
+      await readMembers(kv, this.id)
     } finally {
       this._heartbeatBusy = false
     }
@@ -933,14 +919,9 @@ function bindParticipantStubChannel(
 // KV access
 // ---------------------------------------------------------------------------
 
-type RoomKV = {
-  get(key: string): Promise<string | null>
-  set(key: string, value: string): Promise<void>
-  delete(key: string): Promise<void>
-  keys(prefix: string): Promise<string[]>
-}
-
 /** Room state lives in the broadcast adapter's KV so every server node sees the same rooms. */
+type RoomKV = Required<Pick<BroadcastAdapter, 'get' | 'set' | 'delete' | 'keys'>>
+
 function getRoomKV(): RoomKV {
   const adapter = getBroadcastAdapter()
   const missing = (['get', 'set', 'delete', 'keys'] as const).filter((method) => !adapter[method])
@@ -948,16 +929,16 @@ function getRoomKV(): RoomKV {
     missing.length === 0,
     `The installed broadcast adapter doesn't implement ${missing.map((m) => `\`${m}()\``).join(', ')} — the KV methods required by \`Room\`.`,
   )
-  return {
-    get: async (key) => await adapter.get!(key),
-    set: async (key, value) => {
-      await adapter.set!(key, value)
-    },
-    delete: async (key) => {
-      await adapter.delete!(key)
-    },
-    keys: async (prefix) => await adapter.keys!(prefix),
-  }
+  return adapter as RoomKV
+}
+
+/** Statics prologue: validate the ID and load the room's config — or throw `Room not found`. */
+async function requireRoom(id: string): Promise<{ kv: RoomKV; config: RoomConfigRecord }> {
+  assertRoomId(id)
+  const kv = getRoomKV()
+  const config = await readConfig(kv, id)
+  if (config === null) throw new Error(`Room not found: ${id}`)
+  return { kv, config }
 }
 
 async function readConfig(kv: RoomKV, roomId: string): Promise<RoomConfigRecord | null> {
@@ -965,20 +946,15 @@ async function readConfig(kv: RoomKV, roomId: string): Promise<RoomConfigRecord 
   return raw === null ? null : (parse(raw) as RoomConfigRecord)
 }
 
-/** Read a room's member records. With `'reap'`, members whose owning node stopped
- *  heartbeating (hard crash) are deleted and their leave is announced to all observers. */
-async function readMembers(kv: RoomKV, roomId: string, staleMembers: 'reap' | 'keep'): Promise<MemberSnapshot[]> {
-  const prefix = roomMemberKvPrefix(roomId)
+/** Read a room's member records, reaping members whose owning node stopped heartbeating
+ *  (hard crash): their record is deleted and their leave announced to all observers. */
+async function readMembers(kv: RoomKV, roomId: string): Promise<MemberSnapshot[]> {
   const members: MemberSnapshot[] = []
-  for (const key of await kv.keys(prefix)) {
-    const id = key.slice(prefix.length)
-    // Member IDs are UUIDs — anything else under the prefix belongs to another room
-    // whose ID happens to start with `${roomId}:m:` (e.g. its `:config` key).
-    if (!uuidToBytes(id)) continue
+  for (const { key, id } of await listMemberKeys(kv, roomId)) {
     const raw = await kv.get(key)
     if (raw === null) continue // member left concurrently
     const record = parse(raw) as RoomMemberRecord
-    if (staleMembers === 'reap' && Date.now() - record.seenAt > ROOM_MEMBER_TTL_MS) {
+    if (Date.now() - record.seenAt > ROOM_MEMBER_TTL_MS) {
       await kv.delete(key)
       await publishCtrl(roomId, { __r: 'leave', id })
       continue
@@ -986,6 +962,18 @@ async function readMembers(kv: RoomKV, roomId: string, staleMembers: 'reap' | 'k
     members.push({ id, meta: record.meta, joinedAt: record.joinedAt })
   }
   return members
+}
+
+/** Keys of a room's member records. Member IDs are UUIDs — anything else under the prefix
+ *  belongs to another room whose ID happens to start with `${roomId}:m:` (e.g. its `:config` key). */
+async function listMemberKeys(kv: RoomKV, roomId: string): Promise<Array<{ key: string; id: string }>> {
+  const prefix = roomMemberKvPrefix(roomId)
+  const memberKeys: Array<{ key: string; id: string }> = []
+  for (const key of await kv.keys(prefix)) {
+    const id = key.slice(prefix.length)
+    if (uuidToBytes(id)) memberKeys.push({ key, id })
+  }
+  return memberKeys
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -14,10 +14,12 @@ import { ServerChannel } from '../server/channel.js'
 import { ServerBroadcast } from '../server/server-broadcast.js'
 import { ACK_STATUS, encodePublishBinary, encodePublishText, type WirePublishInfo } from '../shared-ws.js'
 import {
+  ParticipantBase,
   ROOM_KEY_NAMESPACE,
   RoomState,
   frameWithMemberId,
   hasRoomTag,
+  normalizeJoinOptions,
   roomConfigKvKey,
   roomDmKey,
   roomMainKey,
@@ -747,33 +749,19 @@ class ServerRoom implements Room {
 const SERVER_PARTICIPANT_BRAND: unique symbol = Symbol.for('telefunc.ServerRoomParticipant')
 
 /** Server-side `LocalParticipant`, returned by `ServerRoom.join()`. */
-class ServerLocalParticipant implements LocalParticipant {
+class ServerLocalParticipant extends ParticipantBase {
   readonly [SERVER_PARTICIPANT_BRAND] = true
-  readonly id: string
-  readonly selfDelivery: boolean
-
   /** @internal */ readonly _room: ServerRoom
-  /** @internal */ _meta: ParticipantMeta
   /** @internal */ readonly _joinedAt: number
-  private _left = false
-  private _leftFired = false
-  private _leaveCbs: Array<() => void> = []
-  private readonly _messageCbs: Array<(data: unknown, fromId: string) => void> = []
 
   constructor(serverRoom: ServerRoom, id: string, meta: ParticipantMeta, joinedAt: number, selfDelivery: boolean) {
+    super(id, meta, selfDelivery)
     this._room = serverRoom
-    this.id = id
-    this._meta = meta
     this._joinedAt = joinedAt
-    this.selfDelivery = selfDelivery
   }
 
   static isServerLocalParticipant(value: unknown): value is ServerLocalParticipant {
     return value !== null && typeof value === 'object' && SERVER_PARTICIPANT_BRAND in value
-  }
-
-  get meta(): ParticipantMeta {
-    return this._meta
   }
 
   async publish(data: unknown): Promise<ChannelPublishAck> {
@@ -792,25 +780,6 @@ class ServerLocalParticipant implements LocalParticipant {
     await this._room._sendDm(this.id, typeof to === 'string' ? to : to.id, data)
   }
 
-  listen(callback: (data: unknown, fromId: string) => void): () => void {
-    this._messageCbs.push(callback)
-    return () => {
-      const i = this._messageCbs.indexOf(callback)
-      if (i >= 0) this._messageCbs.splice(i, 1)
-    }
-  }
-
-  /** @internal — a direct message arrived on this member's inbox. */
-  _deliverMessage(fromId: string, data: unknown): void {
-    for (const cb of [...this._messageCbs]) {
-      try {
-        cb(data, fromId)
-      } catch (err) {
-        reportRoomError(err)
-      }
-    }
-  }
-
   async setMeta(meta: ParticipantMeta): Promise<void> {
     this._assertActive()
     await this._room._setMemberMeta(this.id, meta)
@@ -824,30 +793,8 @@ class ServerLocalParticipant implements LocalParticipant {
     this._onLeft() // fires even when the room wasn't observing (no echo applied)
   }
 
-  onLeave(callback: () => void): () => void {
-    if (this._leftFired) {
-      invokeCallback(callback)
-      return () => {}
-    }
-    this._leaveCbs.push(callback)
-    return () => {
-      const i = this._leaveCbs.indexOf(callback)
-      if (i >= 0) this._leaveCbs.splice(i, 1)
-    }
-  }
-
-  /** @internal — the member is gone (left, kicked, room closed, or holder disconnected). */
-  _onLeft(): void {
-    this._left = true
-    if (this._leftFired) return
-    this._leftFired = true
-    const cbs = this._leaveCbs
-    this._leaveCbs = []
-    for (const cb of cbs) invokeCallback(cb)
-  }
-
-  private _assertActive(): void {
-    if (this._left) throw new Error('Participant has left the room')
+  protected _reportError(err: unknown): void {
+    reportRoomError(err)
   }
 }
 
@@ -1062,27 +1009,12 @@ function normalizeOptions(options: RoomOptions | undefined): { meta: RoomMeta; s
   return { meta, size }
 }
 
-/** Validates `join(meta, options)` arguments; returns the resolved `selfDelivery`. */
-function normalizeJoinOptions(meta: unknown, options: JoinOptions | undefined): boolean {
-  assertUsage(isObject(meta), 'join() meta should be an object')
-  assertUsage(options === undefined || isObject(options), 'join() options should be an object')
-  return options?.selfDelivery !== false
-}
-
 function makeEid(): string {
   return Math.random().toString(36).slice(2, 10)
 }
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
-}
-
-function invokeCallback(cb: () => void): void {
-  try {
-    cb()
-  } catch (err) {
-    reportRoomError(err)
-  }
 }
 
 function reportRoomError(err: unknown): void {

--- a/packages/telefunc/wire-protocol/room/server.ts
+++ b/packages/telefunc/wire-protocol/room/server.ts
@@ -767,6 +767,12 @@ class ServerLocalParticipant extends ParticipantBase {
     return await this._room._publishData(this.id, { binary: frameWithMemberId(this.id, data) })
   }
 
+  /** @internal — publish a client-framed payload (the frame already carries this member's ID). */
+  _publishFramed(framed: Uint8Array): Promise<ChannelPublishAck> {
+    this._assertActive()
+    return this._room._publishData(this.id, { binary: framed })
+  }
+
   async send(to: string | RemoteParticipant, data: unknown): Promise<void> {
     this._assertActive()
     await this._room._sendDm(this.id, typeof to === 'string' ? to : to.id, data)
@@ -891,7 +897,7 @@ function bindParticipantStubChannel(
   channel.listenBinary(async (framed: Uint8Array) => {
     try {
       if (unframeMemberId(framed)?.from !== participant.id) throw new Error('Malformed room binary publish')
-      return { ok: true, ack: await participant._room._publishData(participant.id, { binary: framed }) }
+      return { ok: true, ack: await participant._publishFramed(framed) }
     } catch (err) {
       return { ok: false, err: errorMessage(err) } satisfies ReqOkAck
     }

--- a/packages/telefunc/wire-protocol/room/shared.ts
+++ b/packages/telefunc/wire-protocol/room/shared.ts
@@ -12,7 +12,9 @@ export {
   frameWithMemberId,
   unframeMemberId,
   hasRoomTag,
+  normalizeJoinOptions,
   RoomState,
+  ParticipantBase,
 }
 export type {
   RoomConfigRecord,
@@ -34,10 +36,10 @@ export type {
   BinaryWants,
 }
 
-import { assert } from '../../utils/assert.js'
+import { assert, assertUsage } from '../../utils/assert.js'
 import { isObject } from '../../utils/isObject.js'
-import type { ChannelPublishInfo } from '../channel.js'
-import type { ParticipantMeta, RemoteParticipant, RoomMeta } from './types.js'
+import type { ChannelPublishAck, ChannelPublishInfo } from '../channel.js'
+import type { JoinOptions, LocalParticipant, ParticipantMeta, RemoteParticipant, RoomMeta } from './types.js'
 
 // ---------------------------------------------------------------------------
 // Keys & records
@@ -184,6 +186,13 @@ function hasRoomTag(value: unknown): value is { __r: string } {
   return isObject(value) && typeof value.__r === 'string'
 }
 
+/** Validates `join(meta, options)` arguments; returns the resolved `selfDelivery`. */
+function normalizeJoinOptions(meta: unknown, options: JoinOptions | undefined): boolean {
+  assertUsage(isObject(meta), 'join() meta should be an object')
+  assertUsage(options === undefined || isObject(options), 'join() options should be an object')
+  return options?.selfDelivery !== false
+}
+
 // ---------------------------------------------------------------------------
 // Member IDs — UUIDs, framed as a fixed 16-byte prefix on binary messages
 // ---------------------------------------------------------------------------
@@ -252,6 +261,7 @@ type RoomStateOptions = {
   meta: RoomMeta
   size: number
   members: MemberSnapshot[]
+  closed?: boolean
   /** Fired whenever the number of attached listeners changes — lets the owner
    *  (de)activate its event source (adapter subscription, wire subscription). */
   onListenersChanged: () => void
@@ -272,7 +282,7 @@ class RoomState {
   readonly roomId: string
   meta: RoomMeta
   size: number
-  closed = false
+  closed: boolean
   /** Bumped on every membership change — guards async KV reconciles against going stale. */
   membershipVersion = 0
 
@@ -303,6 +313,7 @@ class RoomState {
     this.roomId = opts.roomId
     this.meta = opts.meta
     this.size = opts.size
+    this.closed = opts.closed === true
     this._onListenersChanged = opts.onListenersChanged
     this._onCallbackError = opts.onCallbackError
     for (const member of opts.members) this._createEntry(member)
@@ -568,6 +579,95 @@ class RoomState {
       } catch (err) {
         this._onCallbackError(err)
       }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ParticipantBase — the shared half of every LocalParticipant
+// ---------------------------------------------------------------------------
+
+/**
+ * The private-message inbox and the leave lifecycle, identical on server and client.
+ * Flavors supply the transport through the abstract operations and their own error pipeline.
+ */
+abstract class ParticipantBase implements LocalParticipant {
+  readonly id: string
+  readonly selfDelivery: boolean
+  /** @internal */ _meta: ParticipantMeta
+  protected _left = false
+  private _leftFired = false
+  private _leaveCbs: Array<() => void> = []
+  private readonly _messageCbs: Array<(data: unknown, fromId: string) => void> = []
+
+  constructor(id: string, meta: ParticipantMeta, selfDelivery: boolean) {
+    this.id = id
+    this._meta = meta
+    this.selfDelivery = selfDelivery
+  }
+
+  get meta(): ParticipantMeta {
+    return this._meta
+  }
+
+  abstract publish(data: unknown): Promise<ChannelPublishAck>
+  abstract publishBinary(data: Uint8Array): Promise<ChannelPublishAck>
+  abstract send(to: string | RemoteParticipant, data: unknown): Promise<void>
+  abstract setMeta(meta: ParticipantMeta): Promise<void>
+  abstract leave(): Promise<void>
+  /** A user callback threw — each side reports through its own pipeline. */
+  protected abstract _reportError(err: unknown): void
+
+  listen(callback: (data: unknown, fromId: string) => void): () => void {
+    this._messageCbs.push(callback)
+    return () => {
+      const i = this._messageCbs.indexOf(callback)
+      if (i >= 0) this._messageCbs.splice(i, 1)
+    }
+  }
+
+  /** @internal — a direct message arrived on this member's inbox. */
+  _deliverMessage(fromId: string, data: unknown): void {
+    for (const cb of [...this._messageCbs]) {
+      try {
+        cb(data, fromId)
+      } catch (err) {
+        this._reportError(err)
+      }
+    }
+  }
+
+  onLeave(callback: () => void): () => void {
+    if (this._leftFired) {
+      this._invoke(callback)
+      return () => {}
+    }
+    this._leaveCbs.push(callback)
+    return () => {
+      const i = this._leaveCbs.indexOf(callback)
+      if (i >= 0) this._leaveCbs.splice(i, 1)
+    }
+  }
+
+  /** @internal — the member is gone (left, kicked, room closed, or holder disconnected). */
+  _onLeft(): void {
+    this._left = true
+    if (this._leftFired) return
+    this._leftFired = true
+    const cbs = this._leaveCbs
+    this._leaveCbs = []
+    for (const cb of cbs) this._invoke(cb)
+  }
+
+  protected _assertActive(): void {
+    if (this._left) throw new Error('Participant has left the room')
+  }
+
+  private _invoke(cb: () => void): void {
+    try {
+      cb()
+    } catch (err) {
+      this._reportError(err)
     }
   }
 }

--- a/packages/telefunc/wire-protocol/room/shared.ts
+++ b/packages/telefunc/wire-protocol/room/shared.ts
@@ -4,6 +4,7 @@ export {
   roomMemberDataKey,
   roomDmKey,
   roomConfigKvKey,
+  roomIdFromConfigKey,
   roomMemberKvKey,
   roomMemberKvPrefix,
   sizeToWire,
@@ -63,6 +64,11 @@ function roomDmKey(roomId: string, memberId: string): string {
 /** KV key of the room's config record. */
 function roomConfigKvKey(roomId: string): string {
   return `${ROOM_KEY_NAMESPACE}${roomId}:config`
+}
+/** Inverse of `roomConfigKvKey` — `null` for keys that aren't room config records. */
+function roomIdFromConfigKey(key: string): string | null {
+  if (!key.startsWith(ROOM_KEY_NAMESPACE) || !key.endsWith(':config')) return null
+  return key.slice(ROOM_KEY_NAMESPACE.length, -':config'.length)
 }
 /** KV key of one member record. */
 function roomMemberKvKey(roomId: string, memberId: string): string {

--- a/packages/telefunc/wire-protocol/server/channel.ts
+++ b/packages/telefunc/wire-protocol/server/channel.ts
@@ -239,6 +239,12 @@ class ServerChannel<ClientToServer = unknown, ServerToClient = unknown>
   }
 
   listen(callback: ChannelListener<ClientToServer>): () => void {
+    return this._listen(callback)
+  }
+
+  /** Registration primitive behind `listen()` — separate so subclasses that repurpose the
+   *  public verb (`ServerBroadcast` forbids it) can still receive channel messages. */
+  protected _listen(callback: ChannelListener<ClientToServer>): () => void {
     this._listeners.push(callback)
     return () => {
       const i = this._listeners.indexOf(callback)


### PR DESCRIPTION
Stacked on #436 (base = its branch) so only the refactors show in the diff. Every file, function, and logic in #436 was rated 0–10 in a full scrutiny pass; everything that scored below 8 was either refactored here or explicitly judged optimal-as-is with the reason recorded. One commit per refactor; behavior preserved (two narrow edge-case fixes are called out as `fix:` commits with tests) — 223 unit tests, all 13 tsconfig type checks, biome, docs lint, and the room + channel/publish Playwright drives are green on the result.

## Round 1 commits

1. [`1d4e512`](https://github.com/telefunc/telefunc/commit/1d4e512) **refactor(channel): expose listen registration as a protected primitive** — kills `ServerChannel.prototype.listen.call(this, …)`. The capability (receiving channel messages) now has a proper home: `protected _listen()` on `ServerChannel`; the public `listen()` delegates to it; `ServerBroadcast` keeps its usage wall; `RoomStubChannel` uses the primitive directly.
2. [`8e40ae4`](https://github.com/telefunc/telefunc/commit/8e40ae4) **refactor(room): extract the shared participant base** — the DM inbox + leave lifecycle (`listen`/`_deliverMessage`/`onLeave`/`_onLeft`/`_assertActive`) was implemented verbatim twice (server + client) and had already diverged once. Now one `ParticipantBase` in shared.ts (next to `RoomState`, which set the pattern); flavors keep only transport + error pipeline. Also: `normalizeJoinOptions()` shared with `ClientRoom.join()` (was re-validated inline), and `RoomState` takes `closed` as a constructor option instead of a post-construction field poke.
3. [`d42f748`](https://github.com/telefunc/telefunc/commit/d42f748) **refactor(room): tighten the KV access layer** — `RoomKV = Required<Pick<BroadcastAdapter, …>>` replaces four await-only wrapper closures; `requireRoom()` owns the six-times-copy-pasted statics prologue; `readMembers()` loses its `'reap' | 'keep'` mode flag (the one `'keep'` caller only needed keys → new `listMemberKeys()`, now the single home of the UUID-shape disambiguation rule); `listRooms()` uses `roomIdFromConfigKey()` (the inverse now lives next to `roomConfigKvKey()` in shared.ts); fixes an inaccurate Redis hash-tag comment.
4. [`afa2347`](https://github.com/telefunc/telefunc/commit/afa2347) **refactor(room): single join choreography** — local `join()` and stub `req-join` spelled out the same admit ritual with a verbatim-duplicated ordering comment. `_admitMember()` now owns the ritual and its invariant (holder tracked before `_syncSubs()` and the announce); callers only say how the member is tracked.

## Round 2 commits (fresh pass over the round-1 result)

5. [`dc0540e`](https://github.com/telefunc/telefunc/commit/dc0540e) **refactor(room): subscription slots** — `_setSub` selected which subscription to toggle by passing its own field name as a string and indexing `this[field]`. A `SubSlot` object now owns each subscription's lifecycle (`sync` + `active`); `getParticipants()` states its intent as `!this._mainSub.active` instead of null-checking a callback field.
6. [`91be5de`](https://github.com/telefunc/telefunc/commit/91be5de) **fix(room): DM target validation consults KV when the local view lags** — `_sendDm()` rejected targets missing from the instance's local view, which lags while unobserved (and briefly after the observe transition until the async resync lands). On a local miss the authoritative KV member record now decides; the common case pays no extra read. With test.
7. [`9172334`](https://github.com/telefunc/telefunc/commit/9172334) **fix(room): left participants can't publish framed binary via their stub** — the participant stub's binary lane reached two objects deep (`participant._room._publishData`) and, unlike every other participant operation, skipped the has-left assertion. `_publishFramed()` on the participant now owns that lane — right side of the boundary, same active-check as the text path. With test.

## Ratings: old ⇒ new

Entries not listed under a commit are unchanged (full per-entry reasons recorded in the session log; the noteworthy keeps are summarized below). List numbers reference the session log's rating lists, not GitHub issues.

**Files**
- `room/server.ts` 7 ⇒ **9** (commits 1, 3–7)
- `room/client.ts` 7 ⇒ **9** (commit 2)
- `room/shared.ts` 8 ⇒ **9** (commits 2–3)
- `server/channel.ts` — ⇒ **9** (commit 1; touched only for the primitive)
- `redis/index.ts` 8 ⇒ **9** (comment fix, commit 3)
- Unchanged: `room/types.ts` 9, `room.spec.ts` 8 (now with 2 more tests), `server/broadcast.ts` 8, `cloudflare/broadcast.ts` 9, response `room.ts` ×2 9, registries ×2 10, `constants.ts` 9, `wire-protocol/types.ts` 9, `node/server/index.ts` 9, `client/index.ts` 9, playground 8–10, docs 9–10, redis/cf specs 9.

**Functions (changed only)**
- `RoomStubChannel.constructor` 3 ⇒ **9** — commit 1
- `ServerLocalParticipant.listen/_deliverMessage/onLeave/_onLeft` 5 ⇒ **9** — commit 2
- `ClientParticipantBase.listen/_deliverMessage/onLeave/_onLeft` 5 ⇒ **9** — commit 2
- `_assertActive` (×2) 6 ⇒ **9**, `invokeCallback` (×2) 6 ⇒ **9** (absorbed into `ParticipantBase`) — commit 2
- `ClientRoom.join` 6 ⇒ **9**, `RoomState.constructor` 7 ⇒ **9** — commit 2
- `getRoomKV` 6 ⇒ **9**, `readMembers` 6 ⇒ **9**, `listRooms` 7 ⇒ **9**, `getRoom`/`updateRoom`/`closeRoom`/`removeParticipant`/`announceToRoom`/`sendToParticipant` 7–8 ⇒ **9** — commit 3
- `ServerRoom.join` 6 ⇒ **9**, `_handleStubRequest` 7 ⇒ **8.5** — commit 4
- `_setSub` 7 ⇒ replaced by `SubSlot.sync/active` **9**, `getParticipants` 9 ⇒ **9** (intent-stating) — commit 5
- `_sendDm` 8 ⇒ **9** (stale-view false negative removed) — commit 6
- `bindParticipantStubChannel` 7 ⇒ **9**, new `_publishFramed` **9** — commit 7

**Logic (changed only; "logic N" = entry N in the session log's logic list)**
- ack-via-listener-return (logic 19): 8 ⇒ **9** — commit 1
- KV normalization (logic 20): 6 ⇒ **9** — commit 3
- participant duplication (logic 28): 5 ⇒ **9** — commit 2
- join choreography duplication (logic 29): 6 ⇒ **9** — commit 4
- statics prologue duplication (logic 30): 6 ⇒ **9** — commit 3
- key schema (logic 16): 8 ⇒ **9** — commit 3
- `_syncSubs` reconcile (logic 5): 8 ⇒ **8.5** (slot objects; the `binaryIds` ternary stays, judged readable) — commit 5
- DM privacy/validation (logic 9 and 10): 9 ⇒ **9+** (lag false-negative and left-binary gaps closed) — commits 6–7

**Kept as-is (scrutinized, judged optimal — the "8+ second pass")**
- `_syncSubs` as the single home of all subscription truth; splitting would scatter the answer to "what are we subscribed to and why".
- Attach-before-snapshot in `roomReplacer` (snapshot-first loses gap events; idempotent application absorbs the overlap).
- Text-always-flows (no text-wants dimension): presence must flow; media is member-selective where bandwidth lives.
- Suppression registry as module global (two wire values can arrive in different responses; no narrower scope links them).
- `RoomStubChannel extends ServerBroadcast` (real reuse of wire dispatch + designed hooks; commit 1 removed the one reach-around).
- Heartbeat full-scan reap per tick (only guaranteed cleanup for half-crashed rooms; bounded per 30s).
- Sync binary-wants declarations (same-connection FIFO makes subscribe-then-publish see its own frame; coalescing provably broke it in the e2e drive).
- `_onText`/`_onDm` parse guards duplicated ×2: extraction considered and declined — two 6-line sites with different post-conditions; a third site tips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zM1eBVEFAUtQjPAS6DbqY