### PR TITLE
fix(test): expose GC in docker playground so the close/GC e2e test is deterministic

### DIFF
--- a/test/playground-stream/compose.yaml
+++ b/test/playground-stream/compose.yaml
@@ -116,7 +116,10 @@ services:
   playground-a: &playground
     image: node:24-alpine
     working_dir: /repo/test/playground-stream
-    command: node dist/nested/server/index.mjs
+    # `--expose-gc` powers the `/api/gc` endpoint (see `+server.ts`) that the close/GC e2e test
+    # uses to make GC-driven cleanup deterministic. The `dev` and `preview` npm scripts already
+    # pass it; the docker suite must too, otherwise `/api/gc` 500s and the GC test flakes.
+    command: node --expose-gc dist/nested/server/index.mjs
     volumes:
       - ../..:/repo
     environment:

--- a/test/playground-stream/e2e-utils.ts
+++ b/test/playground-stream/e2e-utils.ts
@@ -51,7 +51,14 @@ async function getCleanupState(): Promise<Record<string, string>> {
 
 /** Forces a full GC on the server (via `/api/gc`) so GC-driven cleanup is deterministic in tests. */
 async function forceServerGc() {
-  await fetch(`${getServerUrl()}/api/gc`, { method: 'POST' })
+  const resp = await fetch(`${getServerUrl()}/api/gc`, { method: 'POST' })
+  // `/api/gc` 500s when the server wasn't started with `--expose-gc`, in which case it forced
+  // nothing. Fail loudly and immediately instead of letting the GC test flake on incidental GC
+  // pressure and time out ~90 s later with an inscrutable 'not-fired'.
+  if (!resp.ok) {
+    const reason = await resp.text().catch(() => '')
+    throw new Error(`forceServerGc: /api/gc returned ${resp.status} — server GC not forced. ${reason}`)
+  }
 }
 
 /**


### PR DESCRIPTION
## What & why

CI job [29027373998](https://github.com/telefunc/telefunc/actions/runs/29027373998/job/86150639565) failed on an unrelated docs PR (#436) with:

```
FAIL test/playground-stream/.test-docker.binary-inline.sse.test.ts
Test FAIL because the test "close: passed function GC — context.onClose fires
after the server GC-reclaims a dropped callback" threw an error
AssertionError: expected 'not-fired' to equal 'fired'
  at pages/close/e2e-test.ts:213
```

### Root cause

The `close: passed function GC` test forces a server-side GC through the `/api/gc` endpoint so that a dropped passed-callback's server stub gets reclaimed → its request-side channel closes → `context.onClose` fires. That endpoint (`+server.ts`) is a no-op returning **HTTP 500** unless Node was started with `--expose-gc`:

```ts
const gc = (globalThis as { gc?: () => void }).gc
if (!gc) return c.json({ ok: false, reason: 'gc not exposed (run node with --expose-gc)' }, 500)
```

The `dev` and `preview` npm scripts pass `--expose-gc`, but the docker compose `command` (`node dist/nested/server/index.mjs`) never did. So in the **docker** suite `/api/gc` forced nothing — the test fell back to incidental GC pressure reclaiming the stub, and flaked (~90s of retries, then `'not-fired'`) whenever it didn't. The GC endpoint + test were added in #434, which updated the dev/preview scripts but not `compose.yaml`.

Verified locally: `node` → `typeof globalThis.gc === 'undefined'`; `node --expose-gc` → `'function'`. That's the exact condition the endpoint branches on.

## Changes

- **`compose.yaml`** — start all playground instances with `node --expose-gc …`. The `command` lives on the `&playground` YAML anchor, so the single edit propagates to instances `a`–`f` (verified by parsing the YAML).
- **`e2e-utils.ts`** — `forceServerGc()` now throws if `/api/gc` reports GC isn't exposed, converting a silent ~90s flake into an immediate, self-explaining failure if the flag is ever dropped again.

## Testing

The full end-to-end path is exactly what the failing CI job runs (docker isn't practical to spin up 6 Node instances + Redis + Caddy + Playwright locally). Verified the mechanism the fix depends on:

- `node --expose-gc` makes `globalThis.gc` a `function` (endpoint returns 200 and actually forces GC) vs `undefined` without it (endpoint 500s).
- `compose.yaml` parses and all six playground services resolve to `node --expose-gc dist/nested/server/index.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjPHsXsQqS5Yhwg9mdYqyU)_