### PR TITLE
fix: show usage error for re-exports in .telefunc files (#462)

### DIFF
--- a/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
+++ b/packages/telefunc/node/shared/transformer/generateShield/generateShield.ts
@@ -369,7 +369,7 @@ async function testGenerateShield(telefuncFileCode: string): Promise<string> {
     true,
   )
   objectAssign(project, { tsConfigFilePath: null })
-  const exportList = await getExportList(telefuncFileCode)
+  const exportList = await getExportList(telefuncFileCode, telefuncFilePath)
   const shieldCode = generateShieldCode({
     project,
     shieldGenSource,

--- a/packages/telefunc/node/shared/transformer/getExportList.spec.ts
+++ b/packages/telefunc/node/shared/transformer/getExportList.spec.ts
@@ -1,0 +1,44 @@
+import { getExportList } from './getExportList.js'
+import { expect, describe, it } from 'vitest'
+
+const filePath = '/root/server/foo.telefunc.js'
+
+describe('getExportList()', () => {
+  it('returns the export list', async () => {
+    const src = [
+      "import { db } from './db.js'",
+      'export function onFoo() {}',
+      'const sendBar = () => {}',
+      'export { sendBar }',
+      'export const onBaz = async () => db.query()',
+    ].join('\n')
+    expect(await getExportList(src, filePath)).toEqual([
+      { exportName: 'onFoo', localName: 'onFoo' },
+      { exportName: 'sendBar', localName: 'sendBar' },
+      { exportName: 'onBaz', localName: 'onBaz' },
+    ])
+  })
+
+  it("re-exports are forbidden — there's no local binding the generated code could reference", async () => {
+    await expect(getExportList("export { onFoo } from './x.js'", filePath)).rejects.toThrowError(
+      "The telefunc file /root/server/foo.telefunc.js contains `export { onFoo } from './x.js'` which isn't supported",
+    )
+  })
+
+  it('all re-export forms are caught', async () => {
+    const srcs = [
+      "export { origName as onFoo } from './x.js'",
+      "export * from './x.js'",
+      "export * as ns from './x.js'",
+      "export{onFoo}from'./x.js'",
+    ]
+    for (const src of srcs) {
+      await expect(getExportList(src, filePath), src).rejects.toThrowError("which isn't supported")
+    }
+  })
+
+  it("type-only re-exports are fine — they're erased at compile time", async () => {
+    const src = ["export type { SomeType } from './x.js'", 'export function onFoo() {}'].join('\n')
+    expect(await getExportList(src, filePath)).toEqual([{ exportName: 'onFoo', localName: 'onFoo' }])
+  })
+})

--- a/packages/telefunc/node/shared/transformer/getExportList.ts
+++ b/packages/telefunc/node/shared/transformer/getExportList.ts
@@ -1,13 +1,15 @@
 export { getExportList }
 export type { ExportList }
 
-import { init, parse } from 'es-module-lexer'
+import { init, parse, type ImportSpecifier } from 'es-module-lexer'
+import { assertUsage } from '../../../utils/assert.js'
 
 type ExportList = { exportName: string; localName: string | null }[]
 
-async function getExportList(src: string): Promise<ExportList> {
+async function getExportList(src: string, filePath: string): Promise<ExportList> {
   await init
   const parseResult = parse(src)
+  assertNoReExport(src, parseResult[0], filePath)
   const exports = parseResult[1]
   const exportList = exports.map((e) => {
     const exportName = e.n
@@ -15,4 +17,21 @@ async function getExportList(src: string): Promise<ExportList> {
     return { exportName, localName }
   })
   return exportList
+}
+
+// `export { onFoo } from './impl.js'` creates no local binding the generated code (telefunction
+// decoration, shield()) could reference — the telefunction would crash at runtime instead of getting
+// registered. Not worth supporting (https://github.com/telefunc/telefunc/issues/462) => usage error.
+// Type-only re-exports (`export type { T } from './impl.js'`) are fine: es-module-lexer skips them.
+function assertNoReExport(src: string, imports: readonly ImportSpecifier[], filePath: string) {
+  for (const i of imports) {
+    if (i.d !== -1) continue // dynamic import or import.meta
+    // Re-export statements (`export { onFoo } from './impl.js'`, `export * from './impl.js'`, ...) are
+    // also listed in `imports` — they're the import records starting with the `export` keyword.
+    const statement = src.slice(i.ss, i.se)
+    assertUsage(
+      !/^export\b/.test(statement),
+      `The telefunc file ${filePath} contains \`${statement}\` which isn't supported — define telefunctions in the .telefunc file itself instead of re-exporting them. If you have a use case for re-exports, comment at https://github.com/telefunc/telefunc/issues/462`,
+    )
+  }
 }

--- a/packages/telefunc/node/shared/transformer/transformTelefuncFileClientSide.ts
+++ b/packages/telefunc/node/shared/transformer/transformTelefuncFileClientSide.ts
@@ -9,7 +9,7 @@ async function transformTelefuncFileClientSide(
   appRootDir: string,
   extensionImports: string[],
 ) {
-  const exportList = await getExportList(src)
+  const exportList = await getExportList(src, id)
   const exportNames = exportList.map((e) => e.exportName)
   return transformTelefuncFileClientSideSync(id, appRootDir, exportNames, extensionImports)
 }

--- a/packages/telefunc/node/shared/transformer/transformTelefuncFileServerSide.ts
+++ b/packages/telefunc/node/shared/transformer/transformTelefuncFileServerSide.ts
@@ -22,7 +22,7 @@ async function transformTelefuncFileServerSide(
   //   2. the magicString output (so the runtime extension registers at module load)
   const srcWithImports = [...extensionImports, src].join('\n')
 
-  const exportList = await getExportList(srcWithImports)
+  const exportList = await getExportList(srcWithImports, id)
   const codeDecoration = decorateTelefunctions(exportList, id.replace(appRootDir, ''), appRootDir)
 
   let codeShield: string | undefined


### PR DESCRIPTION
`export { onFoo } from './impl.js'` in a .telefunc file creates no local binding the generated code (telefunction decoration, shield()) can reference — the decoration crashed with a `ReferenceError` at module evaluation (so the first RPC hitting such a file in production), and shield generation emitted `shield(null, ...)`.

Per the decision in #462 (re-export support isn't worth it — supersedes #461), show a `[Wrong Usage]` error instead of generating broken code:

- `getExportList()` now takes the telefunc file path and rejects re-exports via `assertUsage()`, quoting the offending statement and linking #462 so users with a real use case can comment there.
- Detection is a single uniform check: es-module-lexer lists re-export statements in its imports array, so any static import record whose statement starts with the `export` keyword is a re-export. This catches all forms — `export { x } from`, `export { x as y } from`, `export * from` (which never appears in the lexer's exports array), `export * as ns from`, and minified variants.
- The check lives in `getExportList()`, the single choke point shared by the server transform, the client transform, and shield generation — so the error surfaces at build/dev time no matter which side processes the file first.
- Type-only re-exports (`export type { T } from './x.js'`) remain allowed: they're erased at compile time, and es-module-lexer skips them.

Adds `getExportList.spec.ts` covering the export list happy path, all rejected re-export forms, and the type-only exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhLHAZFzv6askY7xtznJHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhLHAZFzv6askY7xtznJHJ)_