### PR TITLE
test: run docker playground with --expose-gc so /api/gc works

### DIFF
--- a/test/playground-stream/compose.yaml
+++ b/test/playground-stream/compose.yaml
@@ -116,7 +116,10 @@ services:
   playground-a: &playground
     image: node:24-alpine
     working_dir: /repo/test/playground-stream
-    command: node dist/nested/server/index.mjs
+    # `--expose-gc` so `/api/gc` (see +server.ts) can force GC — the close-page GC test
+    # relies on it; without the flag the endpoint 500s and the test only passes if natural
+    # GC happens to kick in. Keep in sync with the `dev`/`preview` scripts in package.json.
+    command: node --expose-gc dist/nested/server/index.mjs
     volumes:
       - ../..:/repo
     environment:

--- a/test/playground-stream/e2e-utils.ts
+++ b/test/playground-stream/e2e-utils.ts
@@ -51,7 +51,10 @@ async function getCleanupState(): Promise<Record<string, string>> {
 
 /** Forces a full GC on the server (via `/api/gc`) so GC-driven cleanup is deterministic in tests. */
 async function forceServerGc() {
-  await fetch(`${getServerUrl()}/api/gc`, { method: 'POST' })
+  const resp = await fetch(`${getServerUrl()}/api/gc`, { method: 'POST' })
+  // Fail loudly on `gc not exposed` (server missing `--expose-gc`): silently ignoring it
+  // degrades GC tests into waiting for natural GC, which times out with a misleading assertion.
+  if (!resp.ok) throw new Error(`forceServerGc() failed: ${await resp.text()}`)
 }
 
 /**


### PR DESCRIPTION
Fixes the CI failure in [run 29073876907](https://github.com/telefunc/telefunc/actions/runs/29073876907/job/86301126572) (`Playground Stream (.test-docker.binary-inline.sse.test.ts)`), which also reproduced on the identical-tree re-run [29074164684](https://github.com/telefunc/telefunc/actions/runs/29074164684).

## Root cause

The failing test — `close: passed function GC — context.onClose fires after the server GC-reclaims a dropped callback` — forces server-side GC via `POST /api/gc` on every retry. That endpoint requires `globalThis.gc`, i.e. node started with `--expose-gc` (see `+server.ts`).

The `dev` and `preview` scripts set the flag, but the docker compose services ran plain `node dist/nested/server/index.mjs`. Inside the containers `/api/gc` therefore always answered `500 {"ok":false,"reason":"gc not exposed (run node with --expose-gc)"}` — visible in the job's Caddy access logs as repeated `POST /api/gc → 500` — and `forceServerGc()` swallowed the failure. The docker variant of the test could only pass when *natural* V8 GC happened to reclaim the dropped callback stub within the retry window; in this run it didn't, so `context.onClose` never fired and the test timed out with `expected 'not-fired' to equal 'fired'`.

The failure is unrelated to #444's content: the same test passes deterministically in all dev/preview jobs (which do set `--expose-gc`), including on the failing commits. #444 plausibly just shifted allocation patterns enough that natural GC stopped bailing the docker suite out.

## Changes

- **`compose.yaml`**: `command: node --expose-gc dist/nested/server/index.mjs` — the `&playground` anchor propagates it to all six instances, matching the `dev`/`preview` scripts. The `compose.prof.yaml` overlay (bench-only) overrides `command` wholesale and is unaffected.
- **`e2e-utils.ts`**: `forceServerGc()` now throws on a non-ok response, so a missing `--expose-gc` surfaces as a clear `gc not exposed` error on the failing retry instead of a misleading assertion timeout 90s later. It sits inside `autoRetry`, so transient proxy blips are still retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYevN9xR8ezq4yQpCQXWGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYevN9xR8ezq4yQpCQXWGj)_