### PR TITLE
feat: reference-identity-preserving serialization for telefunction results

### DIFF
--- a/packages/telefunc/wire-protocol/client/response/registry.ts
+++ b/packages/telefunc/wire-protocol/client/response/registry.ts
@@ -29,7 +29,12 @@ const clientTypes = [
   functionReviver,
 ]
 
-/** Creates a JSON-serializer reviver that delegates to type-specific plugins. */
+/** Creates a JSON-serializer reviver that delegates to type-specific plugins.
+ *
+ *  Duplicated references are deduplicated, mirroring createStreamingReplacer: the server emits
+ *  one replacement string per value identity, so equal wire strings denote the same server-side
+ *  value — the first occurrence revives (side effects run once), duplicates resolve to the
+ *  already-revived object, and server-side `===` holds on the client too. */
 function createStreamingReviver(
   context: ClientReviverContext,
   onRevived: (revived: {
@@ -40,13 +45,18 @@ function createStreamingReviver(
   extensionTypes: ReviverType<TypeContract, ClientReviverContext>[],
 ) {
   const allTypes = [...clientTypes, ...extensionTypes]
+  const revivedByWireString = new Map<string, unknown>()
   const reviver: Reviver = (_path, value, parser) => {
+    if (revivedByWireString.has(value)) return { replacement: revivedByWireString.get(value) }
     for (const type of allTypes) {
       if (value.startsWith(type.prefix)) {
         const metadata = parser(value.slice(type.prefix.length))
         assert(isObject(metadata))
         const revived = type.revive(metadata as never, context)
         onRevived(revived)
+        // After onRevived — it wraps `revived.value` (GC proxy), and duplicates must
+        // resolve to the exact object the first occurrence handed out.
+        revivedByWireString.set(value, revived.value)
         return { replacement: revived.value }
       }
     }

--- a/packages/telefunc/wire-protocol/ref-identity.spec.ts
+++ b/packages/telefunc/wire-protocol/ref-identity.spec.ts
@@ -1,0 +1,540 @@
+import { describe, expect, test } from 'vitest'
+
+import { stringify } from '@brillout/json-serializer/stringify'
+import { parse } from '@brillout/json-serializer/parse'
+import { createStreamingReplacer } from './server/response/registry.js'
+import { createStreamingReviver } from './client/response/registry.js'
+import { ServerChannel } from './server/channel.js'
+import { ServerBroadcast } from './server/server-broadcast.js'
+import { wrapProxy } from './wrapProxy.js'
+import { serializeTelefunctionResult } from '../node/server/runTelefunc/serializeTelefunctionResult.js'
+import { createRequestContext } from '../node/server/context/requestContext.js'
+import { parseResponse } from './client/response/parse.js'
+import { STREAM_TRANSPORT } from './constants.js'
+import type { AbortError } from '../shared/Abort.js'
+import type {
+  ClientReviverContext,
+  ReplacerType,
+  ReviverType,
+  ServerReplacerContext,
+  StreamingProducer,
+  TypeContract,
+} from './types.js'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Reference-identity-preserving serialization — bug classes targeted: duplicate
+// replace() side effects (stub channels minted per occurrence, lifecycle
+// registered per occurrence), duplicate revive() side effects (client objects
+// minted per occurrence, N wire subscriptions for one server value), and
+// over-deduplication (distinct values merged into one).
+// ───────────────────────────────────────────────────────────────────────────
+
+// ===== Registry-level harness =====
+// Real registries, real stringify/parse, real ServerChannel/ServerBroadcast —
+// contexts mirror serializeTelefunctionResult / reviveResponse minus transport.
+
+type Lifecycle = { close: () => Promise<void> | void; abort: (abortError: AbortError) => void }
+
+function createServerHarness(extensionTypes: ReplacerType<TypeContract, ServerReplacerContext>[] = []) {
+  const registeredChannels: unknown[] = []
+  const producers: { createProducer: () => StreamingProducer; index: number }[] = []
+  const lifecycles: Lifecycle[] = []
+  let nextIndex = 0
+  const context: ServerReplacerContext = {
+    createChannel(opts) {
+      const channel = new ServerChannel(opts)
+      context.registerChannel(channel)
+      return channel as never
+    },
+    registerChannel(channel) {
+      registeredChannels.push(channel)
+    },
+    sendStream(createProducer) {
+      const index = nextIndex++
+      producers.push({ createProducer, index })
+      return { metadata: { __index: index }, close() {}, abort() {} }
+    },
+    validators: new Map(),
+  }
+  const replacer = createStreamingReplacer(
+    () => context,
+    (replaced) => lifecycles.push(replaced),
+    extensionTypes,
+  )
+  function serialize(value: unknown): string {
+    return stringify(value, { forbidReactElements: true, replacer })
+  }
+  return { serialize, registeredChannels, producers, lifecycles }
+}
+
+function createClientHarness(extensionTypes: ReviverType<TypeContract, ClientReviverContext>[] = []) {
+  const mintedChannels: { channelId: string; ack?: boolean }[] = []
+  const mintedBroadcasts: { channelId: string; key: string }[] = []
+  const lifecycles: { value: unknown; close: () => Promise<void> | void; abort: (abortError: AbortError) => void }[] =
+    []
+  const context: ClientReviverContext = {
+    createChannel(opts) {
+      mintedChannels.push(opts)
+      return { kind: 'client-channel', ...opts, close: async () => {}, abort: () => {} } as never
+    },
+    createBroadcast(opts) {
+      mintedBroadcasts.push(opts)
+      return { kind: 'client-broadcast', ...opts, close: async () => {}, abort: () => {} } as never
+    },
+    receiveStream() {
+      throw new Error('registry-level harness does not stream')
+    },
+    waitFor() {},
+  }
+  const reviver = createStreamingReviver(
+    context,
+    (revived) => {
+      // Mirror reviveResponse: the value handed out (and cached) is the GC wrapper.
+      revived.value = wrapProxy(revived.value as object)
+      lifecycles.push(revived)
+    },
+    extensionTypes,
+  )
+  const parseBody = (body: string) => parse(body, { reviver })
+  return { parseBody, mintedChannels, mintedBroadcasts, lifecycles }
+}
+
+// ===== Room / LocalParticipant extension types =====
+// Shaped after the Room API prototype: replace() mints a fresh stub channel per
+// call and attaches it to the live server object — exactly the side effect that
+// must not run once per occurrence.
+
+class TestServerRoom {
+  readonly id: string
+  readonly stubsAttached: unknown[] = []
+  constructor(id: string) {
+    this.id = id
+  }
+  _attachStub(stub: unknown) {
+    this.stubsAttached.push(stub)
+  }
+}
+
+class TestLocalParticipant {
+  readonly id: string
+  channelsMinted = 0
+  constructor(id: string) {
+    this.id = id
+  }
+}
+
+type RoomContract = TypeContract<
+  TestServerRoom,
+  { kind: string; roomId: string },
+  { channelId: string; roomId: string }
+>
+type ParticipantContract = TypeContract<
+  TestLocalParticipant,
+  { kind: string; participantId: string },
+  { channelId: string; participantId: string }
+>
+
+function makeRoomExtension() {
+  const counters = { serverClose: 0, serverAbort: 0, clientRevive: 0, clientClose: 0, clientAbort: 0 }
+  const serverType: ReplacerType<RoomContract, ServerReplacerContext> = {
+    prefix: '!TestRoom:',
+    detect: (value): value is TestServerRoom => value instanceof TestServerRoom,
+    replace(room, context) {
+      const stub = context.createChannel()
+      room._attachStub(stub)
+      return {
+        metadata: { channelId: (stub as { id: string }).id, roomId: room.id },
+        close() {
+          counters.serverClose++
+        },
+        abort() {
+          counters.serverAbort++
+        },
+      }
+    },
+  }
+  const clientType: ReviverType<RoomContract, ClientReviverContext> = {
+    prefix: '!TestRoom:',
+    revive(metadata) {
+      counters.clientRevive++
+      return {
+        value: { kind: 'client-room', roomId: metadata.roomId },
+        close() {
+          counters.clientClose++
+        },
+        abort() {
+          counters.clientAbort++
+        },
+      }
+    },
+  }
+  return { serverType, clientType, counters }
+}
+
+function makeParticipantExtension() {
+  const counters = { clientRevive: 0 }
+  const serverType: ReplacerType<ParticipantContract, ServerReplacerContext> = {
+    prefix: '!TestParticipant:',
+    detect: (value): value is TestLocalParticipant => value instanceof TestLocalParticipant,
+    replace(participant, context) {
+      const channel = context.createChannel()
+      participant.channelsMinted++
+      return {
+        metadata: { channelId: (channel as { id: string }).id, participantId: participant.id },
+        close() {},
+        abort() {},
+      }
+    },
+  }
+  const clientType: ReviverType<ParticipantContract, ClientReviverContext> = {
+    prefix: '!TestParticipant:',
+    revive(metadata) {
+      counters.clientRevive++
+      return {
+        value: { kind: 'client-participant', participantId: metadata.participantId },
+        close() {},
+        abort() {},
+      }
+    },
+  }
+  return { serverType, clientType, counters }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// One payload — registry-level round-trips
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('reference identity — duplicates in one payload', () => {
+  test('Channel: N references serialize to one identity and revive to one object', () => {
+    const server = createServerHarness()
+    const channel = new ServerChannel()
+    const body = server.serialize({ ch: channel, chDupe: channel, list: [channel, { deep: channel }] })
+
+    // One registration, one lifecycle — not four.
+    expect(server.registeredChannels).toEqual([channel])
+    expect(server.lifecycles).toHaveLength(1)
+    // One channelId on the wire, everywhere.
+    expect(body.match(new RegExp(channel.id, 'g'))).toHaveLength(4)
+
+    const client = createClientHarness()
+    const parsed = client.parseBody(body) as {
+      ch: unknown
+      chDupe: unknown
+      list: [unknown, { deep: unknown }]
+    }
+    expect(client.mintedChannels).toHaveLength(1)
+    expect(client.mintedChannels[0]!.channelId).toBe(channel.id)
+    expect(client.lifecycles).toHaveLength(1)
+    expect(parsed.ch).toBe(parsed.chDupe)
+    expect(parsed.ch).toBe(parsed.list[0])
+    expect(parsed.ch).toBe(parsed.list[1].deep)
+  })
+
+  test('Broadcast: duplicated references mint one client broadcast', () => {
+    const server = createServerHarness()
+    const broadcast = new ServerBroadcast({ key: 'room:identity' })
+    const body = server.serialize({ room: broadcast, roomDupe: broadcast, roomDupe2: broadcast })
+
+    expect(server.registeredChannels).toEqual([broadcast])
+    expect(server.lifecycles).toHaveLength(1)
+
+    const client = createClientHarness()
+    const parsed = client.parseBody(body) as { room: unknown; roomDupe: unknown; roomDupe2: unknown }
+    expect(client.mintedBroadcasts).toHaveLength(1)
+    expect(parsed.room).toBe(parsed.roomDupe)
+    expect(parsed.room).toBe(parsed.roomDupe2)
+  })
+
+  test('Room (extension): one stub channel minted, one _attachStub, one client room', () => {
+    const { serverType, clientType, counters } = makeRoomExtension()
+    const server = createServerHarness([serverType as ReplacerType<TypeContract, ServerReplacerContext>])
+    const room = new TestServerRoom('lobby')
+    const body = server.serialize({ room, roomDupe: room, roomDupe2: room })
+
+    // The repro: three occurrences used to mint three stub channels.
+    expect(room.stubsAttached).toHaveLength(1)
+    expect(server.registeredChannels).toHaveLength(1)
+    expect(server.lifecycles).toHaveLength(1)
+
+    const client = createClientHarness([clientType as ReviverType<TypeContract, ClientReviverContext>])
+    const parsed = client.parseBody(body) as { room: unknown; roomDupe: unknown; roomDupe2: unknown }
+    expect(counters.clientRevive).toBe(1)
+    expect(parsed.room).toBe(parsed.roomDupe)
+    expect(parsed.room).toBe(parsed.roomDupe2)
+    expect((parsed.room as { roomId: string }).roomId).toBe('lobby')
+  })
+
+  test('LocalParticipant (extension): duplicated references mint one channel', () => {
+    const { serverType, clientType, counters } = makeParticipantExtension()
+    const server = createServerHarness([serverType as ReplacerType<TypeContract, ServerReplacerContext>])
+    const participant = new TestLocalParticipant('me')
+    const body = server.serialize({ me: participant, self: participant })
+
+    expect(participant.channelsMinted).toBe(1)
+    expect(server.registeredChannels).toHaveLength(1)
+
+    const client = createClientHarness([clientType as ReviverType<TypeContract, ClientReviverContext>])
+    const parsed = client.parseBody(body) as { me: unknown; self: unknown }
+    expect(counters.clientRevive).toBe(1)
+    expect(parsed.me).toBe(parsed.self)
+  })
+
+  test('Function: duplicated references share one channel and one client wrapper', () => {
+    const server = createServerHarness()
+    const fn = (x: number) => x * 2
+    const body = server.serialize({ fn, fnDupe: fn })
+
+    expect(server.registeredChannels).toHaveLength(1)
+
+    const client = createClientHarness()
+    const parsed = client.parseBody(body) as { fn: unknown; fnDupe: unknown }
+    expect(client.mintedChannels).toHaveLength(1)
+    expect(typeof parsed.fn).toBe('function')
+    expect(parsed.fn).toBe(parsed.fnDupe)
+  })
+
+  test('streamed values: duplicated references register one producer', () => {
+    const server = createServerHarness()
+    const gen = (async function* () {
+      yield 1
+    })()
+    const body = server.serialize({ gen, genDupe: gen })
+    expect(server.producers).toHaveLength(1)
+
+    // Both keys carry the same __index.
+    const parsed = JSON.parse(body) as { gen: string; genDupe: string }
+    expect(parsed.gen).toBe(parsed.genDupe)
+  })
+
+  test('distinct values of the same type stay distinct', () => {
+    const server = createServerHarness()
+    const a = new ServerChannel()
+    const b = new ServerChannel()
+    const body = server.serialize({ a, b })
+
+    expect(server.registeredChannels).toEqual([a, b])
+    expect(server.lifecycles).toHaveLength(2)
+
+    const client = createClientHarness()
+    const parsed = client.parseBody(body) as { a: unknown; b: unknown }
+    expect(client.mintedChannels).toHaveLength(2)
+    expect(parsed.a).not.toBe(parsed.b)
+  })
+
+  test('close/abort lifecycle registers once per identity — closing closes once', async () => {
+    const { serverType, clientType, counters } = makeRoomExtension()
+    const server = createServerHarness([serverType as ReplacerType<TypeContract, ServerReplacerContext>])
+    const room = new TestServerRoom('lifecycle')
+    const body = server.serialize({ room, roomDupe: room })
+
+    expect(server.lifecycles).toHaveLength(1)
+    for (const { close } of server.lifecycles) await close()
+    for (const { abort } of server.lifecycles) abort({ abortValue: undefined } as AbortError)
+    expect(counters.serverClose).toBe(1)
+    expect(counters.serverAbort).toBe(1)
+
+    const client = createClientHarness([clientType as ReviverType<TypeContract, ClientReviverContext>])
+    client.parseBody(body)
+    expect(client.lifecycles).toHaveLength(1)
+    for (const { close } of client.lifecycles) await close()
+    for (const { abort } of client.lifecycles) abort({ abortValue: undefined } as AbortError)
+    expect(counters.clientClose).toBe(1)
+    expect(counters.clientAbort).toBe(1)
+  })
+
+  test('metadata with JSON-escaped characters keeps identity across occurrences', () => {
+    const { serverType, clientType } = makeRoomExtension()
+    const server = createServerHarness([serverType as ReplacerType<TypeContract, ServerReplacerContext>])
+    // '<' and '/' trigger the serializer's HTML-safety escaping; '"' exercises JSON escapes.
+    const room = new TestServerRoom('a/b<c>"d"')
+    const body = server.serialize({ room, roomDupe: room })
+
+    const client = createClientHarness([clientType as ReviverType<TypeContract, ClientReviverContext>])
+    const parsed = client.parseBody(body) as { room: { roomId: string }; roomDupe: unknown }
+    expect(parsed.room).toBe(parsed.roomDupe)
+    expect(parsed.room.roomId).toBe('a/b<c>"d"')
+  })
+
+  test('two distinct values with identical metadata fail loudly (identity contract)', () => {
+    const constantMetadataType: ReplacerType<
+      TypeContract<TestServerRoom, unknown, { constant: true }>,
+      ServerReplacerContext
+    > = {
+      prefix: '!TestConstant:',
+      detect: (value): value is TestServerRoom => value instanceof TestServerRoom,
+      replace() {
+        return { metadata: { constant: true }, close() {}, abort() {} }
+      },
+    }
+    const server = createServerHarness([constantMetadataType as ReplacerType<TypeContract, ServerReplacerContext>])
+    const a = new TestServerRoom('a')
+    const b = new TestServerRoom('b')
+    // Same reference: deduplicated, no complaint.
+    expect(() => server.serialize({ a, aDupe: a })).not.toThrow()
+    // Distinct references, identical wire strings: the client could not tell them apart.
+    expect(() => server.serialize({ a, b })).toThrow(/same wire representation/)
+  })
+
+  test('primitive special values bypass identity (no reference to preserve)', () => {
+    const SENTINEL = 'telefunc-spec-sentinel'
+    let replaceCalls = 0
+    const primitiveType: ReplacerType<TypeContract<string, unknown, { n: number }>, ServerReplacerContext> = {
+      prefix: '!TestPrimitive:',
+      detect: (value): value is string => value === SENTINEL,
+      replace() {
+        replaceCalls++
+        return { metadata: { n: replaceCalls }, close() {}, abort() {} }
+      },
+    }
+    const server = createServerHarness([primitiveType as ReplacerType<TypeContract, ServerReplacerContext>])
+    const body = server.serialize({ a: SENTINEL, b: SENTINEL })
+    // Two occurrences, two replace() calls — primitives are value-semantic.
+    expect(replaceCalls).toBe(2)
+
+    let reviveCalls = 0
+    const primitiveReviver: ReviverType<TypeContract<string, unknown, { n: number }>, ClientReviverContext> = {
+      prefix: '!TestPrimitive:',
+      revive(metadata) {
+        reviveCalls++
+        return { value: { n: metadata.n }, close() {}, abort() {} }
+      },
+    }
+    const client = createClientHarness([primitiveReviver as ReviverType<TypeContract, ClientReviverContext>])
+    const parsed = client.parseBody(body) as { a: { n: number }; b: { n: number } }
+    // Distinct metadata → distinct wire strings → distinct revivals.
+    expect(reviveCalls).toBe(2)
+    expect(parsed.a).not.toBe(parsed.b)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Full pipeline
+// (serializeTelefunctionResult → inline binary body → parseResponse)
+// ───────────────────────────────────────────────────────────────────────────
+
+async function roundTrip(
+  telefunctionReturn: unknown,
+  opts: {
+    serverExtensions?: ReplacerType<TypeContract, ServerReplacerContext>[]
+    clientExtensions?: ReviverType<TypeContract, ClientReviverContext>[]
+  } = {},
+) {
+  const requestContext = createRequestContext(new Request('http://localhost/_telefunc', { method: 'POST' }))
+  const result = serializeTelefunctionResult({
+    telefunctionReturn,
+    telefunctionName: 'testFn',
+    telefuncFilePath: '/pages/spec/ref-identity.telefunc.ts',
+    telefunctionAborted: false,
+    context: {},
+    requestContext,
+    abortSignal: requestContext.abortSignal,
+    streamTransport: STREAM_TRANSPORT.BINARY_INLINE,
+    useNodeStream: false,
+    serverConfig: {
+      extensionResponseTypes: opts.serverExtensions ?? [],
+      log: { shieldErrors: { dev: false, prod: false } },
+    },
+  })
+  const response =
+    result.type === 'text'
+      ? new Response(result.body)
+      : new Response(result.body as ReadableStream<Uint8Array<ArrayBuffer>>, {
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+  const abortController = new AbortController()
+  const parsed = (await parseResponse(response, {
+    telefunctionName: 'testFn',
+    telefuncFilePath: '/pages/spec/ref-identity.telefunc.ts',
+    abortController,
+    channel: { transports: ['sse'] },
+    requestCloseHandlers: [],
+    extensionResponseTypes: opts.clientExtensions ?? [],
+    headers: null,
+    telefuncUrl: 'http://localhost/_telefunc',
+  })) as { ret: unknown }
+  return { ret: parsed.ret, abortController }
+}
+
+async function collect<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const chunk of gen) out.push(chunk)
+  return out
+}
+
+describe('reference identity — full pipeline', () => {
+  test('duplicated async generator: one producer, one client object, chunks delivered once', async () => {
+    const gen = (async function* () {
+      yield 1
+      yield 2
+      yield 3
+    })()
+    const { ret } = await roundTrip({ gen, genDupe: gen })
+    const retTyped = ret as { gen: AsyncGenerator<number>; genDupe: AsyncGenerator<number> }
+
+    expect(retTyped.gen).toBe(retTyped.genDupe)
+    // One consumer sees every chunk — duplicated producers used to steal chunks
+    // from one another (each occurrence pulled the same underlying generator).
+    expect(await collect(retTyped.gen)).toEqual([1, 2, 3])
+  })
+
+  test('duplicated ReadableStream: previously crashed with a locked-stream error', async () => {
+    const payload = new TextEncoder().encode('stream-bytes')
+    const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+      start(controller) {
+        controller.enqueue(payload as Uint8Array<ArrayBuffer>)
+        controller.close()
+      },
+    })
+    // Before identity dedup this threw synchronously: the second occurrence's
+    // producer called stream.getReader() on an already-locked stream.
+    const { ret } = await roundTrip({ stream, streamDupe: stream })
+    const retTyped = ret as { stream: ReadableStream<Uint8Array>; streamDupe: ReadableStream<Uint8Array> }
+
+    expect(retTyped.stream).toBe(retTyped.streamDupe)
+    const reader = retTyped.stream.getReader()
+    const chunks: number[] = []
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(...value)
+    }
+    expect(new TextDecoder().decode(new Uint8Array(chunks))).toBe('stream-bytes')
+  })
+
+  test('duplicated promise: one resolution frame, same client promise', async () => {
+    const promise = Promise.resolve({ answer: 42 })
+    const { ret } = await roundTrip({ p: promise, pDupe: promise })
+    const retTyped = ret as { p: Promise<{ answer: number }>; pDupe: Promise<{ answer: number }> }
+
+    expect(retTyped.p).toBe(retTyped.pDupe)
+    expect(await retTyped.p).toEqual({ answer: 42 })
+  })
+
+  test('duplicated File: one byte stream, same client File promise', async () => {
+    const file = new File(['file-contents'], 'notes.txt', { type: 'text/plain', lastModified: 1234567890 })
+    const { ret } = await roundTrip({ file, fileDupe: file })
+    const retTyped = ret as { file: Promise<File>; fileDupe: Promise<File> }
+
+    expect(retTyped.file).toBe(retTyped.fileDupe)
+    const revived = await retTyped.file
+    expect(revived.name).toBe('notes.txt')
+    expect(await revived.text()).toBe('file-contents')
+  })
+
+  test('abort reaches a duplicated value exactly once', async () => {
+    const { serverType, clientType, counters } = makeRoomExtension()
+    const room = new TestServerRoom('abort-once')
+    const { ret, abortController } = await roundTrip(
+      { room, roomDupe: room },
+      {
+        serverExtensions: [serverType as ReplacerType<TypeContract, ServerReplacerContext>],
+        clientExtensions: [clientType as ReviverType<TypeContract, ClientReviverContext>],
+      },
+    )
+    const retTyped = ret as { room: unknown; roomDupe: unknown }
+    expect(retTyped.room).toBe(retTyped.roomDupe)
+
+    abortController.abort()
+    expect(counters.clientAbort).toBe(1)
+  })
+})

--- a/packages/telefunc/wire-protocol/server/response/registry.ts
+++ b/packages/telefunc/wire-protocol/server/response/registry.ts
@@ -12,6 +12,8 @@ import { channelReplacer } from './channel.js'
 import { functionReplacer } from './function.js'
 import type { ServerReplacerContext, ReplacerType, TypeContract } from '../../types.js'
 import type { AbortError } from '../../../shared/Abort.js'
+import { assertUsage } from '../../../utils/assert.js'
+import { isObjectOrFunction } from '../../../utils/isObjectOrFunction.js'
 import { assertIsNotBrowser } from '../../../utils/assertIsNotBrowser.js'
 assertIsNotBrowser()
 
@@ -32,22 +34,44 @@ const serverTypes = [
 
 /** Creates a JSON-serializer replacer that delegates to type-specific plugins.
  *  The caller provides `getContext(value)` which returns a per-value ServerReplacerContext —
- *  the registry has no shield logic, it just iterates types and forwards the context. */
+ *  the registry has no shield logic, it just iterates types and forwards the context.
+ *
+ *  Duplicated references are deduplicated: `JSON.stringify` visits every occurrence of a shared
+ *  reference, so without the cache each occurrence would run `replace()` again — minting another
+ *  stub channel, another lifecycle registration, another wire subscription. Instead, duplicates
+ *  re-emit the first occurrence's replacement verbatim (wire format unchanged), and the client's
+ *  mirror cache (createStreamingReviver) revives equal wire strings to one object. */
 function createStreamingReplacer(
   getContext: (value: unknown) => ServerReplacerContext,
   onReplaced: (replaced: { close: () => Promise<void> | void; abort: (abortError: AbortError) => void }) => void,
   extensionTypes: ReplacerType<TypeContract, ServerReplacerContext>[],
 ) {
   const allTypes = [...serverTypes, ...extensionTypes]
+  const replaced = new WeakMap<object, string>()
+  const replacements = new Set<string>()
   const replacer = (_key: string, value: unknown, serializer: (v: unknown) => string) => {
     for (const type of allTypes) {
       if (type.detect(value)) {
+        // Primitives have no reference identity — only objects and functions are deduplicated.
+        const hasIdentity = isObjectOrFunction(value)
+        if (hasIdentity) {
+          const cached = replaced.get(value)
+          if (cached !== undefined) return { replacement: cached, resolved: true }
+        }
         const { metadata, close, abort } = type.replace(value as never, getContext(value))
         onReplaced({ close, abort })
-        return {
-          replacement: type.prefix + serializer(metadata),
-          resolved: true,
+        const replacement = type.prefix + serializer(metadata)
+        if (hasIdentity) {
+          // The client treats equal wire strings as the same identity, so two distinct values
+          // must never serialize identically — see the metadata contract on ReplacerType.
+          assertUsage(
+            !replacements.has(replacement),
+            `Two distinct values serialize to the same wire representation (${type.prefix}…). replace() must return metadata that identifies the value uniquely within the payload — mint a fresh id per replace() call, the way every built-in type does.`,
+          )
+          replacements.add(replacement)
+          replaced.set(value, replacement)
         }
+        return { replacement, resolved: true }
       }
     }
     return undefined

--- a/packages/telefunc/wire-protocol/types.ts
+++ b/packages/telefunc/wire-protocol/types.ts
@@ -60,7 +60,11 @@ type TypeContract<V = unknown, R = unknown, M extends Record<string, unknown> = 
  *  `replace` is the primary verb of the Replacer API — it runs once per serialized value and may
  *  perform side effects (register channels, install listeners, wire lifecycle). The returned
  *  `metadata` is what crosses the wire; `close` / `abort` are lifecycle hooks tracked by the
- *  registry and invoked when the carrier message completes or is aborted. */
+ *  registry and invoked when the carrier message completes or is aborted.
+ *
+ *  Duplicated references run `replace` once and revive as one client object (see
+ *  createStreamingReplacer), so metadata must identify the value uniquely within the
+ *  payload: mint a fresh id per `replace` call, the way every built-in does. */
 type ReplacerType<C extends TypeContract = TypeContract, Context = unknown> = {
   prefix: string
   detect(value: unknown): value is C['value']
@@ -78,7 +82,10 @@ type StreamingReplacerType<C extends TypeContract = TypeContract, Context = unkn
 /** Reviver: reconstruct a live value from prefix+metadata during deserialization.
  *  `revive` is the primary verb of the Reviver API — it runs once per deserialized value and may
  *  perform side effects (create channels, start readers, attach validators). Mirrors `replace`
- *  on the Replacer side. */
+ *  on the Replacer side.
+ *
+ *  Duplicated references (equal wire strings) run `revive` once and resolve to the object the
+ *  first occurrence revived — server-side `===` holds on the client (see createStreamingReviver). */
 type ReviverType<C extends TypeContract = TypeContract, Context = unknown> = {
   prefix: string
   revive(

--- a/test/playground-stream/.testRun-docker.ts
+++ b/test/playground-stream/.testRun-docker.ts
@@ -15,6 +15,7 @@ import { testStreamToServer } from './pages/stream-to-server/e2e-test'
 import { testLiveQuery } from './pages/live-query/e2e-test'
 import { testRxjs } from './pages/rxjs/e2e-test'
 import { testPublish } from './pages/publish/e2e-test'
+import { testRefIdentity } from './pages/ref-identity/e2e-test'
 
 // Caddy serves https://localhost:8443 with its own internal CA — skip cert validation.
 ;(globalThis as { process?: { env: Record<string, string | undefined> } }).process!.env.NODE_TLS_REJECT_UNAUTHORIZED =
@@ -97,6 +98,7 @@ function testRunDocker() {
   testLiveQuery()
   testRxjs(true)
   testPublish()
+  testRefIdentity()
 }
 
 // `docker info` fails both when the CLI is missing and when the daemon is not running;

--- a/test/playground-stream/.testRun.ts
+++ b/test/playground-stream/.testRun.ts
@@ -14,6 +14,7 @@ import { testStreamToServer } from './pages/stream-to-server/e2e-test'
 import { testLiveQuery } from './pages/live-query/e2e-test'
 import { testRxjs } from './pages/rxjs/e2e-test'
 import { testPublish } from './pages/publish/e2e-test'
+import { testRefIdentity } from './pages/ref-identity/e2e-test'
 
 function testRun(cmd: 'pnpm dev' | 'pnpm preview') {
   run(cmd, {
@@ -85,4 +86,6 @@ function testRun(cmd: 'pnpm dev' | 'pnpm preview') {
   testRxjs()
 
   testPublish()
+
+  testRefIdentity()
 }

--- a/test/playground-stream/pages/+Layout.tsx
+++ b/test/playground-stream/pages/+Layout.tsx
@@ -15,6 +15,7 @@ const nav = [
   { href: '/function', label: 'Function' },
   { href: '/stream-to-server', label: 'Stream→Server' },
   { href: '/publish', label: 'Publish' },
+  { href: '/ref-identity', label: 'Ref Identity' },
   { href: '/video-chat', label: 'Video Chat' },
   { href: '/live-query', label: 'Live Query' },
   { href: '/kitchen-sink', label: 'Kitchen Sink' },

--- a/test/playground-stream/pages/ref-identity/+Page.tsx
+++ b/test/playground-stream/pages/ref-identity/+Page.tsx
@@ -1,0 +1,13 @@
+export { Page }
+
+import React from 'react'
+import { RefIdentity } from './RefIdentity'
+
+function Page() {
+  return (
+    <div className="max-w-3xl mx-auto px-8 py-10">
+      <h1>Reference Identity</h1>
+      <RefIdentity />
+    </div>
+  )
+}

--- a/test/playground-stream/pages/ref-identity/RefIdentity.telefunc.ts
+++ b/test/playground-stream/pages/ref-identity/RefIdentity.telefunc.ts
@@ -4,8 +4,8 @@ import { BroadcastChannel, Channel } from 'telefunc'
 
 type RoomMsg = { start: true } | { n: number }
 
-/** Returns the same live values under several keys (and inside streamed chunks) — the client
- *  asserts each revives as one object, with exactly one wire subscription behind it. */
+/** Returns the same live values under several keys — the client asserts each revives
+ *  as one object, with exactly one wire subscription behind it. */
 async function onRefIdentity() {
   // Unique key per call so broadcast seq state doesn't leak across page loads.
   const room = new BroadcastChannel<RoomMsg>({ key: `ref-identity:${crypto.randomUUID()}` })
@@ -22,8 +22,8 @@ async function onRefIdentity() {
   })
 
   const gen = (async function* () {
-    yield { tag: 'chunk1', room }
-    yield { tag: 'chunk2', room }
+    yield 1
+    yield 2
   })()
 
   return { room, roomDupe: room, list: [room], ch, chDupe: ch, gen, genDupe: gen }

--- a/test/playground-stream/pages/ref-identity/RefIdentity.telefunc.ts
+++ b/test/playground-stream/pages/ref-identity/RefIdentity.telefunc.ts
@@ -1,0 +1,30 @@
+export { onRefIdentity }
+
+import { BroadcastChannel, Channel } from 'telefunc'
+
+type RoomMsg = { start: true } | { n: number }
+
+/** Returns the same live values under several keys (and inside streamed chunks) — the client
+ *  asserts each revives as one object, with exactly one wire subscription behind it. */
+async function onRefIdentity() {
+  // Unique key per call so broadcast seq state doesn't leak across page loads.
+  const room = new BroadcastChannel<RoomMsg>({ key: `ref-identity:${crypto.randomUUID()}` })
+  room.subscribe(async (msg) => {
+    // Reacts to the client's `{ start: true }`; guards against its own `{ n }` self-echo.
+    if ('start' in msg) {
+      for (let n = 1; n <= 3; n++) await room.publish({ n })
+    }
+  })
+
+  const ch = new Channel<(msg: string) => void, (msg: string) => void>()
+  ch.listen((msg) => {
+    if (msg === 'ping') ch.send('pong')
+  })
+
+  const gen = (async function* () {
+    yield { tag: 'chunk1', room }
+    yield { tag: 'chunk2', room }
+  })()
+
+  return { room, roomDupe: room, list: [room], ch, chDupe: ch, gen, genDupe: gen }
+}

--- a/test/playground-stream/pages/ref-identity/RefIdentity.tsx
+++ b/test/playground-stream/pages/ref-identity/RefIdentity.tsx
@@ -1,0 +1,72 @@
+export { RefIdentity }
+
+import React, { useEffect, useState } from 'react'
+import { onRefIdentity } from './RefIdentity.telefunc'
+
+type State = {
+  identity: {
+    roomDupe: boolean
+    roomList: boolean
+    chDupe: boolean
+    genDupe: boolean
+  } | null
+  chunkIdentity: boolean | null
+  received: number[]
+  pongs: string[]
+}
+
+function RefIdentity() {
+  const [state, setState] = useState<State>({ identity: null, chunkIdentity: null, received: [], pongs: [] })
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => setHydrated(true), [])
+
+  return (
+    <div id={hydrated ? 'hydrated' : undefined}>
+      <pre id="ref-identity-result">{JSON.stringify(state)}</pre>
+
+      <button
+        id="test-ref-identity"
+        onClick={async () => {
+          const result = await onRefIdentity()
+          const { room, roomDupe, list, ch, chDupe, gen, genDupe } = result
+
+          const identity = {
+            roomDupe: room === roomDupe,
+            roomList: room === list[0],
+            chDupe: ch === chDupe,
+            genDupe: gen === genDupe,
+          }
+
+          // The same broadcast yielded inside streamed chunks revives to the same object.
+          const chunks: Array<{ tag: string; room: unknown }> = []
+          for await (const chunk of gen) chunks.push(chunk)
+          const chunkIdentity = chunks.length === 2 && chunks.every((chunk) => chunk.room === room)
+
+          const received: number[] = []
+          const pongs: string[] = []
+          // Render on every event so the e2e autoRetry sees fresh data each iteration.
+          const render = () => setState({ identity, chunkIdentity, received: [...received], pongs: [...pongs] })
+
+          // Subscribe on the duplicate, publish on the original — one object, one subscription.
+          // Duplicated wire subscriptions would show up as duplicated `n` values.
+          roomDupe.subscribe((msg) => {
+            if ('n' in msg) {
+              received.push(msg.n)
+              render()
+            }
+          })
+          chDupe.listen((msg) => {
+            pongs.push(msg)
+            render()
+          })
+
+          render()
+          await room.publish({ start: true })
+          ch.send('ping')
+        }}
+      >
+        Test reference identity
+      </button>
+    </div>
+  )
+}

--- a/test/playground-stream/pages/ref-identity/RefIdentity.tsx
+++ b/test/playground-stream/pages/ref-identity/RefIdentity.tsx
@@ -10,13 +10,13 @@ type State = {
     chDupe: boolean
     genDupe: boolean
   } | null
-  chunkIdentity: boolean | null
+  chunks: number[]
   received: number[]
   pongs: string[]
 }
 
 function RefIdentity() {
-  const [state, setState] = useState<State>({ identity: null, chunkIdentity: null, received: [], pongs: [] })
+  const [state, setState] = useState<State>({ identity: null, chunks: [], received: [], pongs: [] })
   const [hydrated, setHydrated] = useState(false)
   useEffect(() => setHydrated(true), [])
 
@@ -37,15 +37,15 @@ function RefIdentity() {
             genDupe: gen === genDupe,
           }
 
-          // The same broadcast yielded inside streamed chunks revives to the same object.
-          const chunks: Array<{ tag: string; room: unknown }> = []
+          // One consumer sees every chunk exactly once — duplicated producers
+          // used to steal chunks from one another.
+          const chunks: number[] = []
           for await (const chunk of gen) chunks.push(chunk)
-          const chunkIdentity = chunks.length === 2 && chunks.every((chunk) => chunk.room === room)
 
           const received: number[] = []
           const pongs: string[] = []
           // Render on every event so the e2e autoRetry sees fresh data each iteration.
-          const render = () => setState({ identity, chunkIdentity, received: [...received], pongs: [...pongs] })
+          const render = () => setState({ identity, chunks, received: [...received], pongs: [...pongs] })
 
           // Subscribe on the duplicate, publish on the original — one object, one subscription.
           // Duplicated wire subscriptions would show up as duplicated `n` values.

--- a/test/playground-stream/pages/ref-identity/e2e-test.ts
+++ b/test/playground-stream/pages/ref-identity/e2e-test.ts
@@ -1,0 +1,41 @@
+export { testRefIdentity }
+
+import { page, test, expect, autoRetry, getServerUrl } from '@brillout/test-e2e'
+import { navigate, getResult } from '../../e2e-utils'
+
+type RefIdentityResult = {
+  identity: {
+    roomDupe: boolean
+    roomList: boolean
+    chDupe: boolean
+    genDupe: boolean
+  } | null
+  chunkIdentity: boolean | null
+  received: number[]
+  pongs: string[]
+}
+
+function testRefIdentity() {
+  test('reference identity: duplicated refs revive as one object with one subscription', async () => {
+    await navigate(`${getServerUrl()}/ref-identity`)
+    await page.click('#test-ref-identity')
+
+    await autoRetry(async () => {
+      const result = await getResult<RefIdentityResult>('#ref-identity-result')
+
+      // Every occurrence of a duplicated reference is the same client object —
+      // across payload keys, inside arrays, and for streamed values themselves.
+      expect(result.identity).deep.equal({ roomDupe: true, roomList: true, chDupe: true, genDupe: true })
+
+      // The same broadcast yielded inside async-generator chunks === the root one.
+      expect(result.chunkIdentity).toBe(true)
+
+      // One wire subscription: 3 publishes arrive exactly once each, in order.
+      // Duplicated subscriptions would surface as duplicated values.
+      expect(result.received).deep.equal([1, 2, 3])
+
+      // The duplicated channel is live and duplex — and delivers exactly once.
+      expect(result.pongs).deep.equal(['pong'])
+    })
+  })
+}

--- a/test/playground-stream/pages/ref-identity/e2e-test.ts
+++ b/test/playground-stream/pages/ref-identity/e2e-test.ts
@@ -10,7 +10,7 @@ type RefIdentityResult = {
     chDupe: boolean
     genDupe: boolean
   } | null
-  chunkIdentity: boolean | null
+  chunks: number[]
   received: number[]
   pongs: string[]
 }
@@ -27,8 +27,8 @@ function testRefIdentity() {
       // across payload keys, inside arrays, and for streamed values themselves.
       expect(result.identity).deep.equal({ roomDupe: true, roomList: true, chDupe: true, genDupe: true })
 
-      // The same broadcast yielded inside async-generator chunks === the root one.
-      expect(result.chunkIdentity).toBe(true)
+      // The duplicated generator delivers each chunk exactly once.
+      expect(result.chunks).deep.equal([1, 2])
 
       // One wire subscription: 3 publishes arrive exactly once each, in order.
       // Duplicated subscriptions would surface as duplicated values.


### PR DESCRIPTION
## Problem

Telefunc serializes telefunction results with `@brillout/json-serializer` — plain `JSON.stringify` plus a replacer, no seen-map. `JSON.stringify` visits every occurrence of a shared reference, so every occurrence of a special value runs its replacer's `replace()` again, side effects included.

Repro: returning `{ room, roomDupe: room, roomDupe2: room }` runs the value's replacer three times → three stub channels minted (three channel ids, three lifecycle registrations, 3× wire subscriptions) → the client revives three independent, mutually-`!==` live objects for what was one server object. The same holds for `Channel`, `Broadcast`, returned functions, and duplicated references nested in arrays/objects.

For stream-family values it was outright broken:

- `{ stream, streamDupe: stream }` crashed the response — the second occurrence called `getReader()` on an already-locked `ReadableStream`.
- `{ gen, genDupe: gen }` registered two producers pulling one generator — each chunk delivered to exactly one of them (chunk theft).
- `{ file, fileDupe: file }` streamed the file's bytes twice.

## Fix

A dedupe in the two registries — nothing else changes (+23 lines of code, the rest is comments and tests):

- **Server** (`createStreamingReplacer`): a payload-scoped `WeakMap<object, replacement-string>`. First occurrence runs `replace()` (one stub, one lifecycle registration); duplicates re-emit the first occurrence's replacement string verbatim.
- **Client** (`createStreamingReviver`): the mirror — a `Map<wire-string, revived>`. First occurrence runs `revive()` + `onRevived` (one client channel, one GC-proxy wrap, one close/abort registration); equal wire strings resolve to that same object, so `result.room === result.roomDupe` holds on the client.

**Wire format: unchanged.** Duplicates are the first occurrence's replacement re-emitted verbatim, not a def/ref token pair — old and new client/server mixes keep today's behavior in both directions.

**Identity contract**: keying on the wire string means two *distinct* values must never serialize identically. Every built-in already mints a fresh unique id per `replace()` (a channel id or stream index), the contract is documented on `ReplacerType`, and a guard enforces it — an extension whose `replace()` returns non-unique metadata fails loudly instead of silently merging distinct values on the client. (Checked against `@telefunc/rxjs`: its Subject/Observable replacers mint a channel per `replace()` and comply; duplicated Subjects now share one wire instead of duplicating traffic.) Primitives detected by extensions bypass the cache — they have no reference identity.

## Scope

- Identity covers the serialized response payload — where the duplicate-`replace()` damage (stub minting, subscriptions) happens. **Chunk serialization is untouched**: special values inside async-generator yields / promise resolutions remain unsupported, exactly as before.
- **Deferred: plain-object graph identity and cycles** (`return { users, admin: users[0] }` reviving with `admin === users[0]`). That needs ref-token support inside `@brillout/json-serializer` itself (with a `parse` counterpart), which belongs upstream: separate package shared by Vike's SSR serialization, and its output's `JSON.parse`-compatibility is a property consumers rely on. Plain-object duplication has no side-effect damage in the meantime — it costs bytes, not correctness. Nothing is half-supported: plain payloads behave exactly as before.

Motivation beyond today's types: this unblocks returning object graphs of live values — e.g. the open design thread in #436 about returning a `RemoteParticipant` alongside its `Room` without minting duplicate stubs. Nothing room-API-specific is implemented here.

## Tests

- `wire-protocol/ref-identity.spec.ts` — 16 unit tests; **14 fail without the fix** (the other two are negative controls: distinct values stay distinct, primitive bypass).
  - Registry round-trips (real registries, real `stringify`/`parse`, real `ServerChannel`/`ServerBroadcast`): duplicates of each special type — Channel, Broadcast, Room and LocalParticipant (extension types mirroring the Room-API prototype's stub-minting shape), functions, streamed values — with client-side `===` assertions, close/abort registered and fired exactly once, the injectivity guard failing loudly, and escaping-sensitive metadata.
  - Full pipeline (`serializeTelefunctionResult` → inline binary body → `parseResponse`): duplicated generator/stream/promise/File (including the crash and chunk-theft repros above), abort delivered exactly once.
- `test/playground-stream/pages/ref-identity/` — e2e in a real browser: a telefunction returns duplicated `BroadcastChannel`/`Channel`/generator references; asserts `===` across all occurrences, exactly-once message delivery on the single subscription (3 publishes → `[1,2,3]`; duplicated subscriptions would double them), exactly-once chunk delivery on the duplicated generator, and duplex liveness of the deduplicated channel.

## Verification

- `vitest run` from repo root: 188 passed (2 skipped, pre-existing).
- `pnpm run test:types`: all 13 tsconfigs ✅.
- `biome ci`: clean.
- Playground e2e run locally on this exact tree: `.test-dev.binary-inline.sse` ✅ (and `.test-preview.channel.sse` ✅ on the same fix pre-simplification); the full transport matrix runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TShJhSsZG3QZv9UHDZ8ZP7